### PR TITLE
ta: pkcs11: Support RSA keys without CRT parameters

### DIFF
--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2017-2020, Linaro Limited
+ * Copyright 2026 NXP
  */
 
 #include <assert.h>
@@ -352,6 +353,9 @@ enum pkcs11_rc alloc_get_tee_attribute_data(TEE_ObjectHandle tee_obj,
 	size_t sz = 0;
 
 	res = TEE_GetObjectBufferAttribute(tee_obj, attribute, NULL, &sz);
+	if (res == TEE_SUCCESS && sz == 0)
+		return PKCS11_RV_NOT_FOUND;
+
 	if (res != TEE_ERROR_SHORT_BUFFER)
 		return PKCS11_CKR_FUNCTION_FAILED;
 

--- a/ta/pkcs11/src/processing_rsa.c
+++ b/ta/pkcs11/src/processing_rsa.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2018-2021, Linaro Limited
+ * Copyright 2026 NXP
  */
 
 #include <assert.h>
@@ -691,8 +692,12 @@ static enum pkcs11_rc tee2pkcs_rsa_attributes(struct obj_attrs **pub_head,
 
 	rc = tee2pkcs_add_attribute(priv_head, PKCS11_CKA_PRIME_1, tee_obj,
 				    TEE_ATTR_RSA_PRIME1);
-	if (rc)
-		goto out;
+	if (rc == PKCS11_RV_NOT_FOUND) {
+		DMSG("CRT parameters unavailable, using standard RSA");
+		return PKCS11_CKR_OK;
+	} else if (rc != PKCS11_CKR_OK) {
+		return rc;
+	}
 
 	rc = tee2pkcs_add_attribute(priv_head, PKCS11_CKA_PRIME_2, tee_obj,
 				    TEE_ATTR_RSA_PRIME2);


### PR DESCRIPTION
Some RSA private keys may not include Chinese Remainder Theorem (CRT) parameters (PRIME_1, PRIME_2, EXPONENT_1, EXPONENT_2, COEFFICIENT).

These keys are still valid and can perform RSA operations using only the private exponent and modulus, though less efficiently. Currently, tee2pkcs_rsa_attributes() fails when extracting attributes from a TEE object that doesn't contain CRT parameters. This patch allows the function to succeed for non-CRT RSA keys by attempting to retrieve CRT parameters and gracefully handling their absence.

This maintains compatibility with both CRT-enabled and standard RSA private keys as per PKCS#11 specification.

