### PR TITLE
drivers: caam: fix cache invalidation of RSA buffer

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -714,7 +714,7 @@ static TEE_Result do_gen_keypair(struct rsa_keypair *key, size_t key_size)
 
 	if (retstatus == CAAM_NO_ERROR) {
 		caam_key_cache_op(TEE_CACHEINVALIDATE, &genkey.d);
-		cache_operation(TEE_CACHEINVALIDATE, &genkey.n,
+		cache_operation(TEE_CACHEINVALIDATE, genkey.n.data,
 				genkey.n.length);
 
 		cache_operation(TEE_CACHEINVALIDATE, size_d_gen_val_ptr,


### PR DESCRIPTION
When using CAAM to generate an RSA key the CPU caching of the DMA buffers need to be controlled to ensure the correct visibility for both devices. For the n parameter the wrong address was used when invalidating the CPU cache after the DMA operation, resulting in <key length> bytes of the stack being invalidated (without flushing to memory) instead of the buffer.

The first potential consequence of this is that any parts of the n buffer that were cached during the key generation won't get read from RAM, resulting in a corrupt key. This is unlikely since the n buffer was correctly flushed immediately before starting the CAAM operation. To reliably reproduce this, a read that should normally be harmless can be inserted immediately before caam_jr_enqueue:
((volatile uint8_t *)genkey.n.data)[0];

The second effect of this bug is that parts of the do_gen_keypair stack frame will have its cache lines invalidated (again without write back to memory). With 4096 bit keys and a compiler that produces the right stack layout this affects callee saved registers, the return pointer and potentially a stack canary. I have not been able to see the effects of this on my iMX8MQ test device.

Fixes: ccbcceeb73c1 ("drivers: caam: add CAAM key support for RSA")