### PR TITLE
ldelf: fix relocation bounds check

### DIFF
--- a/ldelf/ta_elf_rel.c
+++ b/ldelf/ta_elf_rel.c
@@ -408,11 +408,13 @@ static void e32_relocate(struct ta_elf *elf, unsigned int rel_sidx)
 	for (; rel < rel_end; rel++) {
 		struct ta_elf *mod = NULL;
 		Elf32_Addr *where = NULL;
+		Elf32_Addr end_offs = 0;
 		size_t sym_idx = 0;
 		vaddr_t val = 0;
 
 		/* Check the address is inside TA memory */
-		if (rel->r_offset >= (elf->max_addr - elf->load_addr))
+		if (ADD_OVERFLOW(rel->r_offset, sizeof(*where), &end_offs) ||
+		    end_offs >= (elf->max_addr - elf->load_addr))
 			err(TEE_ERROR_BAD_FORMAT,
 			    "Relocation offset out of range");
 		where = (Elf32_Addr *)(elf->load_addr + rel->r_offset);
@@ -647,10 +649,16 @@ static void e64_relocate(struct ta_elf *elf, unsigned int rel_sidx)
 	rela_end = rela + shdr[rel_sidx].sh_size / sizeof(Elf64_Rela);
 	for (; rela < rela_end; rela++) {
 		Elf64_Addr *where = NULL;
+		size_t write_size = sizeof(*where);
 		size_t sym_idx __maybe_unused = 0;
+		Elf64_Addr end_offs = 0;
+
+		if (ELF64_R_TYPE(rela->r_info) == R_AARCH64_TLSDESC)
+			write_size *= 2;
 
 		/* Check the address is inside TA memory */
-		if (rela->r_offset >= (elf->max_addr - elf->load_addr))
+		if (ADD_OVERFLOW(rela->r_offset, write_size, &end_offs) ||
+		    end_offs >= (elf->max_addr - elf->load_addr))
 			err(TEE_ERROR_BAD_FORMAT,
 			    "Relocation offset out of range");
 


### PR DESCRIPTION
When relocating both ELFs only the start address of the relocation destination is considered when checking that the relocation offset is within bounds. Fix this by added a check for the entire write size.

Fixes: 447354c6e527 ("ldelf: strict checks during relocation")
Fixes: 7509ff7ce5e5 ("Add user mode ELF loader")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
