### PR TITLE
ta: avb: fix memory copied in read_persist_value()

### DIFF
--- a/ta/avb/entry.c
+++ b/ta/avb/entry.c
@@ -345,9 +345,7 @@ static TEE_Result read_persist_value(uint32_t pt,
 		goto out;
 	}
 
-	TEE_MemMove(params[1].memref.buffer, value,
-		    value_sz);
-
+	TEE_MemMove(params[1].memref.buffer, value, count);
 	params[1].memref.size = count;
 out:
 	TEE_CloseObject(h);


### PR DESCRIPTION
read_persist_value() allocates a temporary buffer and reads persistent value from secure storage into that buffer. Next it copies the content of the buffer input an out memref, but it copies the number of allocated bytes instead of the size of the persistent value. No unintended information leaks though, since Temporary buffer was zero-initialized by TEE_Malloc(). To avoid unnecessary copying, copy only the number of read bytes from secure storage.

Fixes: ddcd07a27aa6 ("ta: avb: copy data to temporary buffers")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
