### PR TITLE
core: mm: fix page table lookup in core_mmu_remove_mapping()

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -2330,8 +2330,11 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 	struct core_mmu_table_info tbl_info = { };
 	struct tee_mmap_region *res_map = NULL;
 	struct tee_mmap_region *map = NULL;
+	struct tee_mmap_region r = { };
 	paddr_t pa = virt_to_phys(addr);
 	size_t granule = 0;
+	vaddr_t tbl_span = 0;
+	vaddr_t end = 0;
 	ptrdiff_t i = 0;
 	paddr_t p = 0;
 	size_t l = 0;
@@ -2343,7 +2346,7 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 	res_map = find_map_by_type(MEM_AREA_RES_VASPACE);
 	if (!res_map)
 		return TEE_ERROR_GENERIC;
-	if (!core_mmu_find_table(NULL, res_map->va, UINT_MAX, &tbl_info))
+	if (!core_mmu_find_table(NULL, map->va, UINT_MAX, &tbl_info))
 		return TEE_ERROR_GENERIC;
 	granule = BIT(tbl_info.shift);
 
@@ -2358,7 +2361,17 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 	if (map->pa != p || map->size != l)
 		return TEE_ERROR_GENERIC;
 
-	clear_region(&tbl_info, map);
+	if (ADD_OVERFLOW(map->va, map->size, &end))
+		return TEE_ERROR_GENERIC;
+	for (r = *map; r.va < end; r.pa += r.size, r.va += r.size) {
+		if (!core_mmu_find_table(NULL, r.va, UINT_MAX, &tbl_info))
+			panic("can't find table for unmapping");
+
+		tbl_span = BIT64(tbl_info.shift) * tbl_info.num_entries;
+		r.size = MIN(tbl_span - (r.va - tbl_info.va_base),
+			     end - r.va);
+		clear_region(&tbl_info, &r);
+	}
 	tlbi_all();
 
 	/* If possible remove the va range from res_map */
@@ -2406,7 +2419,10 @@ void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 	struct memory_map *mem_map = &static_memory_map;
 	struct core_mmu_table_info tbl_info = { };
 	struct tee_mmap_region *map = NULL;
+	struct tee_mmap_region r = { };
 	size_t granule = 0;
+	vaddr_t tbl_span = 0;
+	vaddr_t end = 0;
 	paddr_t p = 0;
 	size_t l = 0;
 
@@ -2437,14 +2453,6 @@ void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 	if (map->size < l)
 		return NULL;
 
-	/*
-	 * Something is wrong, we can't fit the va range into the selected
-	 * table. The reserved va range is possibly missaligned with
-	 * granule.
-	 */
-	if (core_mmu_va2idx(&tbl_info, map->va + len) >= tbl_info.num_entries)
-		return NULL;
-
 	if (static_memory_map.count >= static_memory_map.alloc_count)
 		return NULL;
 
@@ -2461,7 +2469,17 @@ void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 	map = mem_map->map + mem_map->count;
 	mem_map->count++;
 
-	set_region(&tbl_info, map);
+	if (ADD_OVERFLOW(map->va, map->size, &end))
+		panic("VA overflow in add_mapping");
+	for (r = *map; r.va < end; r.pa += r.size, r.va += r.size) {
+		if (!core_mmu_find_table(NULL, r.va, UINT_MAX, &tbl_info))
+			panic("can't find table for mapping");
+
+		tbl_span = BIT64(tbl_info.shift) * tbl_info.num_entries;
+		r.size = MIN(tbl_span - (r.va - tbl_info.va_base),
+			     end - r.va);
+		set_region(&tbl_info, &r);
+	}
 
 	/* Make sure the new entry is visible before continuing. */
 	core_mmu_table_write_barrier();

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -2343,7 +2343,8 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 	res_map = find_map_by_type(MEM_AREA_RES_VASPACE);
 	if (!res_map)
 		return TEE_ERROR_GENERIC;
-	if (!core_mmu_find_table(NULL, res_map->va, UINT_MAX, &tbl_info))
+
+	if (!core_mmu_find_table(NULL, map->va, UINT_MAX, &tbl_info))
 		return TEE_ERROR_GENERIC;
 	granule = BIT(tbl_info.shift);
 


### PR DESCRIPTION
core_mmu_remove_mapping() used res_map->va (the current start of the reserved VA pool) to look up the page table via core_mmu_find_table(), but then passed the resulting tbl_info to clear_region() which computes indices using map->va (the VA of the mapping being removed).

If res_map->va is bigger than map->va, and they are located in different L3 translation table pages, core_mmu_va2idx() computes (map->va - tbl_info->va_base) which underflows, producing an out-of-range index.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
