### PR TITLE
ta: pkcs11: fix memory leak in close_persistent_db()

### DIFF
--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -286,8 +286,16 @@ enum pkcs11_rc verify_identity_auth(struct ck_token *token,
 /*
  * Release resources relate to persistent database
  */
-void close_persistent_db(struct ck_token *token __unused)
+void close_persistent_db(struct ck_token *token)
 {
+	if (!token)
+		return;
+
+	TEE_Free(token->db_main);
+	token->db_main = NULL;
+
+	TEE_Free(token->db_objs);
+	token->db_objs = NULL;
 }
 
 static int get_persistent_obj_idx(struct ck_token *token, TEE_UUID *uuid)


### PR DESCRIPTION
close_persistent_db() is a no-op stub that never frees the db_main and db_objs structures allocated by init_persistent_db(). In normal TA operation this is harmless since the TEE framework reclaims all TA memory on unload, which is likely why it was left unimplemented.

However, the leak becomes visible when running the TA in a host-based test environment (e.g. with AddressSanitizer) where the TEE memory reclamation does not occur. ASan reports 264 leaked allocations totalling ~24 KiB per TA lifecycle.

Implement close_persistent_db() to free token->db_main and token->db_objs and NULL the pointers. Add a NULL check on the token argument for robustness.

Fixes: c84ccd0a805e ("ta: pkcs11: persistent database for the pkcs11 tokens")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
