### PR TITLE
core: tee_ree_fs: fix possible mempool leak

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -109,7 +109,7 @@ static TEE_Result out_of_place_write(struct tee_fs_fd *fdp, size_t pos,
 			res = copy_from_user(block + offset, data_user_ptr,
 					     size_to_write);
 			if (res)
-				return res;
+				goto exit;
 		} else {
 			memset(block + offset, 0, size_to_write);
 		}


### PR DESCRIPTION
In out_of_place_write() if copy_from_user() fails, the function returns directly instead of using the common cleanup path. If this happens a temporary block is leaked from the default memory pool. Fix this by using the common exit path.

Fixes: b2284b11a961 ("core: update FS storage API with user space buffer")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
