### PR TITLE
plat-agilex5: add initial platform support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -66,6 +66,12 @@ AllWinner sun50i A64
 S:	Orphan
 F:	core/arch/arm/plat-sunxi/
 
+Altera AGILEX5
+R:	Jit Loon Lim <jit.loon.lim@altera.com> [@BenjaminLimJL]
+R:	BenjaminLimJL <ben9166@gmail.com> [@BenjaminLimJL]
+S:	Maintained
+F:	core/arch/arm/plat-altera
+
 AMD Versal Gen 2
 R:	Michal Simek <michal.simek@amd.com> [@michalsimek]
 R:	Akshay Belsare <akshay.belsare@amd.com> [@Akshay-Belsare]

--- a/core/arch/arm/plat-altera/conf.mk
+++ b/core/arch/arm/plat-altera/conf.mk
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2026, Altera Corporation.
+#
+
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+
+# Memory layout
+# Valid DRAM: 0x80000000-0xEFFFFFFF (1792MB with inline ECC)
+# Service Layer: 0x80000000-0x81FFFFFF (32MB, SDM/mailbox)
+# Linux kernel loads: 0x80080000-0x825FFFFF (~37MB)
+# Place OP-TEE after kernel to avoid overlap: 0x83000000-0x84FFFFFF (32MB)
+CFG_TZDRAM_START ?= 0x83000000
+CFG_TZDRAM_SIZE ?= 0x02000000
+
+$(call force,CFG_CORE_RESERVED_SHM,n)
+$(call force,CFG_CORE_DYN_SHM,y)
+
+$(call force,CFG_8250_UART,y)
+CFG_8250_UART_BASE ?= 0x10C02000
+
+$(call force,CFG_GIC,y)
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_STATS,y)
+
+CFG_CRYPTO_WITH_CE ?= n
+CFG_WITH_SOFTWARE_PRNG ?= y
+
+CFG_TEE_CORE_LOG_LEVEL ?= 2
+
+include core/arch/arm/cpu/cortex-armv8-0.mk

--- a/core/arch/arm/plat-altera/main.c
+++ b/core/arch/arm/plat-altera/main.c
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Altera Corporation.
+ */
+
+#include <console.h>
+#include <drivers/serial8250_uart.h>
+#include <kernel/boot.h>
+#include <mm/core_memprot.h>
+#include "platform_config.h"
+
+static struct serial8250_uart_data uart_console;
+
+void plat_console_init(void)
+{
+	serial8250_uart_init(&uart_console,
+			     CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ,
+			     CONSOLE_BAUDRATE);
+	register_serial_console(&uart_console.chip);
+}
+
+/* Map UART registers as I/O memory */
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
+			SERIAL8250_UART_REG_SIZE);
+
+/* Register main DDR for dynamic shared memory */
+register_ddr(DRAM0_BASE, DRAM0_SIZE);

--- a/core/arch/arm/plat-altera/platform_config.h
+++ b/core/arch/arm/plat-altera/platform_config.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Altera Corporation.
+ */
+
+#ifndef __PLATFORM_CONFIG_H
+#define __PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* UART settings */
+#define CONSOLE_UART_BASE  0x10C02000
+#define CONSOLE_BAUDRATE       115200
+#define CONSOLE_UART_CLK_IN_HZ 100000000
+
+/* Generic Interrupt Controller */
+#define GIC_BASE_ADDR 0x1D000000
+#define GIC_DIST_OFFSET 0x0
+#define GIC_CPU_OFFSET  0x100000
+
+/* DDR memory for dynamic shared memory */
+#define DRAM0_BASE 0x80000000
+#define DRAM0_SIZE 0x70000000  /* 1792 MB */
+
+#endif /* __PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-altera/sub.mk
+++ b/core/arch/arm/plat-altera/sub.mk
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2026, Altera Corporation.
+#
+
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
**Description:**
Add initial OP-TEE OS platform support for Altera Agilex 5.

This change introduces the minimal platform bring-up required to build OP-TEE OS
for Agilex 5, including platform configuration, memory layout, and early
initialization.

**Key changes:**
- Add conf.mk, main.c, platform_config.h, and sub.mk
- Configure CPU cores, TZDRAM, UART, GIC, and dynamic shared memory
- Initialize console and register non-secure DDR
- Add clean target in sub.mk

Enables OP-TEE OS to build for the Agilex 5 platform.

**Impact Analysis:**

**What is the scope of the change?**
Platform-scoped change limited to the new Agilex 5 platform. No impact to
existing platforms.

**Purpose of the change?**
Enable OP-TEE OS to build and boot on Agilex 5 by providing the required
platform definitions and initialization.

**Reach of the change?**
Impacts only the Agilex 5 platform.
