### PR TITLE
drivers: caam: avoid assert on short keys

### DIFF
--- a/core/drivers/crypto/caam/caam_key.c
+++ b/core/drivers/crypto/caam/caam_key.c
@@ -104,7 +104,9 @@ static struct caam_key_serialized *data_to_serialized_key(const uint8_t *data,
 							  size_t size)
 {
 	assert(data && size);
-	assert(size > sizeof(struct caam_key_serialized));
+
+	if (size <= sizeof(struct caam_key_serialized))
+		return NULL;
 
 	/*
 	 * It's important to make sure uint8_t and caam_key_serialized{} are
@@ -135,7 +137,7 @@ static enum caam_key_type get_key_type(const uint8_t *data, size_t size)
 {
 	struct caam_key_serialized *key = data_to_serialized_key(data, size);
 
-	if (key->magic_number != MAGIC_NUMBER)
+	if (!key || key->magic_number != MAGIC_NUMBER)
 		return CAAM_KEY_PLAIN_TEXT;
 
 	return key->key_type;
@@ -151,7 +153,7 @@ static size_t get_key_sec_size(const uint8_t *data, size_t size)
 {
 	struct caam_key_serialized *key = data_to_serialized_key(data, size);
 
-	if (key->magic_number != MAGIC_NUMBER)
+	if (!key || key->magic_number != MAGIC_NUMBER)
 		return size;
 
 	return key->sec_size;
@@ -167,7 +169,7 @@ static unsigned long get_key_buf_offset(const uint8_t *data, size_t size)
 {
 	struct caam_key_serialized *key = data_to_serialized_key(data, size);
 
-	if (key->magic_number != MAGIC_NUMBER)
+	if (!key || key->magic_number != MAGIC_NUMBER)
 		return 0;
 	else
 		return offsetof(struct caam_key_serialized, key);
@@ -182,6 +184,7 @@ static unsigned long get_key_buf_offset(const uint8_t *data, size_t size)
 static size_t get_key_buf_size(const uint8_t *data, size_t size)
 {
 	struct caam_key_serialized *key = data_to_serialized_key(data, size);
+	assert(key);
 
 	/*
 	 * In the caam_key_serialized{}, the last element of the structure is


### PR DESCRIPTION
If the input key is 12 bytes or shorter after removing zero padding, the assert in data_to_serialized_key() would fail. If the size is that short the key can't be a valid wrapped key, so it must either be invalid or a plain text key. Since there is no way to validate that the key is actually a plain text key, short keys are always treated as plain text.

This is reachable using a short private key with:
* DH
* DSA
* ECDH (Wycheproof ecdh_secp256r1_test.json tcId 315)
* ECDSA

The get_key_buf_size function is only used in a context where the key type is known not to be plain text, so it gets an extra assert to keep the same behavior as before.

Fixes: 1495f6c4a82a ("drivers: caam: add CAAM key driver")