### PR TITLE
mk/compile.mk: include conf.h during device tree build

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -271,7 +271,7 @@ cleanfiles := $$(cleanfiles) $2 \
 
 dtb-cppflags-$2 := -Icore/include/ -x assembler-with-cpp -undef -D__DTS__ \
 		   -E -ffreestanding $$(CPPFLAGS) \
-		   -MD -MF $$(dtb-predep-$2) -MP -MT $$(dtb-predts-$2)
+		   -include $$(conf-file) -MD -MF $$(dtb-predep-$2) -MP -MT $$(dtb-predts-$2)
 
 dtb-dtcflags-$2	:= $$(DTC_FLAGS) -I dts -O dtb -Wno-unit_address_vs_reg \
 		   -d $$(dtb-dep-$2)
@@ -284,7 +284,7 @@ dtb-dtcflags-$2	:= $$(DTC_FLAGS) -I dts -O dtb -Wno-unit_address_vs_reg \
 dtb-precmd-$2 = $$(CPP$(sm)) $$(dtb-cppflags-$2) -o $$(dtb-predts-$2) $$<
 dtb-cmd-$2 = $$(DTC) $$(dtb-dtcflags-$2) -o $$@ $$(dtb-predts-$2)
 
-$$(dtb-predts-$2): $1 FORCE
+$$(dtb-predts-$2): $1 $$(conf-file) FORCE
 	$$(if $$(strip $$(filter-out FORCE, $$?) \
 	    $$(filter-out $$(dtb-precmd-$2), $$(dtb-old-precmd-$2)) 	\
 	    $$(filter-out $$(dtb-old-precmd-$2), $$(dtb-precmd-$2))), 	\


### PR DESCRIPTION
When compiling device trees conf.h isn't included in the cpp step. Add the -include for conf.h and add it as a dependency too.

See issue #7683

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
