### PR TITLE
core: pseudo_ta: fix spurious error from from_bounce_params()

### DIFF
--- a/core/kernel/pseudo_ta.c
+++ b/core/kernel/pseudo_ta.c
@@ -421,5 +421,5 @@ TEE_Result from_bounce_params(uint32_t param_types,
 		}
 	}
 
-	return res;
+	return TEE_SUCCESS;
 }


### PR DESCRIPTION
from_bounce_params() initializes res to TEE_ERROR_GENERIC and only updates it when a MEMREF_OUTPUT or MEMREF_INOUT parameter is processed via copy_to_user(). For any other parameter combination - value outputs, input-only, or no params - the loop completes without touching res and the function returns TEE_ERROR_GENERIC even though everything succeeded.

This causes pseudo-TA invocations from TAs on PAN-enabled hardware to fail spuriously when the call has no memory reference output parameters.

The same function to_bounce_params() in the same file correctly ends with return TEE_SUCCESS, making the asymmetry a straightforward mistake.

Fix by initializing res to TEE_SUCCESS instead of TEE_ERROR_GENERIC.

Fixes: 653409a23619 ("core: pta: add helper functions to support calls from TA when CFG_PAN=y")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
