### PR TITLE
ftrace: dump ftrace after every ta_entry

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -267,10 +267,8 @@ void abort_print_current_ts(void)
 	s->ctx->ops->dump_state(s->ctx);
 
 #if defined(CFG_FTRACE_SUPPORT)
-	if (s->ctx->ops->dump_ftrace) {
-		s->fbuf = NULL;
+	if (s->ctx->ops->dump_ftrace)
 		s->ctx->ops->dump_ftrace(s->ctx);
-	}
 #endif
 }
 

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -178,10 +178,8 @@ void abort_print_current_ts(void)
 	s->ctx->ops->dump_state(s->ctx);
 
 #if defined(CFG_FTRACE_SUPPORT)
-	if (s->ctx->ops->dump_ftrace) {
-		s->fbuf = NULL;
+	if (s->ctx->ops->dump_ftrace)
 		s->ctx->ops->dump_ftrace(s->ctx);
-	}
 #endif
 }
 

--- a/ldelf/ftrace.c
+++ b/ldelf/ftrace.c
@@ -107,13 +107,30 @@ void ftrace_copy_buf(void *pctx, void (*copy_func)(void *pctx, void *b,
 		end = hstart + dump_size;
 
 		/* Header */
-		copy_func(pctx, hstart, fbuf->buf_off - fbuf->head_off);
+		if (!fbuf->dump_id)
+			copy_func(pctx, hstart, fbuf->buf_off - fbuf->head_off);
 		if (fbuf->overflow) {
 			/* From current index to end of circular buffer */
 			copy_func(pctx, ccurr, end - ccurr);
 		}
 		/* From start of circular buffer to current index */
 		copy_func(pctx, cstart, ccurr - cstart);
+	}
+}
+
+uint32_t ftrace_get_dump_id(void)
+{
+	if (fbuf)
+		return fbuf->dump_id;
+	else
+		return 0;
+}
+
+void ftrace_reset_buf(void)
+{
+	if (fbuf) {
+		fbuf->curr_idx = 0;
+		fbuf->overflow = false;
 	}
 }
 

--- a/ldelf/ftrace.h
+++ b/ldelf/ftrace.h
@@ -13,6 +13,8 @@
 bool ftrace_init(struct ftrace_buf **fbuf_ptr);
 void ftrace_copy_buf(void *pctx, void (*copy_func)(void *pctx, void *b,
 						   size_t bl));
+uint32_t ftrace_get_dump_id(void);
+void ftrace_reset_buf(void);
 void ftrace_map_lr(uint64_t *lr);
 #else
 static inline void ftrace_map_lr(uint64_t *lr __unused)
@@ -21,4 +23,3 @@ static inline void ftrace_map_lr(uint64_t *lr __unused)
 #endif
 
 #endif /*FTRACE_H*/
-

--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -103,9 +103,18 @@ static void __noreturn ftrace_dump(void *buf, size_t *blen)
 {
 	struct print_buf_ctx pbuf = { .buf = buf, .blen = *blen };
 
-	ta_elf_print_mappings(&pbuf, print_to_pbuf, &main_elf_queue,
-			      0, NULL, mpool_base);
+	/* only print the header when this is a new dump */
+	if (!ftrace_get_dump_id())
+		ta_elf_print_mappings(&pbuf, print_to_pbuf, &main_elf_queue,
+				      0, NULL, mpool_base);
 	ftrace_copy_buf(&pbuf, copy_to_pbuf);
+	/*
+	 * Reset the buffer after dump if this is the actual write
+	 * The OS may call this function with buf == NULL,
+	 * in order to get the length required to write ftrace data.
+	 */
+	if (buf)
+		ftrace_reset_buf();
 	*blen = pbuf.ret;
 	sys_return_cleanup();
 }

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -94,6 +94,7 @@ struct ftrace_buf {
 	uint32_t max_size;	/* Max allowed size of ftrace buffer */
 	uint32_t head_off;	/* Ftrace buffer header offset */
 	uint32_t buf_off;	/* Ftrace buffer offset */
+	uint32_t dump_id;	/* Dump ID returned by the supplicant */
 	bool syscall_trace_enabled; /* Some syscalls are never traced */
 	bool syscall_trace_suspended; /* By foreign interrupt or RPC */
 	bool overflow;		/* Circular buffer has wrapped */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -638,6 +638,18 @@ CFG_FTRACE_SUPPORT ?= n
 CFG_SYSCALL_FTRACE ?= n
 $(call cfg-depends-all,CFG_SYSCALL_FTRACE,CFG_FTRACE_SUPPORT)
 
+# Dump ftrace buffer to tee-supplicant after every TA entry.
+# When this option is enabled, OP-TEE outputs the ftrace buffer to
+# tee-supplicant after every time TA returns from the entrypoint
+# calling. Instead of writing function tracing information after
+# the session is closed.
+# By enabling this option, developer can use smaller ftrace buffer
+# and reduce the chance of getting truncated ftrace information.
+# However, developer still needs to ensure the ftrace buffer is large
+# enough to hold the data generated in single TA entry.
+CFG_FTRACE_DUMP_EVERY_ENTRY ?= $(CFG_FTRACE_SUPPORT)
+$(call cfg-depends-all,CFG_FTRACE_DUMP_EVERY_ENTRY,CFG_FTRACE_SUPPORT)
+
 # Enable to compile user TA libraries with profiling (-pg).
 # Depends on CFG_TA_GPROF_SUPPORT or CFG_FTRACE_SUPPORT.
 CFG_ULIBS_MCOUNT ?= n


### PR DESCRIPTION
We previously have to debug a complex TA, and the ftrace buffer is always not enough. Since it is not feasible to keep increasing memory for OP-TEE, we modified the dump logic to make OP-TEE output the ftrace data when every time TA returns from an invoke command call.

This PR upstream this part of code and add a new config CFG_FTRACE_DUMP_EVERY_ENTRY to control this behavior.

This can reduce the chance of losing the ftrace data due to not enough ftrace buffer and make people easier to debug complex and long-lived TA.

~~Depends on https://github.com/OP-TEE/optee_client/pull/411~~ (no longer needed)
Related to: #3202

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
