### PR TITLE
linker.mk: Fix typo for python command line

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -222,7 +222,7 @@ all: $(link-out-dir)/tee-raw.bin
 cleanfiles += $(link-out-dir)/tee-raw.bin
 $(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@
 
 cleanfiles += $(link-out-dir)/tee.srec
 $(link-out-dir)/tee.srec: $(link-out-dir)/tee-raw.bin


### PR DESCRIPTION
Fix typo for python command line
modify "$(q)scripts/gen_tee_bin.py" to 
"$(q)$(PYTHON3) ./scripts/gen_tee_bin.py"

Fix #7699

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
