### PR TITLE
RFC: Dynamic NS Virt

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -20,6 +20,7 @@
 #include <keep.h>
 #include <kernel/asan.h>
 #include <kernel/boot.h>
+#include <kernel/virtualization.h>
 #include <kernel/dt.h>
 #include <kernel/linker.h>
 #include <kernel/misc.h>
@@ -1055,6 +1056,9 @@ void __weak boot_init_primary_runtime(void)
 #ifdef CFG_NS_VIRTUALIZATION
 	DMSG("NS-virtualization enabled, supporting %u guests",
 	     CFG_VIRT_GUEST_COUNT);
+#if defined(CFG_NS_VIRT_HYP_GUEST_ID) && (CFG_NS_VIRT_HYP_GUEST_ID > 0)
+	virt_guest_created(CFG_NS_VIRT_HYP_GUEST_ID);
+#endif
 #endif
 	if (IS_ENABLED(CFG_MEMTAG))
 		DMSG("Memory tagging %s",

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -33,10 +33,18 @@ void thread_handle_fast_smc(struct thread_smc_args *args)
 {
 	thread_check_canaries();
 
-	if (IS_ENABLED(CFG_NS_VIRTUALIZATION) &&
-	    virt_set_guest(args->a7) && args->a7 != HYP_CLNT_ID) {
-		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
-		goto out;
+	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
+		uint16_t gid = args->a7;
+
+#if defined(CFG_NS_VIRT_HYP_GUEST_ID) && (CFG_NS_VIRT_HYP_GUEST_ID > 0)
+		if (gid == HYP_CLNT_ID && args->a0 != OPTEE_SMC_VM_CREATED &&
+		    args->a0 != OPTEE_SMC_VM_DESTROYED)
+			gid = CFG_NS_VIRT_HYP_GUEST_ID;
+#endif
+		if (virt_set_guest(gid) && args->a7 != HYP_CLNT_ID) {
+			args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
+			goto out;
+		}
 	}
 
 	tee_entry_fast(args);
@@ -57,8 +65,16 @@ uint32_t thread_handle_std_smc(uint32_t a0, uint32_t a1, uint32_t a2,
 
 	thread_check_canaries();
 
-	if (IS_ENABLED(CFG_NS_VIRTUALIZATION) && virt_set_guest(a7))
-		return OPTEE_SMC_RETURN_ENOTAVAIL;
+	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
+		uint16_t gid = a7;
+#if defined(CFG_NS_VIRT_HYP_GUEST_ID) && (CFG_NS_VIRT_HYP_GUEST_ID > 0)
+		if (gid == HYP_CLNT_ID && a0 != OPTEE_SMC_VM_CREATED &&
+		    a0 != OPTEE_SMC_VM_DESTROYED)
+			gid = CFG_NS_VIRT_HYP_GUEST_ID;
+#endif
+		if (virt_set_guest(gid))
+			return OPTEE_SMC_RETURN_ENOTAVAIL;
+	}
 
 	/*
 	 * thread_resume_from_rpc() and thread_alloc_and_run() only return

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -308,6 +308,12 @@ TEE_Result virt_guest_created(uint16_t guest_id)
 	if (guest_id == HYP_CLNT_ID)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	prtn = virt_get_guest(guest_id);
+	if (prtn) {
+		virt_put_guest(prtn);
+		return TEE_SUCCESS;
+	}
+
 	prtn = nex_calloc(1, sizeof(*prtn));
 	if (!prtn)
 		return TEE_ERROR_OUT_OF_MEMORY;

--- a/core/arch/riscv/kernel/thread_optee_abi.c
+++ b/core/arch/riscv/kernel/thread_optee_abi.c
@@ -34,10 +34,16 @@ void thread_handle_fast_abi(struct thread_abi_args *args)
 {
 	thread_check_canaries();
 
-	if (IS_ENABLED(CFG_NS_VIRTUALIZATION) &&
-	    virt_set_guest(args->a7)) {
-		args->a0 = OPTEE_ABI_RETURN_ENOTAVAIL;
-		goto out;
+	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
+		uint16_t gid = args->a7;
+#if defined(CFG_NS_VIRT_HYP_GUEST_ID) && (CFG_NS_VIRT_HYP_GUEST_ID > 0)
+		if (gid == HYP_CLNT_ID)
+			gid = CFG_NS_VIRT_HYP_GUEST_ID;
+#endif
+		if (virt_set_guest(gid)) {
+			args->a0 = OPTEE_ABI_RETURN_ENOTAVAIL;
+			goto out;
+		}
 	}
 
 	tee_entry_fast(args);
@@ -58,8 +64,15 @@ uint32_t thread_handle_std_abi(uint32_t a0, uint32_t a1, uint32_t a2,
 
 	thread_check_canaries();
 
-	if (IS_ENABLED(CFG_NS_VIRTUALIZATION) && virt_set_guest(a7))
-		return OPTEE_ABI_RETURN_ENOTAVAIL;
+	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
+		uint16_t gid = a7;
+#if defined(CFG_NS_VIRT_HYP_GUEST_ID) && (CFG_NS_VIRT_HYP_GUEST_ID > 0)
+		if (gid == HYP_CLNT_ID)
+			gid = CFG_NS_VIRT_HYP_GUEST_ID;
+#endif
+		if (virt_set_guest(gid))
+			return OPTEE_ABI_RETURN_ENOTAVAIL;
+	}
 
 	/*
 	 * thread_resume_from_rpc() and thread_alloc_and_run() only return

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -794,6 +794,8 @@ $(call force,CFG_CORE_RWDATA_NOEXEC,y)
 
 # Default number of virtual guests
 CFG_VIRT_GUEST_COUNT ?= 2
+# Bind hypervisor client to this guest ID (0 disables)
+CFG_NS_VIRT_HYP_GUEST_ID ?= 1
 endif
 
 # Enables backwards compatible derivation of RPMB and SSK keys


### PR DESCRIPTION
Hi, I don't expect this to be merged as is, but am rather hoping for comments on this approach. This is a first pass at making part of what I described in https://github.com/OP-TEE/optee_os/issues/7641 work.

This introduces CFG_NS_VIRT_HYP_GUEST_ID, which when set to a domain ID will allow a pre-hypervisor boot loader, such as u-boot to use that guest's instance.

On its own, this does rely on being able to predict the guest IDs we want, which may be easier in some scenarios than in others.

I have tested this with u-boot -> Xen -> domU1 and ftpm, although I did end up adding an in-memory NV storage backend to ftpm.

I suspect this will be more interesting as a series, but want to make sure I'm on a desirable path.

Thank you for any and all comments!

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
