### PR TITLE
drivers: qcom: simplify memory mapping in PRNG and Ramblur drivers

### DIFF
--- a/core/drivers/qcom/prng/prng.c
+++ b/core/drivers/qcom/prng/prng.c
@@ -52,12 +52,10 @@ TEE_Result hw_get_random_bytes(void *buf, size_t len)
 
 static TEE_Result qcom_prng_init(void)
 {
-	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, prng.pa, SEC_PRNG_REG_SIZE))
-		return TEE_ERROR_GENERIC;
-
-	prng.va = (vaddr_t)phys_to_virt_io(prng.pa, SEC_PRNG_REG_SIZE);
+	prng.va = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC, prng.pa,
+						SEC_PRNG_REG_SIZE);
 	if (!prng.va)
-		return TEE_ERROR_ACCESS_DENIED;
+		return TEE_ERROR_GENERIC;
 
 	return TEE_SUCCESS;
 }

--- a/core/drivers/qcom/ramblur/ramblur_pimem_v3.c
+++ b/core/drivers/qcom/ramblur/ramblur_pimem_v3.c
@@ -292,15 +292,11 @@ static TEE_Result initialize_window(int window, size_t size, uintptr_t vault)
  */
 static TEE_Result qti_ramblur_pimem_init(void)
 {
-	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, RAMBLUR_PIMEM_REG_BASE,
-				  RAMBLUR_PIMEM_REG_SIZE))
-		panic("Can't add Ramblur pIMEM");
-
-	ramblur_va = (vaddr_t)phys_to_virt(RAMBLUR_PIMEM_REG_BASE,
-					   MEM_AREA_IO_SEC,
-					   RAMBLUR_PIMEM_REG_SIZE);
+	ramblur_va = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC,
+						   RAMBLUR_PIMEM_REG_BASE,
+						   RAMBLUR_PIMEM_REG_SIZE);
 	if (!ramblur_va)
-		panic("Can't get Ramblur virtual");
+		panic("Can't map Ramblur pIMEM");
 
 	get_hardware_version(&ramblur_version.major,
 			     &ramblur_version.minor,


### PR DESCRIPTION
This series simplifies memory mapping in QCOM drivers by directly using the
virtual address returned by core_mmu_add_mapping(), eliminating redundant
phys_to_virt*() calls.