### PR TITLE
drivers: crypto: fix SM2 ECC encrypt and decrypt

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -365,10 +365,15 @@ static TEE_Result ecc_sm2_encrypt(struct ecc_public_key *key,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	/* Uncompressed form indicator */
-	dst[0] = 0x04;
 
 	ciphertext_len = 2 * size_bytes + src_len + TEE_SM3_HASH_SIZE;
+	if (*dst_len < ciphertext_len + 1) {
+		*dst_len = ciphertext_len + 1;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	/* Uncompressed form indicator */
+	dst[0] = 0x04;
 
 	cdata.key = key;
 	cdata.size_sec = size_bytes;
@@ -452,6 +457,11 @@ static TEE_Result ecc_sm2_decrypt(struct ecc_keypair *key,
 	if (SUB_OVERFLOW(ciphertext_len, 2 * size_bytes + TEE_SM3_HASH_SIZE,
 			 &plaintext_len))
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (*dst_len < plaintext_len) {
+		*dst_len = plaintext_len;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
 
 	cdata.key = key;
 	cdata.size_sec = size_bytes;


### PR DESCRIPTION
Adds checks that the destination buffer has room for the result in ecc_sm2_decrypt() and ecc_sm2_encrypt(). Note that these two functions not reachable upstream since none of the crypto drivers registers ECC encrypt or decrypt drivers. So fix this before it becomes a problem.

Fixes: f4f85ac774af ("drivers: crypto: add SM2 ECC encrypt and decrypt")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
