### PR TITLE
drivers: caam: improve empty aad updates

### DIFF
--- a/core/drivers/crypto/caam/ae/caam_ae.c
+++ b/core/drivers/crypto/caam/ae/caam_ae.c
@@ -212,7 +212,7 @@ caam_ae_update_aad(struct drvcrypt_authenc_update_aad *dupdate)
 	if (!caam_ctx)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (dupdate->aad.data) {
+	if (dupdate->aad.data && dupdate->aad.length) {
 		retstatus = caam_cpy_buf(&aad, dupdate->aad.data,
 					 dupdate->aad.length);
 		if (retstatus) {


### PR DESCRIPTION
In caam_ae_update_aad an update without data was already handled as long as the data pointer was NULL. This change updates the logic to also account for the case where the pointer is non-null but the length is zero. When that was the case caam_cpy_buf would exit early without allocating, leaving aad->data as NULL, making caam_cpy_block_src fail.

This was found through the Android Keymint tests because Rust represents empty buffers (Rust slices) with a non-null pointer and length 0.

Fixes: faaf0c5975d2 ("drivers: caam: Add AES GCM")

--

This could potentially be lifted out of the drivers as well, e.g. to syscall_authenc_update_aad, but the pointer isn't checked there so this seemed like the more natural place to put it.