### PR TITLE
core: vm_buf_intersects_um_private(): fix flag check

### DIFF
--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -1117,7 +1117,7 @@ bool vm_buf_intersects_um_private(const struct user_mode_ctx *uctx,
 	struct vm_region *r = NULL;
 
 	TAILQ_FOREACH(r, &uctx->vm_info.regions, link) {
-		if (r->attr & VM_FLAGS_NONPRIV)
+		if (r->flags & VM_FLAGS_NONPRIV)
 			continue;
 		if (core_is_buffer_intersect((vaddr_t)va, size, r->va, r->size))
 			return true;


### PR DESCRIPTION
vm_buf_intersects_um_private() checks if a memory range intersects with already registered memory ranges with the flag VM_FLAGS_NONPRIV set. However, until now, the function was checking the flag against the attr field instead of the correct flags field. In practise this results in the function always returning false. Fix this by checking against the correct field.

Fixes: 89c9728d981f ("core: replace tee_mmu prefix with vm")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
