### PR TITLE
plat-rockchip: rk3588: fix firewall setup

### DIFF
--- a/core/arch/arm/plat-rockchip/platform_rk3588.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3588.c
@@ -89,12 +89,12 @@ int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
 	io_write32(fw_ddr_base + FIREWALL_DDR_RGN(rgn),
 		   RG_MAP_SECURE(ed_mb, st_mb));
 
+	io_write32(fw_dsu_base + FIREWALL_DSU_RGN(rgn),
+		   RG_MAP_SECURE(ed_mb, st_mb));
+
 	/* Map secure region in each DSU channel and enable */
-	for (i = 0; i < DDR_CHN_CNT; i++) {
-		io_write32(fw_dsu_base + FIREWALL_DSU_RGN(i),
-			   RG_MAP_SECURE(ed_mb, st_mb));
+	for (i = 0; i < DDR_CHN_CNT; i++)
 		io_setbits32(fw_dsu_base + FIREWALL_DSU_CON(i), BIT(rgn));
-	}
 
 	/* Enable secure region for DDR */
 	io_setbits32(fw_ddr_base + FIREWALL_DDR_CON, BIT(rgn));


### PR DESCRIPTION
FIREWALL_DSU_RGN() is one register per region, not one register per channel. Move the register write out of the channel loop and use the current region as index instead of the channel loop counter.

The practical effect of this bug was that the OP-TEE firewall setup destroyed the region that the TF-A had previously configured. TF-A protects the first MiB of address space from non secure access, due to the bug the region became visible again to non secure world.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
