### PR TITLE
Revert "ci: disable regression_1034 for SPMC_AT_EL=2"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,7 @@ jobs:
               make -j$(nproc) check SPMC_AT_EL=1 CFG_SECURE_PARTITION=y CFG_SPMC_TESTS=y
           - name: SPMC_AT_EL=2
             make_commands: |
-              make -j$(nproc) check SPMC_AT_EL=2 XTEST_ARGS="-x n_1034"
+              make -j$(nproc) check SPMC_AT_EL=2
           - name: SPMC_AT_EL=3
             make_commands: |
               make -j$(nproc) check SPMC_AT_EL=3


### PR DESCRIPTION
This reverts commit e4a86928c2052a1e04f4014f2e98f0e70c63351e. The Linux kernel has been updated to v6.18 which brings FF-A 1.2. With FF-A 1.2 both in the normal world and in OP-TEE, Hafnium will not panic on too large fragmented mem share requests. So let's re-enable the test case regression 1034 for Hafnium.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
