### PR TITLE
libutee: fix copy_mpi_to_bigint()

### DIFF
--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -71,7 +71,7 @@ static TEE_Result copy_mpi_to_bigint(mbedtls_mpi *mpi, TEE_BigInt *bigInt)
 
 	hdr->nblimbs = n;
 	hdr->sign = mpi->s;
-	memcpy(hdr + 1, mpi->p, mpi->n * sizeof(mbedtls_mpi_uint));
+	memcpy(hdr + 1, mpi->p, n * sizeof(mbedtls_mpi_uint));
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
In copy_mpi_to_bigint() when copying an mbedtls_mpi to a TEE_BigInt we trim eventual leading zeroes before copying the bignum words. Prior to this patch, the number of copied bytes where always the capacity of the source mbedtls_mpi. This can if, the destination TEE_BigInt, isn't large enough lead to writing zeroes beyond the end of the memory allocation. So fix this by only copying the significant bignum words.

Fixes: 7696ab7fe0b2 ("libutee: lessen dependency on mbedtls internals")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
