### PR TITLE
drivers: crypto: hisilicon: fix qp memory leak

### DIFF
--- a/core/drivers/crypto/hisilicon/hisi_qm.c
+++ b/core/drivers/crypto/hisilicon/hisi_qm.c
@@ -745,9 +745,9 @@ struct hisi_qp *hisi_qm_create_qp(struct hisi_qm *qm, uint8_t sq_type)
 
 err_qp_release:
 	qp->used = false;
-err_proc:
 	qp->sq_type = 0;
 	qp->cqc_phase = false;
+err_proc:
 	mutex_unlock(&qm->qp_lock);
 	return NULL;
 }


### PR DESCRIPTION
Fix the null pointer access issue for hisilicon QM driver.

Fixes: c7f9abc ("drivers: implement HiSilicon Queue Management (QM) module ")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
