### PR TITLE
drivers: imx: rngb: use explicit seed generation command

### DIFF
--- a/core/drivers/imx_rngb.c
+++ b/core/drivers/imx_rngb.c
@@ -32,6 +32,7 @@
 #define RNG_CMD_SEED		BIT(1)
 #define RNG_CMD_CLR_INT		BIT(4)
 #define RNG_CMD_CLR_ERR		BIT(5)
+#define RNG_CMD_SOFT_RESET	BIT(6)
 
 #define RNG_CR_AR		BIT(4)
 #define RNG_CR_MASK_DONE	BIT(5)
@@ -86,6 +87,11 @@ static void wait_for_irq(struct imx_rng *rng)
 	} while ((status & (RNG_SR_SEED_DONE | RNG_SR_ST_DONE)) == 0);
 }
 
+static void soft_reset(struct imx_rng *rng)
+{
+	io_setbits32(rng->base.va + RNG_CMD, RNG_CMD_SOFT_RESET);
+}
+
 static void irq_clear(struct imx_rng *rng)
 {
 	io_setbits32(rng->base.va + RNG_CMD,
@@ -115,7 +121,10 @@ static void rng_seed(struct imx_rng *rng)
 		/* seed creation */
 		io_setbits32(rng->base.va + RNG_CMD, RNG_CMD_SEED);
 		wait_for_irq(rng);
-		irq_clear(rng);
+		if (rng->error)
+			soft_reset(rng);
+		else
+			irq_clear(rng);
 		irq_mask(rng);
 
 		if (timeout_elapsed(tref))


### PR DESCRIPTION
Follow the [Linux](https://elixir.bootlin.com/linux/v6.19-rc5/source/drivers/char/hw_random/imx-rngc.c#L197) and [U-Boot](https://elixir.bootlin.com/u-boot/v2026.01/source/drivers/crypto/fsl/dcp_rng.c#L97) drivers in using the explicit command to trigger seed generation. Relying on auto-seeding didn't seem to trigger reseeding when the first try fails the statistics tests.

Only switch to continuous auto-reseeding after initialization succeeded.