### PR TITLE
Fix mx8mpevk optee memory layout

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -448,6 +448,7 @@ CFG_DDR_SIZE ?= UL(0x180000000)
 CFG_UART_BASE ?= UART2_BASE
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,36)
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mp_libra_fpsc))


### PR DESCRIPTION
Mostly all i.MX OP-TEE platforms place OP-TEE at the end of the available memory. Since the i.MX8MP-EVK has 6GiB RAM we need to set CFG_LPAE_ADDR_SPACE_BITS accordingly else OP-TEE uses 32-bit and can't access the memory above.

The fix uses the same amount of bits as used for CFG_CORE_ARM64_PA_BITS.