### PR TITLE
ci: free disk space earlier and in all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,10 @@ jobs:
     name: Build QEMUv7 image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Host cleanup
+        run: |
+          wget https://raw.githubusercontent.com/OP-TEE/optee_os/refs/heads/master/scripts/ci-host-cleanup.sh
+          bash ci-host-cleanup.sh
       - name: Create Dockerfile
         run: |
           cat > Dockerfile <<'EOF'
@@ -417,6 +420,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Update Git config
         run: git config --global --add safe.directory /home/runner/work/optee_os/optee_os
+      - name: Host cleanup
+        run: bash /home/runner/work/optee_os/optee_os/scripts/ci-host-cleanup.sh
       - name: Download Docker image
         uses: actions/download-artifact@v4
         with:
@@ -437,8 +442,6 @@ jobs:
           key: ${{ env.CACHE_KEY }}
           restore-keys: |
             ${{ env.CACHE_RESTORE_KEY }}
-      - name: Host setup
-        run: bash /home/runner/work/optee_os/optee_os/scripts/ci-host-cleanup.sh
       - name: Run 'make check' tasks in container
         env:
           MAKE_COMMANDS: "${{ matrix.make_commands }}"
@@ -469,7 +472,10 @@ jobs:
     name: Build QEMUv8 image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Host cleanup
+        run: |
+          wget https://raw.githubusercontent.com/OP-TEE/optee_os/refs/heads/master/scripts/ci-host-cleanup.sh
+          bash ci-host-cleanup.sh
       - name: Create Dockerfile
         run: |
           cat > Dockerfile <<'EOF'
@@ -558,6 +564,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Update Git config
         run: git config --global --add safe.directory /home/runner/work/optee_os/optee_os
+      - name: Host cleanup
+        run: bash /home/runner/work/optee_os/optee_os/scripts/ci-host-cleanup.sh
       - name: Download Docker image
         uses: actions/download-artifact@v4
         with:
@@ -578,8 +586,6 @@ jobs:
           key: ${{ env.CACHE_KEY }}
           restore-keys: |
             ${{ env.CACHE_RESTORE_KEY }}
-      - name: Host setup
-        run: bash /home/runner/work/optee_os/optee_os/scripts/ci-host-cleanup.sh
       - name: Run 'make check' tasks in container
         env:
           MAKE_COMMANDS: "${{ matrix.make_commands }}"
@@ -612,7 +618,10 @@ jobs:
     name: Build QEMUv8 arm64 image
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - name: Host cleanup
+        run: |
+          wget https://raw.githubusercontent.com/OP-TEE/optee_os/refs/heads/master/scripts/ci-host-cleanup.sh
+          bash ci-host-cleanup.sh
       - name: Create Dockerfile
         run: |
           cat > Dockerfile <<'EOF'
@@ -646,6 +655,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Update Git config
         run: git config --global --add safe.directory /home/runner/work/optee_os/optee_os
+      - name: Host setup
+        run: bash /home/runner/work/optee_os/optee_os/scripts/ci-host-cleanup.sh
       - name: Download Docker image
         uses: actions/download-artifact@v4
         with:
@@ -666,8 +677,6 @@ jobs:
           key: ${{ env.CACHE_KEY }}
           restore-keys: |
             ${{ env.CACHE_RESTORE_KEY }}
-      - name: Host setup
-        run: bash /home/runner/work/optee_os/optee_os/scripts/ci-host-cleanup.sh
       - name: Run 'make check' tasks in container
         env:
           MAKE_COMMANDS: "${{ matrix.make_commands }}"


### PR DESCRIPTION
Address two new "no space left on device" errors in CI:

- The first one appeared in the QEMUv8_checks_image_build job. To fix it, avoid cloning the OP-TEE repository which is not needed in that job i.e., remove the checkout action, and also run the host cleanup script. The two other "image_build" jobs are updated as well for consistency.

- The second one happens in the _checks jobs. The fix consists in running the host cleanup script earlier, before loading the Docker image.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
