### PR TITLE
plat-qcom: Enable support for ARMv8 CE by default

### DIFF
--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -11,6 +11,7 @@ $(call force,CFG_CORE_ARM64_PA_BITS,40)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_RESERVED_SHM,n)
 $(call force,CFG_QCOM_GENI_UART,y)
+$(call force,CFG_CRYPTO_WITH_CE,y)
 
 ta-targets = ta_arm64
 supported-ta-targets ?= ta_arm64


### PR DESCRIPTION
Qcom platforms support ARMv8 Crypto Extensions (CE), so let's enable it by default to optimize the crypto operations.