### PR TITLE
ci: notify_maintainers.py: filter out comment authors

### DIFF
--- a/scripts/notify_maintainers.py
+++ b/scripts/notify_maintainers.py
@@ -113,6 +113,8 @@ def main():
         existing_handles = set()
         for comment in pr.get_issue_comments():
             existing_handles.update(re.findall(r"@([\w-]+)", comment.body))
+            if comment.user:
+                existing_handles.add(comment.user.login)
         if existing_handles:
             print("# Already mentioned: " +
                   " ".join(f"@{h}" for h in existing_handles))


### PR DESCRIPTION
This is a small bug fix for the notify_maintainers.py script which should not mention a user who has already been involved in the discussion. Currently, it filters out users that have explicitly been mentioned (via '@user'), either by the CI bot or by a real user. But it does not consider the comment authors. This is a mistake. Update the code accordingly.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
