### PR TITLE
core: arm: stmm_sp: make StMM heap size configurable via CFG_STMM_HEAP_PAGE_COUNT

### DIFF
--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -70,7 +70,11 @@ static const uint16_t stmm_id = 1U;
 static const uint16_t stmm_pta_id = 2U;
 static const uint16_t ffa_storage_id = 4U;
 
-static const unsigned int stmm_heap_size = 402 * SMALL_PAGE_SIZE;
+static_assert(CFG_STMM_HEAP_PAGE_COUNT >= 402,
+	      "CFG_STMM_HEAP_PAGE_COUNT must be at least 402");
+
+static const unsigned int stmm_heap_size = CFG_STMM_HEAP_PAGE_COUNT *
+					   SMALL_PAGE_SIZE;
 static const unsigned int stmm_sec_buf_size = 4 * SMALL_PAGE_SIZE;
 static const unsigned int stmm_ns_comm_buf_size = 4 * SMALL_PAGE_SIZE;
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -914,6 +914,13 @@ CFG_WITH_STMM_SP ?= n
 endif
 ifeq ($(CFG_WITH_STMM_SP),y)
 $(call force,CFG_ZLIB,y)
+# Number of 4KiB pages reserved for the StandaloneMm SP heap. The default
+# of 402 pages (~1.6MiB) is sufficient for minimal configurations, but
+# builds that include UEFI Secure Boot (AuthVariableLib + VarCheckPolicyLib
+# pulling in OpenSSL) typically require ~800 pages to avoid heap exhaustion
+# during StMM initialization. Values smaller than 402 are rejected at build
+# time as they are known to break existing configurations.
+CFG_STMM_HEAP_PAGE_COUNT ?= 402
 endif
 
 # When enabled checks that buffers passed to the GP Internal Core API


### PR DESCRIPTION
The StMM SP heap size has been hardcoded to 402 pages (~1.6 MiB), which is sufficient for minimal configurations but too small for builds that include UEFI Secure Boot. AuthVariableLib + VarCheckPolicyLib pull in OpenSSL, whose constructors exhaust the heap during MM initialization.

Add `CFG_STMM_HEAP_PAGE_COUNT` to make the heap size configurable, defaulting to 402 pages to preserve existing behavior. Reject values below 402 at build time via `static_assert()`, since smaller values are known to break existing configurations.

Platforms requiring Secure Boot can override the value (for example `CFG_STMM_HEAP_PAGE_COUNT=800` for ~3.2 MiB) without forking OP-TEE.

Closes #7728 (@apalos asked for a build config option keeping 402 as the default and failing the build below that; @etienne-lms suggested the page-count naming over a bytes-with-multiple-of-4kB assert).