### PR TITLE
core: huk: Enable support for platform specific HUK length

### DIFF
--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -12,6 +12,7 @@ $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_RESERVED_SHM,n)
 $(call force,CFG_QCOM_GENI_UART,y)
 $(call force,CFG_CRYPTO_WITH_CE,y)
+$(call force,CFG_HW_UNIQUE_KEY_LENGTH,32)
 
 ta-targets = ta_arm64
 supported-ta-targets ?= ta_arm64

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -349,11 +349,7 @@ static inline size_t __tee_alg_get_digest_size(uint32_t algo)
 /* ------------------------------------------------------------ */
 /* OTP mapping                                                  */
 /* ------------------------------------------------------------ */
-#define HW_UNIQUE_KEY_WORD1      (8)
-#define HW_UNIQUE_KEY_LENGTH     (16)
-#define HW_UNIQUE_KEY_WORD2      (HW_UNIQUE_KEY_WORD1 + 1)
-#define HW_UNIQUE_KEY_WORD3      (HW_UNIQUE_KEY_WORD1 + 2)
-#define HW_UNIQUE_KEY_WORD4      (HW_UNIQUE_KEY_WORD1 + 3)
+#define HW_UNIQUE_KEY_LENGTH		(CFG_HW_UNIQUE_KEY_LENGTH)
 
 #define UTEE_SE_READER_PRESENT			(1 << 0)
 #define UTEE_SE_READER_TEE_ONLY			(1 << 1)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -812,6 +812,10 @@ $(call force,CFG_CORE_RWDATA_NOEXEC,y)
 CFG_VIRT_GUEST_COUNT ?= 2
 endif
 
+# Default length of hardware unique key, platforms can override it based on
+# their capabilities.
+CFG_HW_UNIQUE_KEY_LENGTH ?= 16
+
 # Enables backwards compatible derivation of RPMB and SSK keys
 CFG_CORE_HUK_SUBKEY_COMPAT ?= y
 


### PR DESCRIPTION
huk_subkey_derive() uses TEE_ALG_HMAC_SHA256 operation for key derivation. And the ideal key size for this HMAC operation should match the size of SHA operation bits (256 bits or 32 bytes). Also, the hardware key manager on Qualcomm SoCs provide by default a 32 byte hardware unique key. So, let's enable that for Qualcomm platforms.

The HWKM support for Qcom SoCs will be enabled by followup patches.