### PR TITLE
fix ASAN longjmp guard in arm setjmp

### DIFF
--- a/lib/libutils/ext/include/asan.h
+++ b/lib/libutils/ext/include/asan.h
@@ -14,6 +14,15 @@
 #define ASAN_BLOCK_SHIFT	U(3)
 #define ASAN_BLOCK_MASK		(ASAN_BLOCK_SIZE - 1)
 
+#if ((!defined(__KERNEL__) && !defined(__LDELF__)) && \
+     defined(CFG_TA_SANITIZE_KADDRESS)) || \
+	((defined(__KERNEL__) || defined(__LDELF__)) && \
+	 defined(CFG_CORE_SANITIZE_KADDRESS))
+#define ASAN_IS_ENABLED 1
+#else
+#define ASAN_IS_ENABLED 0
+#endif
+
 #ifndef __ASSEMBLER__
 #include <compiler.h>
 #include <string.h>
@@ -50,15 +59,6 @@ struct asan_global_info {
 #else
 #define GET_ASAN_INFO() ((struct asan_global_info *) \
 	(CFG_USER_ASAN_SHADOW_OFFSET - SMALL_PAGE_SIZE))
-#endif
-
-#if ((!defined(__KERNEL__) && !defined(__LDELF__)) && \
-     defined(CFG_TA_SANITIZE_KADDRESS)) || \
-	((defined(__KERNEL__) || defined(__LDELF__)) && \
-	 defined(CFG_CORE_SANITIZE_KADDRESS))
-#define ASAN_IS_ENABLED 1
-#else
-#define ASAN_IS_ENABLED 0
 #endif
 
 #if ASAN_IS_ENABLED

--- a/lib/libutils/isoc/arch/arm/setjmp_a32.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a32.S
@@ -33,6 +33,8 @@
 
    Nick Clifton, Cygnus Solutions, 13 June 1997.  */
 
+#include <asan.h>
+
 /* ANSI concatenation macros.  */
 #define CONCAT(a, b)  CONCAT2(a, b)
 #define CONCAT2(a, b) a##b
@@ -252,9 +254,8 @@ SYM (\name):
 	bl		ftrace_longjmp
 	ldmia		sp!, { a1, a2, lr }
 #endif
-#if ASAN_IS_ENABLED && \
-	!(defined(__KERNEL__) && defined(CFG_CORE_SANITIZE_KADDRESS) && \
-	  defined(CFG_DYN_CONFIG))
+
+#if ASAN_IS_ENABLED && (!defined(__KERNEL__) || !defined(CFG_DYN_CONFIG))
 	stmdb		sp!, { a1, a2, a3, lr }
 
 #ifdef __thumb2__

--- a/lib/libutils/isoc/arch/arm/setjmp_a64.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a64.S
@@ -27,6 +27,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <asan.h>
 #include <asm.S>
 
 #define GPR_LAYOUT			\
@@ -83,9 +84,8 @@ BTI(	bti	c)
 	ldp	x29, x30, [sp], #16
 	ldp	x0, x1, [sp], #16
 #endif
-#if ASAN_IS_ENABLED && \
-	!(defined(__KERNEL__) && defined(CFG_CORE_SANITIZE_KADDRESS) && \
-	  defined(CFG_DYN_CONFIG))
+
+#if ASAN_IS_ENABLED && (!defined(__KERNEL__) || !defined(CFG_DYN_CONFIG))
 	stp	x0, x1, [sp, #-16]!
 	ldr	x0, [x0, 96]
 	bl	asan_handle_longjmp


### PR DESCRIPTION
The recent [changes](https://github.com/OP-TEE/optee_os/commit/4cafd8a3f88594ce06758c2a85b59c2d32a6ac7e#diff-eb5f985b9fc08d455b10df7f70263f6be7519ba4e96280587fbc75b25b8d2346R255) introduced a regression in the `ASAN=y`  `CFG_DYN_CONFIG=n` case: the stack-unpoisoning path in `setjmp` no longer builds because `ASAN_IS_ENABLED` is always evaluated as 0. To fix that, `asan.h` is now included from the relevant ` .S` files.

To reproduce a problem
`make run CFG_TA_SANITIZE_KADDRESS=y CFG_CORE_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_DYN_CONFIG=n -j8`

NW:
```
# xtest -t regression 1001
Test ID: 1001
Run test suite with level=0

TEE test application started over default TEE instance
######################################################
#
# regression
#
######################################################
 
* regression_1001 Core self tests
o regression_1001.1 Core self tests
  regression_1001.1 OK
o regression_1001.2 Core dt_driver self tests
  regression_1001.2 OK
o regression_1001.3 Core transfer list self tests
```
SW:
```
D/TC:? 1 create_ta:381 create entry point for pseudo TA "invoke_tests.pta"
D/TC:? 1 open_session:394 open entry point for pseudo ta "invoke_tests.pta"
E/TC:0 1 asan_report:299 e271518: 0xff 0x00 0x07 0xff 0xff 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe27152f size: 1
I/TC:   => [asan] test (s) glob overflow: ok
E/TC:0 1 asan_report:299 e2714d8: 0xff 0x00 0x07 0xff 0xff 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2714ef size: 1
I/TC:   => [asan] test glob overflow: ok
E/TC:0 1 asan_report:299 e22ce80: 0x00 0x00 0xff 0xff 0xff 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe22ce90 size: 1
I/TC:   => [asan] test glob ro overflow: ok
E/TC:0 1 asan_report:299 e2b8a58: 0xf1 0x00 0x07 0xf3 0xf3 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2b8a6f size: 1
I/TC:   => [asan] test stack overflow: ok
E/TC:0 1 asan_report:299 e2b8a30: 0x00 0x00 0xf1 0xf1 0xf1 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2b8a40 size: 1
I/TC:   => [asan] test malloc: ok
E/TC:0 1 asan_report:299 e2b8a30: 0x00 0x00 0xf1 0xf1 0xf1 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2b8a40 size: 1
I/TC:   => [asan] test malloc2: ok
E/TC:0 1 asan_report:299 e2b8a30: 0x00 0x00 0xf1 0xf1 0xf1 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2b8a40 size: 1
I/TC:   => [asan] test use_after_free: ok
E/TC:0 1 asan_report:299 e2713b8: 0xff 0x00 0x07 0xff 0xff 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2713cf size: 1
I/TC:   => [asan] test memcpy_dst: ok
E/TC:0 1 asan_report:299 e2712f8: 0xff 0x00 0x07 0xff 0xff 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe27130f size: 1
I/TC:   => [asan] test memcpy_src: ok
E/TC:0 1 asan_report:299 e2b8a30: 0x00 0x00 0xf1 0xf1 0xf1 
E/TC:0 1 asan_report:302 [ASAN]: access violation, addr: 0xe2b8a40 size: 1
I/TC:   => [asan] test memset: ok
E/TC:? 1 asan_report:299 e2b8a40: 0xf1 0xf1 0xf1 0xf1 0x00 
E/TC:? 1 asan_report:302 [ASAN]: access violation, addr: 0xe2b8a50 size: 8
E/TC:0 1 Panic at lib/libutils/ext/asan.c:76 <asan_panic>
E/TC:0 1 TEE load address @ 0xe100000
E/TC:0 1 Call stack:
E/TC:0 1  0x0e1093c8
E/TC:0 1  0x0e11d6a4
E/TC:0 1  0x0e18cde0
E/TC:0 1  0x0e18cefc
E/TC:0 1  0x0e10397c
E/TC:0 1  0x0e18bf70
E/TC:0 1  0x0e18c154
E/TC:0 1  0x0e11f660
E/TC:0 1  0x0e1398c4
E/TC:0 1  0x0e106f8c
E/TC:0 1  0x0e107524
```
