### PR TITLE
ci: code_style: run directly in the Ubuntu VM (no container)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
   code_style:
     name: Code style
     runs-on: ubuntu-latest
-    container: jforissier/optee_os_ci
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,6 +16,8 @@ jobs:
           fetch-depth: 0 # full history so checkpatch can check commit IDs in commit messages
       - name: Update Git config
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Install prerequisites
+        run: sudo apt-get update -qq -y && sudo apt-get install -qq -y codespell pycodestyle
       - name: Run checkpatch
         shell: bash
         run: |
@@ -52,10 +53,7 @@ jobs:
           [ -z "$failed" ]
       - name: Run pycodestyle
         if: success() || failure()
-        run: |
-          # pycodestyle task
-          sudo -E bash -c "apt update -qq -y && apt install -qq -y pycodestyle"
-          pycodestyle scripts/*.py core/arch/arm/plat-stm32mp1/scripts/stm32image.py
+        run: pycodestyle scripts/*.py core/arch/arm/plat-stm32mp1/scripts/stm32image.py
   builds:
     name: Build (${{ matrix.name }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
The code_style job doesn't have so many special dependencies so it can as well be run directly in the Ubuntu VM provided by the GitHub Actions environment. With this change, the job typically takes less than 30 seconds to complete instead of 1 minute. Not a massive impact on the overall CI workflow, but still good to take if only for the "keep it simple" principle.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
