### PR TITLE
core: add FF-A RAS error injection LSP support

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -223,6 +223,10 @@ ifneq ($(CFG_TEE_CORE_EMBED_INTERNAL_TESTS),y)
 core-platform-subdirs += $(arch-dir)/tests
 endif
 
+ifeq ($(CFG_CORE_SEL1_SPMC),y)
+core-platform-subdirs += $(arch-dir)/lsp
+endif
+
 arm64-platform-cppflags += -DARM64=1 -D__LP64__=1
 arm32-platform-cppflags += -DARM32=1 -D__ILP32__=1
 

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
- * Copyright (c) 2023, Arm Limited
+ * Copyright (c) 2023-2026, Arm Limited
  */
 #ifndef __ARM64_H
 #define __ARM64_H
@@ -526,6 +526,7 @@ DEFINE_U64_REG_READ_FUNC(par_el1)
 
 DEFINE_U64_REG_WRITE_FUNC(mair_el1)
 
+DEFINE_U64_REG_READ_FUNC(id_aa64pfr0_el1)
 DEFINE_U64_REG_READ_FUNC(id_aa64mmfr0_el1)
 DEFINE_U64_REG_READ_FUNC(id_aa64mmfr1_el1)
 DEFINE_U64_REG_READ_FUNC(id_aa64pfr1_el1)
@@ -575,7 +576,27 @@ static inline void write_pan_disable(void)
 	asm volatile("msr	S0_0_c4_c0_4, xzr" ::: "memory" );
 }
 
+/* ERXPFGCTL_EL1 field definitions */
+#define ERXPFGCTL_CDNEN_BIT	BIT64(31)
+#define ERXPFGCTL_R_BIT		BIT64(30)
+#define ERXPFGCTL_CE_BIT	BIT64(6)
+#define ERXPFGCTL_DE_BIT	BIT64(5)
+#define ERXPFGCTL_UC_BIT	BIT64(1)
+
+/* ID_AA64PFR0_EL1 RAS field definitions */
+#define ID_AA64PFR0_EL1_RAS_SHIFT	U(28)
+#define ID_AA64PFR0_EL1_RAS_MASK	U(0xf)
+
+/* Register read/write functions for RAS Error Record and PFG (Processor Fault Generation) registers */
+DEFINE_REG_WRITE_FUNC_(errselr_el1, uint64_t, S3_0_C5_C3_1)
+DEFINE_REG_READ_FUNC_(erxstatus_el1, uint64_t, S3_0_C5_C4_2)
+DEFINE_REG_WRITE_FUNC_(erxstatus_el1, uint64_t, S3_0_C5_C4_2)
+DEFINE_REG_READ_FUNC_(erxpfgctl_el1, uint64_t, S3_0_C5_C4_5)
+DEFINE_REG_WRITE_FUNC_(erxpfgctl_el1, uint64_t, S3_0_C5_C4_5)
+DEFINE_REG_WRITE_FUNC_(erxpfgcdn_el1, uint64_t, S3_0_C5_C4_6)
+DEFINE_REG_READ_FUNC_(erxmisc0_el1, uint64_t, S3_0_C5_C5_0)
+DEFINE_REG_WRITE_FUNC_(erxmisc0_el1, uint64_t, S3_0_C5_C5_0)
+
 #endif /*__ASSEMBLER__*/
 
 #endif /*__ARM64_H*/
-

--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2024, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2026, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -41,6 +41,9 @@
 #define FFA_VERSION_1_0			MAKE_FFA_VERSION(1, 0)
 #define FFA_VERSION_1_1			MAKE_FFA_VERSION(1, 1)
 #define FFA_VERSION_1_2			MAKE_FFA_VERSION(1, 2)
+
+#define FFA_DST(x)				((x) & UINT16_MAX)
+#define FFA_SRC(x)				(((x) >> 16) & UINT16_MAX)
 
 /* Function IDs */
 #define FFA_ERROR			U(0x84000060)

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -11,9 +11,6 @@
 #include <tee_api_types.h>
 #include <tee/entry_std.h>
 
-#define FFA_DST(x)	((x) & UINT16_MAX)
-#define FFA_SRC(x)	(((x) >> 16) & UINT16_MAX)
-
 void spmc_sp_thread_entry(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
 void spmc_sp_msg_handler(struct thread_smc_1_2_regs *args,
 			 struct sp_session *caller_sp);

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2021-2024, Arm Limited.
+ * Copyright (c) 2021-2026, Arm Limited.
  * Copyright (c) 2023-2025, Linaro Limited
  */
 #ifndef __KERNEL_THREAD_SPMC_H
@@ -55,8 +55,11 @@ int spmc_read_mem_transaction(uint32_t ffa_vers, void *buf, size_t blen,
 
 bool spmc_is_reserved_id(uint16_t id);
 
+struct sp_session;
+
 struct spmc_lsp_desc {
-	void (*direct_req)(struct thread_smc_1_2_regs *args);
+	void (*direct_req)(struct thread_smc_1_2_regs *args,
+			   struct sp_session *caller_sp);
 	uint16_t sp_id;
 	uint32_t properties;
 	uint32_t uuid_words[4];

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2021-2024, Arm Limited
+ * Copyright (c) 2021-2026, Arm Limited
  */
 #include <assert.h>
 #include <io.h>
@@ -10,6 +10,7 @@
 #include <kernel/spmc_sp_handler.h>
 #include <kernel/tee_misc.h>
 #include <kernel/thread_private.h>
+#include <kernel/thread_spmc.h>
 #include <mm/mobj.h>
 #include <mm/sp_mem.h>
 #include <mm/vm.h>
@@ -884,6 +885,7 @@ ffa_handle_sp_direct_req(struct thread_smc_1_2_regs *args,
 			 struct sp_session *caller_sp)
 {
 	struct sp_session *dst = NULL;
+	struct spmc_lsp_desc *lsp = NULL;
 	TEE_Result res = FFA_OK;
 
 	res = ffa_get_dst(args, caller_sp, &dst);
@@ -893,9 +895,12 @@ ffa_handle_sp_direct_req(struct thread_smc_1_2_regs *args,
 		return caller_sp;
 	}
 	if (!dst) {
-		EMSG("Request to normal world not supported");
-		ffa_set_error(args, FFA_NOT_SUPPORTED);
-		return caller_sp;
+		lsp = spmc_find_lsp_by_sp_id(FFA_DST(args->a1));
+		if (!lsp) {
+			EMSG("Request to normal world not supported");
+			ffa_set_error(args, FFA_NOT_SUPPORTED);
+			return caller_sp;
+		}
 	}
 
 	if (dst == caller_sp) {
@@ -912,10 +917,22 @@ ffa_handle_sp_direct_req(struct thread_smc_1_2_regs *args,
 		return caller_sp;
 	}
 
-	if (!(dst->props & FFA_PART_PROP_DIRECT_REQ_RECV)) {
+	if (dst && !(dst->props & FFA_PART_PROP_DIRECT_REQ_RECV)) {
 		EMSG("SP 0x%"PRIx16" doesn't support receipt of direct requests",
 		     dst->endpoint_id);
 		ffa_set_error(args, FFA_NOT_SUPPORTED);
+		return caller_sp;
+	}
+
+	if (lsp && !(lsp->properties & FFA_PART_PROP_DIRECT_REQ_RECV)) {
+		EMSG("LSP 0x%"PRIx16" doesn't support receipt of direct requests",
+		     lsp->sp_id);
+		ffa_set_error(args, FFA_NOT_SUPPORTED);
+		return caller_sp;
+	}
+
+	if (lsp) {
+		lsp->direct_req(args, caller_sp);
 		return caller_sp;
 	}
 

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2020-2025, Linaro Limited.
- * Copyright (c) 2019-2024, Arm Limited. All rights reserved.
+ * Copyright (c) 2019-2026, Arm Limited. All rights reserved.
  */
 
 #include <assert.h>
@@ -896,8 +896,15 @@ static void handle_framework_direct_request(struct thread_smc_1_2_regs *args)
 	spmc_set_args(args, w0, w1, w2, w3, FFA_PARAM_MBZ, FFA_PARAM_MBZ);
 }
 
-static void optee_lsp_handle_direct_request(struct thread_smc_1_2_regs *args)
+static void
+optee_lsp_handle_direct_request(struct thread_smc_1_2_regs *args,
+				struct sp_session *caller_sp)
 {
+	if (caller_sp) {
+		set_simple_ret_val(args, FFA_INVALID_PARAMETERS);
+		return;
+	}
+
 	if (args->a2 & FFA_MSG_FLAG_FRAMEWORK) {
 		handle_framework_direct_request(args);
 		return;
@@ -926,8 +933,14 @@ static void optee_lsp_handle_direct_request(struct thread_smc_1_2_regs *args)
 }
 
 static void __maybe_unused
-optee_spmc_lsp_handle_direct_request(struct thread_smc_1_2_regs *args)
+optee_spmc_lsp_handle_direct_request(struct thread_smc_1_2_regs *args,
+				     struct sp_session *caller_sp)
 {
+	if (caller_sp) {
+		set_simple_ret_val(args, FFA_INVALID_PARAMETERS);
+		return;
+	}
+
 	if (args->a2 & FFA_MSG_FLAG_FRAMEWORK)
 		handle_framework_direct_request(args);
 	else
@@ -939,7 +952,7 @@ static void handle_direct_request(struct thread_smc_1_2_regs *args)
 	struct spmc_lsp_desc *lsp = spmc_find_lsp_by_sp_id(FFA_DST(args->a1));
 
 	if (lsp) {
-		lsp->direct_req(args);
+		lsp->direct_req(args, NULL);
 	} else {
 		int rc = spmc_sp_start_thread(args);
 

--- a/core/arch/arm/lsp/lsp_ras_inject.c
+++ b/core/arch/arm/lsp/lsp_ras_inject.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Arm Limited.
+ */
+
+#include <arm64.h>
+#include <ffa.h>
+#include <initcall.h>
+#include <inttypes.h>
+#include <kernel/thread_spmc.h>
+#include <sm/optee_smc.h>
+#include <trace.h>
+#include <util.h>
+
+#define CORE_RAM_ERR_RECORD	    U(1)
+#define ERXPFGCDN_CDN		    U(0xF)
+
+/* Predefined ERXMISC0 value for CE (correctable error) injection */
+#define ERX_MISC0_CE_INJ	    0x200810000000001ULL
+
+/* Supported RAS components */
+#define RAS_COMPONENT_CPU	    U(0x01)
+
+/*
+ * ACPI EINJ error types are encoded as a bitmap.
+ * Firmware-communication and deferred-error are local extensions.
+ */
+#define RAS_ERROR_PROCESSOR_CORRECTABLE			    BIT32(0)
+#define RAS_ERROR_PROCESSOR_UNCORRECTABLE_NONFATAL	BIT32(1)
+#define RAS_ERROR_PROCESSOR_UNCORRECTABLE_FATAL		BIT32(2)
+#define RAS_ERROR_MEMORY_CORRECTABLE			    BIT32(3)
+#define RAS_ERROR_MEMORY_UNCORRECTABLE_NONFATAL		BIT32(4)
+#define RAS_ERROR_MEMORY_UNCORRECTABLE_FATAL		BIT32(5)
+#define RAS_ERROR_PCI_CORRECTABLE			        BIT32(6)
+#define RAS_ERROR_PCI_UNCORRECTABLE_NONFATAL		BIT32(7)
+#define RAS_ERROR_PCI_UNCORRECTABLE_FATAL		    BIT32(8)
+#define RAS_ERROR_PLATFORM_CORRECTABLE			    BIT32(9)
+#define RAS_ERROR_PLATFORM_UNCORRECTABLE_NONFATAL	BIT32(10)
+#define RAS_ERROR_PLATFORM_UNCORRECTABLE_FATAL		BIT32(11)
+#define RAS_ERROR_VENDOR_DEFINED_START			    BIT32(31)
+
+/*
+ * Program a CPU RAS error record for later error injection.
+ *
+ * This is an internal direct request ABI used by SP clients of the RAS LSP.
+ *
+ * error_type selects the processor error class to arm.
+ * The current supported values are:
+ * - RAS_ERROR_PROCESSOR_CORRECTABLE
+ * - RAS_ERROR_PROCESSOR_UNCORRECTABLE_NONFATAL
+ * - RAS_ERROR_PROCESSOR_UNCORRECTABLE_FATAL
+ *
+ * component selects the target component.
+ * Only RAS_COMPONENT_CPU is currently supported.
+ *
+ * data is currently unused.
+ *
+ * The handler selects the Core RAM error record and programs the associated
+ * RAS Error Record and PFG registers for the requested injection type.
+ * The direct response reports only whether this programming step succeeded.
+ *
+ * The actual error is expected to be observed later, when the programmed
+ * condition is triggered and the CPU reports it through
+ * the RAS handling path. This handler does not consume that exception
+ * and does not return it synchronously to the caller.
+ */
+static TEE_Result ras_injection_handler(uint32_t error_type, uint32_t component,
+					uint32_t data __unused)
+{
+	TEE_Result ret = TEE_ERROR_NOT_SUPPORTED;
+	uint64_t erx_status;
+	uint64_t v = 0;
+
+	FMSG("RAS LSP: error_type: %"PRIx32" component: %"PRIx32
+	     " data: %"PRIx32, error_type, component, data);
+
+	if (component != RAS_COMPONENT_CPU)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	/* Select error record 1, which contains Core RAM errors. */
+	write_errselr_el1(CORE_RAM_ERR_RECORD);
+	write_erxpfgctl_el1(0);
+
+	/* Clear any sticky status bits in the selected error record. */
+	erx_status = read_erxstatus_el1();
+	write_erxstatus_el1(erx_status);
+	write_erxpfgcdn_el1(ERXPFGCDN_CDN);
+
+	switch (error_type) {
+	case RAS_ERROR_PROCESSOR_CORRECTABLE:
+		v = read_erxmisc0_el1();
+		write_erxmisc0_el1(v | ERX_MISC0_CE_INJ);
+		v = read_erxpfgctl_el1();
+		v |= ERXPFGCTL_CDNEN_BIT | ERXPFGCTL_R_BIT |
+		     ERXPFGCTL_CE_BIT;
+		write_erxpfgctl_el1(v);
+		return TEE_SUCCESS;
+	case RAS_ERROR_PROCESSOR_UNCORRECTABLE_NONFATAL:
+		v = read_erxpfgctl_el1();
+		v |= ERXPFGCTL_CDNEN_BIT | ERXPFGCTL_DE_BIT;
+		write_erxpfgctl_el1(v);
+		return TEE_SUCCESS;
+	case RAS_ERROR_PROCESSOR_UNCORRECTABLE_FATAL:
+		v = read_erxpfgctl_el1();
+		v |= ERXPFGCTL_CDNEN_BIT | ERXPFGCTL_UC_BIT;
+		write_erxpfgctl_el1(v);
+		return TEE_SUCCESS;
+	default:
+		EMSG("RAS LSP: Unsupported error type: 0x%"PRIx32,
+		     error_type);
+	}
+
+	return ret;
+}
+
+static void ras_direct_req_handler(struct thread_smc_1_2_regs *args,
+				   struct sp_session *caller_sp __unused)
+{
+	TEE_Result ret = TEE_ERROR_NOT_SUPPORTED;
+	uint32_t error_type = args->a5;
+	uint32_t component = args->a6;
+	uint32_t data = args->a7;
+
+	ret = ras_injection_handler(error_type, component, data);
+
+	if (OPTEE_SMC_IS_64(args->a0))
+		args->a0 = FFA_MSG_SEND_DIRECT_RESP_64;
+	else
+		args->a0 = FFA_MSG_SEND_DIRECT_RESP_32;
+
+	args->a2 = FFA_DST(args->a1);
+	args->a3 = ret;
+}
+
+static struct spmc_lsp_desc ras_lsp __nex_data = {
+	.name = "ras_lsp",
+	.direct_req = ras_direct_req_handler,
+	.properties = FFA_PART_PROP_DIRECT_REQ_RECV |
+		      FFA_PART_PROP_DIRECT_REQ_SEND,
+	.uuid_words = { 0x7011a688, 0x4dde4053, 0xa5a97bac, 0xf13b8cd4 },
+};
+
+static TEE_Result ras_lsp_init(void)
+{
+	uint64_t pfr0 = read_id_aa64pfr0_el1();
+
+	/* Register the LSP only when the CPU advertises architectural RAS. */
+	if (!((pfr0 >> ID_AA64PFR0_EL1_RAS_SHIFT) &
+	      ID_AA64PFR0_EL1_RAS_MASK))
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	return spmc_register_lsp(&ras_lsp);
+}
+
+nex_service_init_late(ras_lsp_init);

--- a/core/arch/arm/lsp/sub.mk
+++ b/core/arch/arm/lsp/sub.mk
@@ -1,0 +1,1 @@
+srcs-$(CFG_RAS_LSP) += lsp_ras_inject.c

--- a/core/arch/arm/tests/ffa_lsp.c
+++ b/core/arch/arm/tests/ffa_lsp.c
@@ -8,7 +8,8 @@
 #include <kernel/thread_spmc.h>
 #include <sm/optee_smc.h>
 
-static void test_direct_req(struct thread_smc_1_2_regs *args)
+static void test_direct_req(struct thread_smc_1_2_regs *args,
+			    struct sp_session *caller_sp __unused)
 {
 	uint16_t src = args->a1 >> 16;
 	uint16_t dst = args->a1;


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

This pull request adds support for RAS error injection through a Logical Secure Partition (LSP) over FF-A.

It includes:

- routing SP direct requests to LSPs in the SPMC path
- adding a RAS error injection LSP in OP-TEE
- adding RD-Aspen platform-specific helper routines for RAS register programming
- adding the build integration for the LSP and platform helper

The implementation follows the maintainer guidance discussed in [issue #7549](https://github.com/OP-TEE/optee_os/issues/7549), in particular:

- extending the `direct_req()` callback with a caller-origin flag
- dispatching SP-originated direct requests from `ffa_handle_sp_direct_req()`
- allowing LSP handlers to reject S-EL0 callers for interfaces intended for the normal world only
