### PR TITLE
core: ree_fs_ta: fix dead size check in buf_ta_get_tag()

### DIFF
--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -797,10 +797,12 @@ static TEE_Result buf_ta_get_tag(const struct ts_store_handle *h,
 {
 	struct buf_ree_fs_ta_handle *handle = (struct buf_ree_fs_ta_handle *)h;
 
-	*tag_len = handle->tag_len;
-	if (!tag || *tag_len < handle->tag_len)
+	if (!tag || *tag_len < handle->tag_len) {
+		*tag_len = handle->tag_len;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
 
+	*tag_len = handle->tag_len;
 	memcpy(tag, handle->tag, handle->tag_len);
 
 	return TEE_SUCCESS;


### PR DESCRIPTION
buf_ta_get_tag() overwrites *tag_len with handle->tag_len before
performing the size check, making the comparison always false:

    *tag_len = handle->tag_len;
    if (!tag || *tag_len < handle->tag_len)  /* always false */
        return TEE_ERROR_SHORT_BUFFER;

Move the assignment inside the guard block to match the correct
pattern used by ree_fs_ta_get_tag() directly above it in the same
file.

Related to security advisory GHSA-wm5j-x8j4-978q.