### PR TITLE
ensure handleState becomes "not INITIALIZED" when TEE_SetOperationKey…

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -602,8 +602,10 @@ TEE_Result TEE_SetOperationKey(TEE_OperationHandle operation,
 		/* Operation key cleared */
 		TEE_ResetTransientObject(operation->key1);
 		operation->info.handleState &= ~TEE_HANDLE_FLAG_KEY_SET;
-		if (operation->operationState != TEE_OPERATION_STATE_INITIAL)
+		if (operation->operationState != TEE_OPERATION_STATE_INITIAL ||
+		    operation->info.operationClass == TEE_OPERATION_AE) {
 			reset_operation_state(operation);
+		}
 		return TEE_SUCCESS;
 	}
 
@@ -650,8 +652,10 @@ TEE_Result TEE_SetOperationKey(TEE_OperationHandle operation,
 
 	operation->info.keySize = key_size;
 
-	if (operation->operationState != TEE_OPERATION_STATE_INITIAL)
+	if (operation->operationState != TEE_OPERATION_STATE_INITIAL ||
+	    operation->info.operationClass == TEE_OPERATION_AE) {
 		reset_operation_state(operation);
+	}
 
 out:
 	if (res != TEE_SUCCESS  &&


### PR DESCRIPTION
… called after TEE_AEInit

fix: ensure handleState becomes "not INITIALIZED" when TEE_SetOperationKey called after TEE_AEInit

changed:
- Add a separate check for TEE_OPERATION_AE in TEE_SetOperationKey

Fixes #7602

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
