### PR TITLE
core: kernel: fix big latency due to trace_ext_put() via. uart

### DIFF
--- a/core/kernel/trace_ext.c
+++ b/core/kernel/trace_ext.c
@@ -13,7 +13,6 @@
 
 const char trace_ext_prefix[] = "TC";
 int trace_level __nex_data = TRACE_LEVEL;
-static unsigned int puts_lock __nex_bss = SPINLOCK_UNLOCK;
 
 void __weak plat_trace_ext_puts(const char *str __unused)
 {
@@ -21,32 +20,16 @@ void __weak plat_trace_ext_puts(const char *str __unused)
 
 void trace_ext_puts(const char *str)
 {
-	uint32_t itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
-	bool mmu_enabled = cpu_mmu_enabled();
-	bool was_contended = false;
 	const char *p;
-
-	if (mmu_enabled && !cpu_spin_trylock(&puts_lock)) {
-		was_contended = true;
-		cpu_spin_lock_no_dldetect(&puts_lock);
-	}
 
 	plat_trace_ext_puts(str);
 
 	console_flush();
 
-	if (was_contended)
-		console_putc('*');
-
 	for (p = str; *p; p++)
 		console_putc(*p);
 
 	console_flush();
-
-	if (mmu_enabled)
-		cpu_spin_unlock(&puts_lock);
-
-	thread_unmask_exceptions(itr_status);
 }
 
 int trace_ext_get_thread_id(void)


### PR DESCRIPTION
When optee emits log, the NW interrupts are masked, if console_putc() is implemetned by writing to a uart, given uart slow characteristic, this could introduce a big NW irq latency.

Though, this patch brings a side effect: trace_ext_put() may emit log simultenaously thus the log is hard to read. However, comparing the side effect between hard to read log and big NW irq latency, the NW irq latency is much more severe, we have to compromise here.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
