### PR TITLE
plat-rockchip: px30: set CFG_CRYPTO_WITH_CE ?= y

### DIFF
--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -47,6 +47,7 @@ endif
 ifeq ($(PLATFORM_FLAVOR),px30)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,4)
+CFG_CRYPTO_WITH_CE ?= y
 
 CFG_TZDRAM_START ?= 0x30000000
 CFG_TZDRAM_SIZE  ?= 0x02000000


### PR DESCRIPTION
Similarly to what's been done to RK3399 in commit 3ab148c8f4a0 ("plat-rockchip: rk3399: set CFG_CRYPTO_WITH_CE ?= y"), we can enable the Arm Cryptography Extensions by default for PX30 as Rockchip claims they are supported in the datasheet[1].

[1] https://opensource.rock-chips.com/images/8/87/Rockchip_PX30_Datasheet_V1.4-20191227.pdf

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

Can anyone tell me how one is supposed to test if this works and the hardware accelerator indeed is used? This was applied on top of 4.7.0 and then I ran `xtest` on it and it passed, that's all I can say.

Cc @mmind