### PR TITLE
core: only dump ftrace buffer with TA mapped

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -300,7 +300,8 @@ static void dump_ftrace(struct tee_ta_session *s __maybe_unused)
 #if defined(CFG_FTRACE_SUPPORT)
 	struct ts_ctx *ts_ctx = s->ts_sess.ctx;
 
-	if (ts_ctx && ts_ctx->ops->dump_ftrace) {
+	if (ts_ctx && ts_ctx->ops->dump_ftrace &&
+	    core_mmu_user_mapping_is_active()) {
 		ts_push_current_session(&s->ts_sess);
 		ts_ctx->ops->dump_ftrace(ts_ctx);
 		ts_pop_current_session();


### PR DESCRIPTION
The ftrace buffer is mapped in secure user space. The dump_ftrace() callback must only be called if the buffer is mapped. During TA panic the dump_ftrace() might get called as part of the TA context cleanup and cause a crash. So fix this by skipping the dump_ftrace() callback during those occasions.

Fixes: 17513217b24c ("ftrace: dump ftrace after every ta_entry")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
