### PR TITLE
drivers: qcom: prng: Add timeout to hw_get_random_bytes

### DIFF
--- a/core/drivers/qcom/prng/prng.c
+++ b/core/drivers/qcom/prng/prng.c
@@ -5,6 +5,7 @@
 
 #include <initcall.h>
 #include <io.h>
+#include <kernel/delay.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 #include <rng_support.h>
@@ -14,6 +15,8 @@
 #define SEC_PRNG_DATA_OUT			0x0
 #define SEC_PRNG_STATUS				0x4
 #define SEC_PRNG_STATUS_DATA_AVAIL_BMSK		0x1
+
+#define PRNG_TIMEOUT_US				1000000
 
 static struct {
 	paddr_t pa;
@@ -25,7 +28,8 @@ static struct {
 TEE_Result hw_get_random_bytes(void *buf, size_t len)
 {
 	uint8_t *out = buf;
-	uint32_t val;
+	uint32_t val = 0;
+	uint64_t to = 0;
 
 	if (!prng.va)
 		return TEE_ERROR_NOT_SUPPORTED;
@@ -33,13 +37,19 @@ TEE_Result hw_get_random_bytes(void *buf, size_t len)
 	if (!out || !len)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	to = timeout_init_us(PRNG_TIMEOUT_US);
 	while (len) {
 		if (!(io_read32(prng.va + SEC_PRNG_STATUS) &
-		      SEC_PRNG_STATUS_DATA_AVAIL_BMSK))
+		      SEC_PRNG_STATUS_DATA_AVAIL_BMSK)) {
+			if (timeout_elapsed(to))
+				return TEE_ERROR_BUSY;
 			continue;
+		}
 
-		while ((val = io_read32(prng.va + SEC_PRNG_DATA_OUT)) == 0)
-			;
+		while ((val = io_read32(prng.va + SEC_PRNG_DATA_OUT)) == 0) {
+			if (timeout_elapsed(to))
+				return TEE_ERROR_BUSY;
+		}
 
 		for (size_t i = 0; i < sizeof(val) && len; i++) {
 			*out++ = (uint8_t)(val >> (i * 8));


### PR DESCRIPTION
The busy-wait loops polling the PRNG status and data registers had no exit condition, risking an infinite loop if the hardware stopped responding. Add a 10ms timeout and return TEE_ERROR_BUSY if it elapses.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
