### PR TITLE
run TA ASAN self-tests in ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,10 +413,10 @@ jobs:
               make -j$(nproc) check CFG_LOCKDEP=y CFG_LOCKDEP_RECORD_STACK=n CFG_IN_TREE_EARLY_TAS=pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee CFG_PKCS11_TA=y CFG_CORE_UNSAFE_MODEXP=y XTEST_ARGS="-x pkcs11_1007"
           - name: 2
             make_commands: |
-              make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n XTEST_ARGS="n_1001 n_1003 n_1004"
+              make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_TA_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n XTEST_ARGS="n_1001 n_1003 n_1004 n_1042"
           - name: 3
             make_commands: |
-              make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n CFG_DYN_CONFIG=n XTEST_ARGS="n_1001 n_1003 n_1004"
+              make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_TA_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n CFG_DYN_CONFIG=n XTEST_ARGS="n_1001 n_1003 n_1004 n_1042"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -536,7 +536,7 @@ jobs:
               make -j$(nproc) check ARM_FIRMWARE_HANDOFF=y
           - name: KASAN
             make_commands: |
-              make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n RUST_ENABLE=n MEASURED_BOOT_FTPM=n XTEST_ARGS="n_1001 n_1003 n_1004"
+              make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_TA_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n RUST_ENABLE=n MEASURED_BOOT_FTPM=n XTEST_ARGS="n_1001 n_1003 n_1004 n_1042"
           - name: pager
             make_commands: |
               make -j$(nproc) check CFG_WITH_PAGER=y MEASURED_BOOT_FTPM=n


### PR DESCRIPTION
Enable TA KASAN in the relevant CI jobs by setting `CFG_TA_SANITIZE_KADDRESS=y` and extend the xtest selection to run regression `n_1042`.