### PR TITLE
core: dt_driver: fix under-counted bounds check in prop_phandle helper

### DIFF
--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -338,7 +338,8 @@ TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
 		return TEE_ERROR_DEFER_DRIVER_INIT;
 
 	prop_index *= dt_driver_provider_cells(prv);
-	if ((prop_index + 1) * sizeof(*prop) > (size_t)len)
+	if ((prop_index + dt_driver_provider_cells(prv)) *
+	    sizeof(*prop) > (size_t)len)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	phandle_node = fdt_node_offset_by_phandle(fdt, phandle);


### PR DESCRIPTION
dt_driver_device_from_node_idx_prop_phandle() scales prop_index to a cell offset by multiplying by provider_cells, then checks that only (prop_index + 1) cells fit within the property buffer. However, device_from_provider_prop() subsequently reads provider_cells values starting at prop + prop_index, not just one cell.

For any provider with more than one cell (e.g. an interrupt controller with #interrupt-cells = 2 or 3) the bounds check is insufficient and the subsequent read in device_from_provider_prop() can access memory beyond the end of the property buffer.

Fix by checking (prop_index + dt_driver_provider_cells(prv)) cells rather than (prop_index + 1).

Fixes: 50dd2af06ae4 ("core: dt_driver: add helper for old fashion interrupt bindings")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
