### PR TITLE
plat_trace_init: platform hook to configure the trace infrastructure

### DIFF
--- a/core/arch/arm/plat-bcm/main.c
+++ b/core/arch/arm/plat-bcm/main.c
@@ -62,14 +62,17 @@ void plat_trace_ext_puts(const char *str)
 		bcm_elog_putchar(*p);
 }
 
+void plat_trace_init(void)
+{
+	bcm_elog_init(CFG_BCM_ELOG_AP_UART_LOG_BASE,
+		      CFG_BCM_ELOG_AP_UART_LOG_SIZE);
+}
+
 void plat_console_init(void)
 {
 	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
 			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 	register_serial_console(&console_data.chip);
-
-	bcm_elog_init(CFG_BCM_ELOG_AP_UART_LOG_BASE,
-		      CFG_BCM_ELOG_AP_UART_LOG_SIZE);
 }
 
 void boot_primary_init_intc(void)

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -15,6 +15,7 @@ void console_putc(int ch);
 void console_flush(void);
 
 void plat_console_init(void);
+void plat_trace_init(void);
 
 struct serial_chip;
 void register_serial_console(struct serial_chip *chip);

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -25,8 +25,14 @@ __weak void plat_console_init(void)
 {
 }
 
+__weak void plat_trace_init(void)
+{
+}
+
 void console_init(void)
 {
+	plat_trace_init();
+
 	if (IS_ENABLED(CFG_SEMIHOSTING_CONSOLE))
 		semihosting_console_init(CFG_SEMIHOSTING_CONSOLE_FILE);
 	else if (IS_ENABLED(CFG_FFA_CONSOLE))


### PR DESCRIPTION
plat_trace_ext_puts() is platform specific, but plat_console_init is not (wont get called for other consoles)

```
void console_init(void)
{
	if (IS_ENABLED(CFG_SEMIHOSTING_CONSOLE))
		semihosting_console_init(CFG_SEMIHOSTING_CONSOLE_FILE);
	else if (IS_ENABLED(CFG_FFA_CONSOLE))
		ffa_console_init();
	else
		plat_console_init();
}
```

When registering the trace configuration, users rely on plat_console_init to prepare the trace layout for the platform early enough in the boot chain and so changing the console via config will break the trace.

The following PR provides an exclusive hook to configure the platform specific trace infrastructure.