### PR TITLE
plat-rockchip: increase FDT max size to 384KiB on all Aarch64 supported SoCs

### DIFF
--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -9,6 +9,10 @@ CFG_WITH_STATS ?= y
 CFG_NUM_THREADS ?= 4
 CFG_EARLY_CONSOLE ?= n
 
+ifneq ($(PLATFORM_FLAVOR),rk322x)
+CFG_DTB_MAX_SIZE ?= 0x60000
+endif
+
 ifeq ($(PLATFORM_FLAVOR),rk322x)
 include ./core/arch/arm/cpu/cortex-a7.mk
 $(call force,CFG_TEE_CORE_NB_CORE,4)
@@ -77,8 +81,6 @@ CFG_EARLY_CONSOLE_BASE ?= UART2_BASE
 CFG_EARLY_CONSOLE_SIZE ?= UART2_SIZE
 CFG_EARLY_CONSOLE_BAUDRATE ?= 1500000
 CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
-
-CFG_DTB_MAX_SIZE ?= 0x60000
 endif
 
 ifeq ($(platform-flavor-armv8),1)


### PR DESCRIPTION
Increase the maximum size of the FDT to 384KiB in sync with Trusted
Firmware-A since TF-A commit [1] available since v2.13 (May 2025). This
limit is applicable to all Rockchip SoCs supported by TF-A.

Prior to that commit in TF-A, we had 0x20000 (double the default of the
current OP-TEE OS default) since commit [2] available since v2.4 (Nov
2020).

This allows us to pass and parse the FDT within OP-TEE as the default
64KiB really isn't enough nowadays (especially if one takes into account
FDT with symbols enabled for FDTO support), otherwise OP-TEE OS panics
at:
E/TC:0   init_external_dt:827 Invalid Device Tree at 0x8a2690: error -3

We currently only allocate 2MiB for TZDRAM on rk322x (as opposed to
32MiB on other Rockchip SoCs; see CFG_TZDRAM_SIZE), so increasing the
FDT buffer size from 64KiB to 384KiB may not be the best idea,
especially considering I couldn't find someone with a device based on
rk322x to test this commit. Additionally, the sizes of the two FDTs for
RK322x boards in the upstream Linux kernel built with symbols enabled
(DTC_FLAGS=-@) only is almost 33KiB. In U-Boot, the FDT for the only
supported board compiles to less than 28KiB for U-Boot proper's and a
tiny bit above 2KiB for SPL's. Thus, there is no hurry to increase the
FDT buffer size on rk322x, especially without being able to test, so
leave rk322x FDT buffer at 64KiB for now.

This fixes OP-TEE OS panics on PX30 and RK3399.

Link: https://review.trustedfirmware.org/plugins/gitiles/TF-A/trusted-firmware-a/+/ab99dce4b7c8473d5bcb8c833bd410ab87b1e801%5E%21/ [1]
Link: https://review.trustedfirmware.org/plugins/gitiles/TF-A/trusted-firmware-a/+/8109f738ffa79a63735cba29da26e7c2859977b5%5E%21/ [2]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

Cc @mmind