### PR TITLE
core: kernel: allow not masking interrupts on output traces

### DIFF
--- a/core/kernel/trace_ext.c
+++ b/core/kernel/trace_ext.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <trace.h>
 #include <console.h>
+#include <config.h>
 #include <kernel/misc.h>
 #include <kernel/spinlock.h>
 #include <kernel/thread.h>
@@ -15,21 +16,75 @@ const char trace_ext_prefix[] = "TC";
 int trace_level __nex_data = TRACE_LEVEL;
 static unsigned int puts_lock __nex_bss = SPINLOCK_UNLOCK;
 
+/*
+ * Atomic flags for sequencing concurrent messages
+ * when CFG_CONSOLE_MASK_INTERRUPTS is disabled.
+ * itr_trace_busy tracks context always uninterruptible
+ * (when thread_is_in_normal_mode() returns false).
+ */
+static unsigned int thread_trace_busy;
+static unsigned int itr_trace_busy;
+
+static unsigned int *get_busy_state(void)
+{
+	if (thread_is_in_normal_mode())
+		return &thread_trace_busy;
+	else
+		return &itr_trace_busy;
+}
+
+static bool wait_if_trace_contended(uint32_t *itr_status)
+{
+	bool was_contended = false;
+
+	if (IS_ENABLED(CFG_CONSOLE_MASK_INTERRUPTS)) {
+		*itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
+
+		if (cpu_mmu_enabled() && !cpu_spin_trylock(&puts_lock)) {
+			was_contended = true;
+			cpu_spin_lock_no_dldetect(&puts_lock);
+		}
+	} else if (cpu_mmu_enabled()) {
+		unsigned int trace_not_busy = 0;
+
+		/* Don't mix thread traces, don't mix interrupt traces */
+		while (!atomic_cas_uint(get_busy_state(), &trace_not_busy, 1)) {
+			trace_not_busy = 0;
+			was_contended = true;
+		}
+
+		/* Don't emit a thread trace inside an interrupt trace */
+		if (thread_is_in_normal_mode())
+			while (atomic_load_uint(&itr_trace_busy))
+				was_contended = true;
+	}
+
+	return was_contended;
+}
+
+static void release_trace_contention(uint32_t itr_status)
+{
+	if (IS_ENABLED(CFG_CONSOLE_MASK_INTERRUPTS)) {
+		if (cpu_mmu_enabled())
+			cpu_spin_unlock(&puts_lock);
+
+		thread_unmask_exceptions(itr_status);
+	} else if (cpu_mmu_enabled()) {
+		atomic_store_uint(get_busy_state(), 0);
+	}
+}
+
 void __weak plat_trace_ext_puts(const char *str __unused)
 {
 }
 
 void trace_ext_puts(const char *str)
 {
-	uint32_t itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
-	bool mmu_enabled = cpu_mmu_enabled();
 	bool was_contended = false;
-	const char *p;
+	uint32_t itr_status = 0;
+	const char *p = NULL;
 
-	if (mmu_enabled && !cpu_spin_trylock(&puts_lock)) {
-		was_contended = true;
-		cpu_spin_lock_no_dldetect(&puts_lock);
-	}
+	was_contended = wait_if_trace_contended(&itr_status);
 
 	plat_trace_ext_puts(str);
 
@@ -43,10 +98,7 @@ void trace_ext_puts(const char *str)
 
 	console_flush();
 
-	if (mmu_enabled)
-		cpu_spin_unlock(&puts_lock);
-
-	thread_unmask_exceptions(itr_status);
+	release_trace_contention(itr_status);
 }
 
 int trace_ext_get_thread_id(void)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -89,6 +89,14 @@ CFG_TEE_TA_LOG_LEVEL ?= 1
 # CFG_TEE_TA_LOG_LEVEL. Otherwise, they are not output at all
 CFG_TEE_CORE_TA_TRACE ?= y
 
+# By default, OP-TEE masks interrupts when emitting console trace messages
+# and uses a spinlock to prevent they intertwine.
+# When CFG_CONSOLE_MASK_INTERRUPTS is disabled, OP-TEE only attempts,
+# when possible, to withhold trace message evictions to prevent they
+# intertwine. However, trace mesasges from atomic contexts may still be
+# inserted into or even interleaved with non-atomic trace messages.
+CFG_CONSOLE_MASK_INTERRUPTS ?= y
+
 # If y, enable the memory leak detection feature in the bget memory allocator.
 # When this feature is enabled, calling mdbg_check(1) will print a list of all
 # the currently allocated buffers and the location of the allocation (file and


### PR DESCRIPTION
Add configuration switch `CFG_TEE_CONSOLE_UNLOCKED` to evacuate trace messages without masking interrupts. This configuration can be handy to still benefit from OP-TEE threads output console trace support without affecting native and foreign interrupts handling latency.

Enabling the configuration does not fully prevent collision of trace messages: a trace message from an non-thread context can still be interrupted by a message from a interrupt context.

By the way, add an initial value to local variable p in trace_ext_puts().

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
