### PR TITLE
plat-rockchip: rk3588: Add platform-specific PRNG initialization

### DIFF
--- a/core/arch/arm/plat-rockchip/platform_rk3588.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3588.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <common.h>
+#include <crypto/crypto.h>
 #include <drivers/rockchip_otp.h>
 #include <io.h>
 #include <kernel/panic.h>
@@ -18,6 +19,7 @@
 #include <stdlib_ext.h>
 #include <string.h>
 #include <string_ext.h>
+#include <tee/tee_cryp_utl.h>
 #include <utee_defines.h>
 
 #define FIREWALL_DDR_RGN(i)		((i) * 0x4)
@@ -51,6 +53,13 @@
 
 #define TRNG_POLL_PERIOD_US	0
 #define TRNG_POLL_TIMEOUT_US	1000
+
+/*
+ * We want at least 256 bits of entropy, so we need to gather
+ * 48 bytes of TRNG data: SP 800-90B Entropy Assessment determined
+ * a worst-case entropy of 6.6556 bits/byte for the RK3588 TRNG.
+ */
+#define TRNG_ENTROPY_256        48
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, FIREWALL_DDR_BASE, FIREWALL_DDR_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, FIREWALL_DSU_BASE, FIREWALL_DSU_SIZE);
@@ -291,3 +300,21 @@ out:
 
 	return res;
 }
+
+#ifdef CFG_WITH_SOFTWARE_PRNG
+void plat_init_soft_prng(void)
+{
+	uint8_t seed[TRNG_ENTROPY_256] = {};
+	TEE_Result res = TEE_SUCCESS;
+
+	res = hw_get_random_bytes(seed, sizeof(seed));
+	if (res != TEE_SUCCESS) {
+		/* Should not happen on RK3588 as TRNG is always present.  */
+		panic("Failed to get TRNG seed data");
+	}
+
+	res = crypto_rng_init(seed, sizeof(seed));
+	if (res != TEE_SUCCESS)
+		panic("Failed to initialize RNG with seed");
+}
+#endif /* CFG_WITH_SOFTWARE_PRNG */


### PR DESCRIPTION
Implement plat_rng_init() for RK3588 to seed the PRNG with entropy from the hardware TRNG.

The implementation collects 48 bytes from the RK3588 hardware TRNG, providing at least 256 bits of entropy based on the measured entropy rate of 6.6556 bits/byte (validated through SP 800-90B Entropy Assessment). This ensures cryptographically strong seeding of the software PRNG when CFG_WITH_SOFTWARE_PRNG is enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
