### PR TITLE
core: riscv: core_mmu_arch: zero-initialize new page tables

### DIFF
--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -308,6 +308,9 @@ static struct mmu_pgt *core_mmu_pgt_alloc(struct mmu_partition *prtn)
 				prtn->pool_pgts = pgt;
 			}
 		}
+
+		memset(pgt, 0, RISCV_MMU_PGT_SIZE);
+
 		prtn->pgts_used++;
 		DMSG("pgts used %u", prtn->pgts_used);
 	} else {


### PR DESCRIPTION
New page table pages must always start cleared. On some platforms (e.g., QEMU) RAM happens to be zeroed at reset, but on real hardware (FPGA/SoC DDR) may not be the case. Without this memset, stale contents can make
core_mmu_map_region() see non-zero old_attr and panic with "Page is already mapped" when CFG_DYN_CONFIG is enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
