### PR TITLE
core: kernel: bump transfer list to spec version 2.0

### DIFF
--- a/core/include/kernel/transfer_list.h
+++ b/core/include/kernel/transfer_list.h
@@ -7,7 +7,7 @@
 #define __KERNEL_TRANSFER_LIST_H
 
 #define TRANSFER_LIST_SIGNATURE		U(0x4a0fb10b)
-#define TRANSFER_LIST_VERSION		U(0x0001)
+#define TRANSFER_LIST_VERSION		U(0x0002)
 
 /*
  * Init value of maximum alignment required by any transfer entry data in the TL


### PR DESCRIPTION
Update the transfer list library to implement specification version 2.0, as versions 1.0 and 0.9 have been withdrawn [1]. The primary change is switching the checksum calculation from an XOR sum to a byte-wise sum. This aligns the implementation with the updated specification and with behavior already used in existing deployments.

1. https://github.com/FirmwareHandoff/firmware_handoff/pull/81

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
