### PR TITLE
Rockchip PTA: fix OTP programming and device lockdown

### DIFF
--- a/core/pta/rockchip/rk_secure_boot.c
+++ b/core/pta/rockchip/rk_secure_boot.c
@@ -160,6 +160,7 @@ static TEE_Result burn_hash(uint32_t param_types,
 {
 	uint32_t new_hash[ROCKCHIP_OTP_RSA_HASH_SIZE] = {};
 	uint32_t old_hash[ROCKCHIP_OTP_RSA_HASH_SIZE] = {};
+	uint32_t zero[ROCKCHIP_OTP_RSA_HASH_SIZE] = { 0 };
 	char __maybe_unused str[HASH_STRING_SIZE] = {};
 	struct pta_rk_secure_boot_hash *hash = NULL;
 	TEE_Result res = TEE_SUCCESS;
@@ -190,12 +191,15 @@ static TEE_Result burn_hash(uint32_t param_types,
 				       ROCKCHIP_OTP_RSA_HASH_SIZE);
 	if (res)
 		return res;
-	if (memcmp(old_hash, new_hash, sizeof(new_hash))) {
+
+	/* If a hash is already set, ensure new hash matches the old hash. */
+	if (memcmp(old_hash, zero, sizeof(zero)) &&
+	    memcmp(old_hash, new_hash, sizeof(new_hash))) {
 		EMSG("Refusing to burn hash %s",
 		     otp_to_string(new_hash, str, sizeof(str)));
 		EMSG("OTP hash is %s",
 		     otp_to_string(old_hash, str, sizeof(str)));
-		return res;
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	/*

--- a/core/pta/rockchip/rk_secure_boot.c
+++ b/core/pta/rockchip/rk_secure_boot.c
@@ -272,7 +272,7 @@ static TEE_Result lockdown_device(uint32_t param_types,
 		return TEE_SUCCESS;
 	}
 
-	status = ROCKCHIP_OTP_SECURE_BOOT_STATUS_ENABLE;
+	status |= ROCKCHIP_OTP_SECURE_BOOT_STATUS_ENABLE;
 
 	if (IS_ENABLED(CFG_RK_SECURE_BOOT_SIMULATION)) {
 		IMSG("Simulation mode: Skip writing status: %"PRIx32,
@@ -292,7 +292,7 @@ static TEE_Result lockdown_device(uint32_t param_types,
 				       ROCKCHIP_OTP_SECURE_BOOT_STATUS_SIZE);
 	if (res)
 		return res;
-	if (test_bit_mask(status, ROCKCHIP_OTP_SECURE_BOOT_STATUS_ENABLE)) {
+	if (!test_bit_mask(status, ROCKCHIP_OTP_SECURE_BOOT_STATUS_ENABLE)) {
 		EMSG("Failed to write secure boot status");
 		return TEE_ERROR_GENERIC;
 	}


### PR DESCRIPTION
This PR fixes two independent logic errors in the Rockchip PTA that prevent correct OTP programming and device lockdown:

- Fix OTP hash programming guard (burn_hash())
  The protection check intended to prevent overwriting an already programmed OTP hash was incorrect.

- Fix OTP lockdown flow (lockdown_device())
  Two issues caused lockdown to fail with TEE_ERROR_GENERIC (0xffff0000) even on valid devices: 
  - The status variable was overwritten with only `ROCKCHIP_OTP_SECURE_BOOT_STATUS_ENABLE`,
  - The post-write validation used `test_bit_mask()` incorrectly.

Implementation tested on RK-3588.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
