### PR TITLE
drivers: caam: fix bits/bytes confusion

### DIFF
--- a/core/drivers/crypto/caam/caam_key.c
+++ b/core/drivers/crypto/caam/caam_key.c
@@ -733,7 +733,7 @@ enum caam_status caam_key_init(void)
 	size_t alloc_size = 0;
 	const struct caamkey key = {
 		.key_type = caam_key_default_key_gen_type(),
-		.sec_size = 4096, /* Max RSA key size */
+		.sec_size = 4096 / 8, /* Max RSA key size */
 		.is_blob = true,
 	};
 
@@ -744,7 +744,7 @@ enum caam_status caam_key_init(void)
 	if (caam_key_serialized_size(&key, &alloc_size))
 		return CAAM_FAILURE;
 
-	assert(alloc_size <= CFG_CORE_BIGNUM_MAX_BITS);
+	assert(alloc_size <= CFG_CORE_BIGNUM_MAX_BITS / 8);
 
 	key_blob_modifier = caam_calloc_align(KEY_BLOB_MODIFIER_SIZE);
 	if (!key_blob_modifier)


### PR DESCRIPTION
Fixes two mixups of bits and bytes in caam_key_init that roughly cancel each other out. Both sec_size and the result from
caam_key_serialized_size are values in bytes, so the key sizes in bits need to be converted. For plain text keys this makes no difference to the result since they cancel each other out exactly.

For the default key type of BLACK_CCM the blob overhead is now correctly counted as bytes instead of bits which decreases the headroom, but since the default config of 4576 was calculated correctly, the assert still shouldn't fail.

Fixes: 1495f6c4a82a ("drivers: caam: add CAAM key driver")