### PR TITLE
core: tee_ree_fs: conditionally remove corrupt dirf.db file

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -457,8 +457,14 @@ out:
 			DMSG("Secure storage corruption detected");
 		if (fdp->fd != -1)
 			tee_fs_rpc_close(OPTEE_RPC_CMD_FS, fdp->fd);
-		if (create)
+		/*
+		 * Remove the file if hash is NULL and min_counter is 0,
+		 * as it is not yet rollback-protected
+		 */
+		if (create || (!hash && !min_counter)) {
+			DMSG("Remove corrupt file");
 			tee_fs_rpc_remove_dfh(OPTEE_RPC_CMD_FS, dfh);
+		}
 		free(fdp);
 	}
 
@@ -565,6 +571,7 @@ static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 			}
 		}
 
+		DMSG("Create dirf.db");
 		res = tee_fs_dirfile_open(true, NULL, 0, &ree_dirf_ops, dirh);
 	}
 


### PR DESCRIPTION
When a trusted application uses the REE-FS secure store API during the first boot, OP-TEE OS creates the _dirf.db_ file. If a power outage occurs immediately after the creation of _dirf.db_, it may result in an empty file with an unset hash. This corrupted _dirf.db_ file blocks subsequent REE-FS secure store operations. This commit addresses the issue by allowing the system to detect and delete an empty, corrupted dirf.db file, enabling secure store operations to proceed.



**How to Simulate**
1. Insert a delay (mdelay) immediately after the creation of dirf.db (see line 442 in [tee_ree_fs.c](https://github.com/OP-TEE/optee_os/blob/4.8.0/core/tee/tee_ree_fs.c#L442)), then power off the device.

`422 static TEE_Result ree_fs_open_primitive(bool create, uint8_t *hash,`
`423					uint32_t min_counter,`
`424					const TEE_UUID *uuid,`
`425					struct tee_fs_dirfile_fileh *dfh,`
`426					struct tee_file_handle **fh)`
`427 {`
`428	TEE_Result res;`
`429	struct tee_fs_fd *fdp;`
`430`
`431	fdp = calloc(1, sizeof(struct tee_fs_fd));`
`432	if (!fdp)`
`433		return TEE_ERROR_OUT_OF_MEMORY;`
`434	fdp->fd = -1;`
`435	fdp->uuid = uuid;`
`436`
`437	if (create)`
`438		res = tee_fs_rpc_create_dfh(OPTEE_RPC_CMD_FS,`
`439					    dfh, &fdp->fd);`
`440	else`
`441		res = tee_fs_rpc_open_dfh(OPTEE_RPC_CMD_FS, dfh, &fdp->fd);`  
`442`
`443	if (res != TEE_SUCCESS)`
`444		goto out;`

2. Upon reboot, check if the size of dirf.db is 0.

**Effect of the Commit**
After applying this commit, the system will automatically remove a corrupted dirf.db file for this power outage case (i.e., a file with size 0 with an unset hash), allowing subsequent secure store operations to function correctly.
