### PR TITLE
ta:pkcs11:fix eddsa key reusage

### DIFF
--- a/ta/pkcs11/src/processing_asymm.c
+++ b/ta/pkcs11/src/processing_asymm.c
@@ -330,6 +330,12 @@ static enum pkcs11_rc load_tee_key(struct pkcs11_session *session,
 				break;
 			}
 			break;
+		case PKCS11_CKK_EC_EDWARDS:
+			assert((obj->key_type == TEE_TYPE_ED25519_PUBLIC_KEY &&
+				class == PKCS11_CKO_PUBLIC_KEY) ||
+			       (obj->key_type == TEE_TYPE_ED25519_KEYPAIR &&
+				class == PKCS11_CKO_PRIVATE_KEY));
+			goto key_ready;
 		default:
 			assert(0);
 			break;


### PR DESCRIPTION
EdDsa key weren't enabled to be re-used in the same session in the load_tee_key function, forcing the client to close the session and open it again whenever the same operation should have been done multiple times.

Close: #7686
Signed-off-by: Christian Zoia <czoia@amazon.es>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
