### PR TITLE
libmbedtls: Fix missing ctx_clone_func in xts_aes_info

### DIFF
--- a/lib/libmbedtls/mbedtls/library/cipher_wrap.c
+++ b/lib/libmbedtls/mbedtls/library/cipher_wrap.c
@@ -519,6 +519,11 @@ static void *xts_aes_ctx_alloc(void)
     return xts_ctx;
 }
 
+static void xts_aes_ctx_clone(void *dst, const void *src)
+{
+    memcpy(dst, src, sizeof(mbedtls_aes_xts_context));
+}
+
 static void xts_aes_ctx_free(void *ctx)
 {
     mbedtls_aes_xts_context *xts_ctx = ctx;
@@ -555,6 +560,7 @@ static const mbedtls_cipher_base_t xts_aes_info = {
     xts_aes_setkey_enc_wrap,
     xts_aes_setkey_dec_wrap,
     xts_aes_ctx_alloc,
+    xts_aes_ctx_clone,
     xts_aes_ctx_free
 };
 


### PR DESCRIPTION
If adding `#define MBEDTLS_CIPHER_MODE_XTS` in `lib/libmbedtls/include/mbedtls_config_{kernel,uta}.h` to enable the AES XTS algorithm, a compiler warning/error is gererated (clang defaults to generate an error, gcc simply put a warning):
```
lib/libmbedtls/mbedtls/library/cipher_wrap.c:558:5: error: incompatible function pointer types initializing 'void (*)(void *, const void *)' with an expression of type 'void (void *)'
[-Wincompatible-function-pointer-types]
  558 |     xts_aes_ctx_free
      |     ^~~~~~~~~~~~~~~~
1 error generated.
```

It seems that xts_aes_info is forgot to add ctx_clone_func implementation, making the free function be wrongly placed into the ctx_clone_func field.

This commit adds the missing xts_aes_ctx_clone() implementation and fixes the function pointer in the xts_aes_info.
