### PR TITLE
plat-k3: drivers: ti-sci: add support for retrieving SOC UID

### DIFF
--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -522,6 +522,27 @@ int ti_sci_set_keyrev(uint32_t keyrev,
 	return 0;
 }
 
+int ti_sci_get_soc_uid(uint32_t soc_uid[UID_LEN_WORDS])
+{
+	struct ti_sci_msg_req_get_soc_uid req = { };
+	struct ti_sci_msg_resp_get_soc_uid resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_GET_SOC_UID, 0,
+				&req, sizeof(req), &resp, sizeof(resp), &xfer);
+	if (ret)
+		return ret;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	memcpy(soc_uid, resp.soc_uid, sizeof(resp.soc_uid));
+	memzero_explicit(&resp, sizeof(resp));
+	return 0;
+}
+
 int ti_sci_init(void)
 {
 	struct ti_sci_msg_resp_version rev_info = { };

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -209,6 +209,18 @@ int ti_sci_set_keyrev(uint32_t keyrev,
 		      uint32_t cert_addr_hi);
 
 /**
+ * ti_sci_get_soc_uid - Get the SoC UID
+ * @soc_uid:	Array to store the SoC UID
+ *
+ * Reads the SOC UID value from the device.
+ * SOC UID is a unique identifier for the SOC calculated on the device by the
+ * Boot ROM.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_soc_uid(uint32_t soc_uid[UID_LEN_WORDS]);
+
+/**
  * ti_sci_init() - Basic initialization
  *
  * Return: 0 if all goes well, else appropriate error message

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -23,6 +23,7 @@
 #define TI_SCI_MSG_FWL_GET               0x9001
 #define TI_SCI_MSG_FWL_CHANGE_OWNER      0x9002
 #define TI_SCI_MSG_SA2UL_GET_DKEK        0x9029
+#define TI_SCI_MSG_GET_SOC_UID		 0x9021
 #define TI_SCI_MSG_READ_OTP_MMR          0x9022
 #define TI_SCI_MSG_WRITE_OTP_ROW         0x9023
 #define TI_SCI_MSG_LOCK_OTP_ROW          0x9024
@@ -503,6 +504,28 @@ struct ti_sci_msq_req_set_keyrev {
  */
 struct ti_sci_msq_resp_set_keyrev {
 	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msq_req_get_soc_uid - Request for reading the SoC UID
+ * @hdr:	Generic header
+ *
+ * Request for TI_SCI_MSG_GET_SOC_UID
+ */
+struct ti_sci_msg_req_get_soc_uid {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msq_resp_get_soc_uid - Response for reading the SoC UID
+ * @hdr:	Generic header
+ *
+ * Response for TI_SCI_MSG_GET_SOC_UID
+ */
+struct ti_sci_msg_resp_get_soc_uid {
+	struct ti_sci_msg_hdr hdr;
+#define UID_LEN_WORDS	8U
+	uint32_t soc_uid[UID_LEN_WORDS];
 } __packed;
 
 #endif


### PR DESCRIPTION
Add TISCI call to retrieve SOC UID. Unlocking the JTAG port on a SOC requires a X509 certificate signed with the active root of trust asymmetric key and containing the UID for the SOC. This TISCI call enables to retrieve the SOC UID to populate into the certificate.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
