### PR TITLE
core: fix typo MOBJ_USE_CASE_TRUSED_UI -> TRUSTED_UI

### DIFF
--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -230,7 +230,7 @@ struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 		m = ffa_shm_new(num_pages);
 		break;
 	case MOBJ_USE_CASE_SEC_VIDEO_PLAY:
-	case MOBJ_USE_CASE_TRUSED_UI:
+	case MOBJ_USE_CASE_TRUSTED_UI:
 		m = ffa_prm_new(num_pages, use_case);
 		break;
 	default:

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -21,12 +21,6 @@ enum mobj_use_case {
 	MOBJ_USE_CASE_NS_SHM,
 	MOBJ_USE_CASE_SEC_VIDEO_PLAY,
 	MOBJ_USE_CASE_TRUSTED_UI,
-	/*
-	 * Platforms can extend this enum with additional use cases as needed.
-	 * The use_case value is passed to plat_set_protmem_range() and
-	 * plat_get_protmem_config() for platform-specific memory firewall
-	 * configuration.
-	 */
 };
 
 struct mobj {

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -20,7 +20,13 @@
 enum mobj_use_case {
 	MOBJ_USE_CASE_NS_SHM,
 	MOBJ_USE_CASE_SEC_VIDEO_PLAY,
-	MOBJ_USE_CASE_TRUSED_UI,
+	MOBJ_USE_CASE_TRUSTED_UI,
+	/*
+	 * Platforms can extend this enum with additional use cases as needed.
+	 * The use_case value is passed to plat_set_protmem_range() and
+	 * plat_get_protmem_config() for platform-specific memory firewall
+	 * configuration.
+	 */
 };
 
 struct mobj {

--- a/core/tee/entry_std.c
+++ b/core/tee/entry_std.c
@@ -549,7 +549,7 @@ static void __maybe_unused lend_protmem(struct optee_msg_arg *arg,
 
 	switch (use_case) {
 	case MOBJ_USE_CASE_SEC_VIDEO_PLAY:
-	case MOBJ_USE_CASE_TRUSED_UI:
+	case MOBJ_USE_CASE_TRUSTED_UI:
 		break;
 	default:
 		goto out;


### PR DESCRIPTION
Fix typo in enum mobj_use_case: TRUSED_UI should be TRUSTED_UI.

Also add a comment explaining that platforms can extend this enum
with additional use cases for platform-specific memory firewall
configuration.

Typo spotted in #7786.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
