### PR TITLE
plat-k3: drivers: Increase mailbox timeout to 1000ms

### DIFF
--- a/core/arch/arm/plat-k3/drivers/mailbox.c
+++ b/core/arch/arm/plat-k3/drivers/mailbox.c
@@ -28,7 +28,7 @@ static TEE_Result ti_mailbox_poll_rx_status(void)
 	vaddr_t mailbox_status_addr = mailbox_rx_base + TI_MAILBOX_MSG_STATUS;
 
 	if (IO_READ32_POLL_TIMEOUT(mailbox_status_addr, num_messages_pending,
-				   num_messages_pending != 0, 10, 1000)) {
+				   num_messages_pending != 0, 10, 100000)) {
 		EMSG("Mailbox RX status polling timed out");
 		return TEE_ERROR_TIMEOUT;
 	}


### PR DESCRIPTION
Mailbox driver waits for 10ms to get a response from TIFS, before flagging the transaction a failure. 10ms seems to be right at the edge, since unrelated updates to other components in the boot chain are causing the actual wait time to increase. Therefore increase the timeout to 1000ms.

