### PR TITLE
core: user_mode_ctx: fix unused warning when disable log

### DIFF
--- a/core/kernel/user_mode_ctx.c
+++ b/core/kernel/user_mode_ctx.c
@@ -11,7 +11,7 @@ void user_mode_ctx_print_mappings(struct user_mode_ctx *uctx)
 {
 	struct vm_region *r = NULL;
 	char flags[7] = { '\0', };
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	TAILQ_FOREACH(r, &uctx->vm_info.regions, link) {
 		paddr_t pa = 0;


### PR DESCRIPTION
When setting CFG_TEE_CORE_LOG_LEVEL to 0, the variable n becomes unused and the compiler generates a warning, which can fail the build process if -Werror is also enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
