### PR TITLE
core: fs: report key manager initialization failure

### DIFF
--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -143,10 +143,12 @@ static TEE_Result tee_fs_init_key_manager(void)
 
 	res = huk_subkey_derive(HUK_SUBKEY_SSK, NULL, 0,
 				tee_fs_ssk.key, sizeof(tee_fs_ssk.key));
-	if (res == TEE_SUCCESS)
+	if (res == TEE_SUCCESS) {
 		tee_fs_ssk.is_init = 1;
-	else
+	} else {
 		memzero_explicit(&tee_fs_ssk, sizeof(tee_fs_ssk));
+		EMSG("Secure storage will not be available");
+	}
 
 	return res;
 }


### PR DESCRIPTION
    Some platforms may fail at deriving the Hardware Unique Key (HUK).
    
    When the HUK cannot be retrieved, the secure storage subsystem cannot
    derive the Secure Storage Key (SSK). In this case secure storage is not
    usable and the key manager initialization fails.
    
    Emit an explicit error message when SSK derivation fails so that the
    reason for secure storage being unavailable is visible in the logs.
    
    This is particularly useful on platforms such as Versal where fuse
    access depends on external firmware components.
