### PR TITLE
ci: notify_maintainers: do not print message without any handle

### DIFF
--- a/scripts/notify_maintainers.py
+++ b/scripts/notify_maintainers.py
@@ -97,10 +97,10 @@ def main():
     pr_number = os.getenv("PR_NUMBER")
     token = os.getenv("GITHUB_TOKEN")
 
+    message = ""
     handles_to_mention = get_handles_for_pr(pr_number)
     if not handles_to_mention:
         print("# No maintainers or reviewers to mention.")
-        message = ""
     else:
         print("# Final list of subsystem/platform maintainers/reviewers: " +
               " ".join(f"@{h}" for h in handles_to_mention))
@@ -128,11 +128,11 @@ def main():
 
         # Exclude all these from new notifications
         new_handles = handles_to_mention - existing_handles - skip_handles
-        if not new_handles:
+        if new_handles:
+            message = "FYI " + " ".join(f"@{h}" for h in new_handles)
+        else:
             print("# All relevant handles have already been mentioned "
                   "or are already notified by GitHub.")
-
-        message = "FYI " + " ".join(f"@{h}" for h in new_handles)
 
     print(f"message={message}")
 


### PR DESCRIPTION
In case all handles have been filtered out from handles_to_mention, do not print any message at all. This avoids posting a useless "FYI <nothing>" comment.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
