### PR TITLE
libutee: remove TEE_BigIntFMMConvertToBigInt

### DIFF
--- a/lib/libutee/include/tee_internal_api.h
+++ b/lib/libutee/include/tee_internal_api.h
@@ -629,10 +629,6 @@ void TEE_BigIntConvertFromFMM(TEE_BigInt *dest, const TEE_BigIntFMM *src,
 			      const TEE_BigInt *n,
 			      const TEE_BigIntFMMContext *context);
 
-void TEE_BigIntFMMConvertToBigInt(TEE_BigInt *dest, const TEE_BigIntFMM *src,
-				  const TEE_BigInt *n,
-				  const TEE_BigIntFMMContext *context);
-
 void TEE_BigIntComputeFMM(TEE_BigIntFMM *dest, const TEE_BigIntFMM *op1,
 			  const TEE_BigIntFMM *op2, const TEE_BigInt *n,
 			  const TEE_BigIntFMMContext *context);


### PR DESCRIPTION
TEE_BigIntFMMConvertToBigInt is not implemented, and any usage leads to linkage errors. Remove its declaration from the header file.

Fixes: #7758 
