### PR TITLE
ci: disable regression_1034 for SPMC_AT_EL=2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
               make -j$(nproc) check SPMC_AT_EL=1 CFG_SECURE_PARTITION=y CFG_SPMC_TESTS=y
           - name: SPMC_AT_EL=2
             make_commands: |
-              make -j$(nproc) check SPMC_AT_EL=2
+              make -j$(nproc) check SPMC_AT_EL=2 XTEST_ARGS="-x n_1034"
           - name: SPMC_AT_EL=3
             make_commands: |
               make -j$(nproc) check SPMC_AT_EL=3


### PR DESCRIPTION
The regression test case 1034 loads a large TA that depending on how fragmented the memory used by tee-supplicant, can use more memory than usual to describe the physical pages involved. For Hafnium this can cause a panic since it expects that everything should fit in 4 kB.

Here's an error log with the Hafnium panic:
D/TC:3 0 mobj_ffa_get_by_cookie:684 Populating mobj from rx buffer, cookie 0x3 Panic: check failed (ffa_retrieved_memory_region_init( retrieve_request, to_locked.vm->ffa_version, HF_MAILBOX_SIZE, memory_region->sender, attributes, memory_region->flags, handle, permissions, receiver, 1, memory_access_desc_size, composite->page_count, composite->constituent_count, share_state->fragments[0], share_state->fragment_constituent_counts[0], &total_length, &fragment_length)) at ../../src/ffa_memory.c:3437 [  102.392292] rcu: INFO: rcu_preempt detected stalls

The log above is from a build with Hafnium v2.12.0, but the error also exists in the latest version, v2.14.0. This is obviously a bug, but until it's resolved disable the troublesome test case.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
