### PR TITLE
Adding code to clear the pkcs#11 persistent db after deinit call so that memory leaks are not observed.

### DIFF
--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -286,8 +286,17 @@ enum pkcs11_rc verify_identity_auth(struct ck_token *token,
 /*
  * Release resources relate to persistent database
  */
-void close_persistent_db(struct ck_token *token __unused)
-{
+void close_persistent_db(struct ck_token *token)
+{	
+	if (!token)
+		return;
+
+	TEE_Free(token->db_main);
+	token->db_main = NULL;
+
+	TEE_Free(token->db_objs);
+	token->db_objs = NULL;
+
 }
 
 static int get_persistent_obj_idx(struct ck_token *token, TEE_UUID *uuid)


### PR DESCRIPTION
Tested and verified that there is no PKCS#11 TA crash observed due to memory leak.
The persistent_db is cleared after deinit() call.

Reviewed-by: Neeraj Soni <neersoni@qti.qualcomm.com> 
                      Saurabh Gupta <saursaur@qti.qualcomm.com>
Tested on: SM7325 SoC
Signed-off-by: Saheli Saha <sahesaha@qti.qualcomm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
