### PR TITLE
drivers: caam: handle serialization of short params

### DIFF
--- a/core/drivers/crypto/caam/caam_key.c
+++ b/core/drivers/crypto/caam/caam_key.c
@@ -491,12 +491,12 @@ enum caam_status caam_key_serialize_to_bin(uint8_t *data, size_t size,
 
 	/* If the key is plain text, just copy key to buffer */
 	if (key->key_type == CAAM_KEY_PLAIN_TEXT) {
-		if (size < key->buf.length) {
+		if (size < key->sec_size) {
 			KEY_TRACE("Buffer is too short");
 			return CAAM_SHORT_BUFFER;
 		}
 
-		memcpy(data, key->buf.data, key->buf.length);
+		memcpy(data, key->buf.data, key->sec_size);
 
 		return CAAM_NO_ERROR;
 	}
@@ -552,7 +552,7 @@ enum caam_status caam_key_serialized_size(const struct caamkey *key,
 	assert(key && size);
 
 	/* For a plain text key, the serialized key is identical to the key */
-	*size = key->buf.length;
+	*size = key->sec_size;
 
 	/*
 	 * For black keys, the serialized key includes the header and must be


### PR DESCRIPTION
Adjusts the caam key serialization code to account for keys where sec_size < buf.length. When that is the case the serialization can only touch the first sec_size bytes since the rest are invalid, and the serialized length is thus sec_size.

If the default key type has been changed to plain this can happen during RSA keygen if the d parameter ends up shorter than the key size in bytes. In that case the valid bytes are at the front of the buffer and do_gen_keypair accounts for this by setting sec_size correctly, and caam_key_serialize_to_bn is called with an inkey in the sec_size < buf.length state. This ended up creating corrupt keys for roughly 1% of keygens, and was caught by various RSA tests in optee_test.

Fixes: 1495f6c4a82a ("drivers: caam: add CAAM key driver")