### PR TITLE
core: rpmb: fix file corruption when updating

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2495,8 +2495,8 @@ static TEE_Result update_write_helper(struct rpmb_file_handle *fh,
 		blk_size = MIN(TMP_BLOCK_SIZE, new_size - blk_offset);
 		memset(blk_buf, 0, blk_size);
 
-		/* Possibly read old RPMB data in temporary buffer */
-		if (blk_offset < pos && blk_offset < old_size) {
+		/* Read old RPMB data in temporary buffer */
+		if (blk_offset < old_size) {
 			rd_size = MIN(blk_size, old_size - blk_offset);
 
 			res = tee_rpmb_read(old_fat + blk_offset, blk_buf,


### PR DESCRIPTION
The heap memory saving patch 64c6d2917 is introducing a file corruption when updating an existing file, the data in the updated file after "pos + size" that must remain same as before is getting zeroed.

This patch ensures that the temporary update buffer is always synced with the existing file data before updating.

Fixes: 64c6d2917 (core: rpmb fs uses mempool for temporary transfer buffers)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
