### PR TITLE
core: imx: use ifeq() instead of ifneq() for checking CFG_INSECURE

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -576,7 +576,7 @@ CFG_IMX_CSU ?= y
 endif
 
 ifneq (,$(filter y, $(CFG_MX8M)))
-ifneq ($(CFG_INSECURE),y)
+ifeq ($(CFG_INSECURE),n)
 $(call force,CFG_TZASC_REGION0_SECURE,y)
 endif
 endif
@@ -585,7 +585,7 @@ endif
 # Once all platforms are supported we can remove the CFG_TZASC_CHECK_ENABLED
 # and perform the check always.
 ifneq (,$(filter y, $(CFG_MX6) $(CFG_MX8M)))
-ifneq ($(CFG_INSECURE),y)
+ifeq ($(CFG_INSECURE),n)
 $(call force,CFG_TZASC_CHECK_ENABLED,y)
 endif
 endif


### PR DESCRIPTION
The current logic uses 'ifneq (,y)' which evaluates to true
when CFG_INSECURE is unset (empty string),
potentially leading to unexpected behavior during Makefile parsing.

Using a 'ifeq (,n)' for CFG_INSECURE

Fixes: a18f1b4 (drivers: imx: tzc380: add support to check TZASC enable statte)
Fixes: 443c581 (drivers: imx: tzc380: add support to verify region0)