### PR TITLE
core: fix protmem overlap in check_reg_shm_conflict()

### DIFF
--- a/core/mm/mobj_dyn_shm.c
+++ b/core/mm/mobj_dyn_shm.c
@@ -318,9 +318,12 @@ static struct mobj_reg_shm *to_mobj_reg_shm(struct mobj *mobj)
 static TEE_Result check_reg_shm_conflict(struct mobj_reg_shm *r, paddr_t pa,
 					 paddr_size_t size)
 {
+	size_t page_count = 0;
 	size_t n = 0;
 
-	for (n = 0; n < r->mobj.size / SMALL_PAGE_SIZE; n++)
+	page_count = ROUNDUP2_DIV(r->mobj.size + r->page_offset,
+				  SMALL_PAGE_SIZE);
+	for (n = 0; n < page_count; n++)
 		if (core_is_buffer_intersect(pa, size, r->pages[n],
 					     SMALL_PAGE_SIZE))
 			return TEE_ERROR_BAD_PARAMETERS;


### PR DESCRIPTION
Prior to this patch, check_reg_shm_conflict() would miss checking the last page of a registered shared memory if it had a non-zero page_offset or a page-unaligned mobj.size. So fix it and ensure the final page is included in the conflict check by accounting for the page_offset and any remaining unaligned bytes in the size.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
