### PR TITLE
plat-marvell: register DDR for dynamic shared memory

### DIFF
--- a/core/arch/arm/plat-marvell/conf.mk
+++ b/core/arch/arm/plat-marvell/conf.mk
@@ -10,6 +10,8 @@ $(call force,CFG_SHMEM_SIZE,0x00400000)
 $(call force,CFG_TEE_RAM_VA_SIZE,0x00400000)
 # If Secure Data Path is enabled, uses the TZDRAM last 4MByte
 $(call force,CFG_TEE_SDP_MEM_SIZE,0x00400000)
+# Total DRAM size for dynamic shared memory registration
+CFG_DDR_SIZE ?= 0x80000000
 platform-debugger-arm := 1
 $(call force,CFG_8250_UART,y)
 endif
@@ -24,6 +26,8 @@ $(call force,CFG_SHMEM_SIZE,0x00400000)
 $(call force,CFG_TEE_RAM_VA_SIZE,0x00400000)
 # If Secure Data Path is enabled, uses the TZDRAM last 4MByte
 $(call force,CFG_TEE_SDP_MEM_SIZE,0x00400000)
+# Total DRAM size for dynamic shared memory registration
+CFG_DDR_SIZE ?= 0x80000000
 platform-debugger-arm := 1
 $(call force,CFG_MVEBU_UART,y)
 $(call force,CFG_ARM_GICV3,y)

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -60,6 +60,13 @@ static struct pl011_data console_data;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE,
 			CORE_MMU_PGDIR_SIZE);
+
+/* Non-secure DDR for dynamic shared memory (after OP-TEE reserved region) */
+#ifdef CFG_DDR_SIZE
+#define NSEC_DDR_BASE	(CFG_SHMEM_START + CFG_SHMEM_SIZE)
+#define NSEC_DDR_SIZE	(CFG_DDR_SIZE - NSEC_DDR_BASE)
+register_ddr(NSEC_DDR_BASE, NSEC_DDR_SIZE);
+#endif
 #ifdef CFG_HW_UNQ_KEY_SUPPORT
 register_phys_mem(MEM_AREA_IO_SEC, PLAT_MARVELL_FUSF_FUSE_BASE,
 		  SMALL_PAGE_SIZE);


### PR DESCRIPTION
Register non-secure DDR memory region for Armada 7K/8K and Armada 3700 platforms to enable dynamic shared memory support.

Without this, U-Boot's OP-TEE driver fails to probe with:  "OP-TEE capabilities mismatch"

The U-Boot OPTEE driver requires OPTEE_SMC_SEC_CAP_DYNAMIC_SHM capability, which is advertised when core_mmu_nsec_ddr_is_defined() returns true.

The registered region starts after the reserved shared memory (CFG_SHMEM_START + CFG_SHMEM_SIZE) and extends to the end of DRAM. DRAM_SIZE defaults to 2GB but can be overridden at build time for boards with different memory configurations.