### PR TITLE
core: atomic ftrace buffer map update

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -1137,6 +1137,7 @@ static void ftrace_update_times(bool suspend)
 {
 	struct ts_session *s = ts_get_current_session_may_fail();
 	struct ftrace_buf *fbuf = NULL;
+	TEE_Result res = TEE_SUCCESS;
 	uint64_t now = 0;
 	uint32_t i = 0;
 
@@ -1147,6 +1148,13 @@ static void ftrace_update_times(bool suspend)
 
 	fbuf = s->fbuf;
 	if (!fbuf)
+		return;
+
+	res = vm_check_access_rights(to_user_mode_ctx(s->ctx),
+				     TEE_MEMORY_ACCESS_WRITE |
+				     TEE_MEMORY_ACCESS_ANY_OWNER,
+				     (uaddr_t)fbuf, sizeof(*fbuf));
+	if (res)
 		return;
 
 	if (suspend) {

--- a/core/kernel/ts_manager.c
+++ b/core/kernel/ts_manager.c
@@ -35,23 +35,90 @@ static void update_current_ctx(struct thread_specific_data *tsd)
 		panic("unexpected active mapping");
 }
 
+static void *swap_fbuf(struct ts_session *s __maybe_unused,
+		       void *fbuf __maybe_unused)
+{
+	void *ret = NULL;
+
+#if defined(CFG_FTRACE_SUPPORT)
+	ret = s->fbuf;
+	s->fbuf = fbuf;
+#endif
+
+	return ret;
+}
+
 void ts_push_current_session(struct ts_session *s)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
+	uint32_t state = 0;
+	void *fbuf = NULL;
+
+	/*
+	 * If ftrace is enabled we may access the session list and the fbuf
+	 * field in the current (first) session when processing a foreign
+	 * interrupt when saving the state of the thread. Mask foreign
+	 * interrupts temporarily to make sure that we present a consistent
+	 * state.
+	 *
+	 * We disable the fbuf temporarily while switching mapped TS to
+	 * since this isn't an atomic operation, that is, the mappings are
+	 * replaced entry by entry so it's not clear what is mapped during
+	 * the call to update_current_ctx().
+	 */
+
+	if (IS_ENABLED(CFG_FTRACE_SUPPORT)) {
+		state = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+		fbuf = swap_fbuf(s, NULL);
+	}
 
 	TAILQ_INSERT_HEAD(&tsd->sess_stack, s, link_tsd);
+
+	if (IS_ENABLED(CFG_FTRACE_SUPPORT))
+		thread_unmask_exceptions(state);
+
 	update_current_ctx(tsd);
+
+	if (IS_ENABLED(CFG_FTRACE_SUPPORT) && fbuf) {
+		state = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+		swap_fbuf(s, fbuf);
+		thread_unmask_exceptions(state);
+	}
 }
 
 struct ts_session *ts_pop_current_session(void)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
 	struct ts_session *s = TAILQ_FIRST(&tsd->sess_stack);
+	struct ts_session *s2 = NULL;
+	uint32_t state = 0;
+	void *fbuf = NULL;
 
-	if (s) {
-		TAILQ_REMOVE(&tsd->sess_stack, s, link_tsd);
-		update_current_ctx(tsd);
+	if (!s)
+		return NULL;
+
+	/* See comment in ts_push_current_session() above for ftrace support */
+
+	if (IS_ENABLED(CFG_FTRACE_SUPPORT)) {
+		s2 = TAILQ_NEXT(s, link_tsd);
+		if (s2)
+			fbuf = swap_fbuf(s2, NULL);
+		state = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
 	}
+
+	TAILQ_REMOVE(&tsd->sess_stack, s, link_tsd);
+
+	if (IS_ENABLED(CFG_FTRACE_SUPPORT))
+		thread_unmask_exceptions(state);
+
+	update_current_ctx(tsd);
+
+	if (IS_ENABLED(CFG_FTRACE_SUPPORT) && fbuf) {
+		state = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+		swap_fbuf(s2, fbuf);
+		thread_unmask_exceptions(state);
+	}
+
 	return s;
 }
 


### PR DESCRIPTION
When switching sessions, that is, calling ts_push_current_session() or ts_pop_current_session(), a foreign interrupt may save the current thread. When this happens, the ftrace buffer mapping must be consistent with the current session, or bad things, like OP-TEE core crashing or corrupting TA memory, might occur. Fix this by masking foreign interrupts while updating the linked list, and disable the ftrace buffer while setting new TA mappings.

All mappings of a TA are removed if the TA crashes, even if user mappings might still be active. Add checks in the functions accessing the ftrace buffer that the buffer is accessible before accessing it to avoid eventual OP-TEE core crashes.

Fixes: 17513217b24c ("ftrace: dump ftrace after every ta_entry")

Please help review this. It's needed before the release on Friday.