### PR TITLE
libutee: make TEE_SetOperationKey() panic if handle state is initialized

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -688,10 +688,7 @@ static TEE_Result set_operation_key2(TEE_OperationHandle operation,
 	TEE_ObjectInfo key_info1;
 	TEE_ObjectInfo key_info2;
 
-	if (operation == TEE_HANDLE_NULL) {
-		res = TEE_ERROR_BAD_PARAMETERS;
-		goto out;
-	}
+	assert(operation);
 
 	/*
 	 * Key1/Key2 and/or are not initialized and
@@ -803,15 +800,6 @@ out:
 	return res;
 }
 
-TEE_Result TEE_SetOperationKey2(TEE_OperationHandle operation,
-				TEE_ObjectHandle key1, TEE_ObjectHandle key2)
-{
-	if (operation != TEE_HANDLE_NULL && key1 && key1 == key2)
-		return TEE_ERROR_SECURITY;
-
-	return set_operation_key2(operation, key1, key2);
-}
-
 TEE_Result __GP11_TEE_SetOperationKey2(TEE_OperationHandle operation,
 				       TEE_ObjectHandle key1,
 				       TEE_ObjectHandle key2)
@@ -821,6 +809,15 @@ TEE_Result __GP11_TEE_SetOperationKey2(TEE_OperationHandle operation,
 		TEE_Panic(0);
 
 	return set_operation_key2(operation, key1, key2);
+}
+
+TEE_Result TEE_SetOperationKey2(TEE_OperationHandle operation,
+				TEE_ObjectHandle key1, TEE_ObjectHandle key2)
+{
+	if (operation != TEE_HANDLE_NULL && key1 && key1 == key2)
+		return TEE_ERROR_SECURITY;
+
+	return __GP11_TEE_SetOperationKey2(operation, key1, key2);
 }
 
 void TEE_CopyOperation(TEE_OperationHandle dst_op, TEE_OperationHandle src_op)


### PR DESCRIPTION
According to the TEE Internal Core API specification v1.3.1 section 6.2.6, TEE_SetOperationKey() should panic if the flag TEE_HANDLE_FLAG_INITIALIZED is set on the operation. Update TEE_SetOperationKey() accordingly.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
