### PR TITLE
ta: pkcs11: fix a few error cases return codes

### DIFF
--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -366,7 +366,18 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 	TEE_MemMove(params[0].memref.buffer, &rc, sizeof(rc));
 	params[0].memref.size = sizeof(rc);
 
-	if (rc == PKCS11_CKR_BUFFER_TOO_SMALL)
+	/*
+	 * When command PKCS11_CMD_GET_ATTRIBUTE_VALUE emits
+	 * PKCS11_CKR_BUFFER_TOO_SMALL status, it shall still return
+	 * with TEE_SUCCESS since caller can read valid output data
+	 * from memref[0] (PKCS#11 return code) and memref[2] (retrieved
+	 * object attributes information).
+	 *
+	 * For all other commands, return TEE_ERROR_SHORT_BUFFER since
+	 * only the memrefs output sizes are meaningful to the client.
+	 */
+	if (cmd != PKCS11_CMD_GET_ATTRIBUTE_VALUE &&
+	    rc == PKCS11_CKR_BUFFER_TOO_SMALL)
 		return TEE_ERROR_SHORT_BUFFER;
 	else
 		return TEE_SUCCESS;

--- a/ta/pkcs11/src/processing_ec.c
+++ b/ta/pkcs11/src/processing_ec.c
@@ -337,6 +337,30 @@ uint32_t ec_params2tee_curve(void *ec_params, size_t size)
 	return curve->tee_id;
 }
 
+static bool tee_curve_is_ec_legacy(uint32_t tee_id)
+{
+	switch (tee_id) {
+	case TEE_ECC_CURVE_NIST_P192:
+	case TEE_ECC_CURVE_NIST_P224:
+	case TEE_ECC_CURVE_NIST_P256:
+	case TEE_ECC_CURVE_NIST_P384:
+	case TEE_ECC_CURVE_NIST_P521:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool tee_curve_is_ec_edwards(uint32_t tee_id)
+{
+	switch (tee_id) {
+	case TEE_ECC_CURVE_25519:
+		return true;
+	default:
+		return false;
+	}
+}
+
 enum pkcs11_rc load_tee_ec_key_attrs(TEE_Attribute **tee_attrs,
 				     size_t *tee_count,
 				     struct pkcs11_object *obj)
@@ -619,9 +643,12 @@ enum pkcs11_rc generate_ec_keys(struct pkcs11_attribute_head *proc_params,
 
 	tee_size = ec_params2tee_keysize(a_ptr, a_size);
 	if (!tee_size)
-		return PKCS11_CKR_ATTRIBUTE_TYPE_INVALID;
+		return PKCS11_CKR_CURVE_NOT_SUPPORTED;
 
 	tee_curve = ec_params2tee_curve(a_ptr, a_size);
+
+	if (!tee_curve_is_ec_legacy(tee_curve))
+		return PKCS11_CKR_CURVE_NOT_SUPPORTED;
 
 	TEE_InitValueAttribute(tee_key_attr, TEE_ATTR_ECC_CURVE, tee_curve, 0);
 
@@ -754,7 +781,10 @@ enum pkcs11_rc generate_eddsa_keys(struct pkcs11_attribute_head *proc_params,
 
 	tee_size = ec_params2tee_keysize(a_ptr, a_size);
 	if (!tee_size)
-		return PKCS11_CKR_ATTRIBUTE_TYPE_INVALID;
+		return PKCS11_CKR_CURVE_NOT_SUPPORTED;
+
+	if (!tee_curve_is_ec_edwards(ec_params2tee_curve(a_ptr, a_size)))
+		return PKCS11_CKR_CURVE_NOT_SUPPORTED;
 
 	res = TEE_AllocateTransientObject(TEE_TYPE_ED25519_KEYPAIR, tee_size,
 					  &tee_obj);

--- a/ta/pkcs11/src/processing_rsa.c
+++ b/ta/pkcs11/src/processing_rsa.c
@@ -769,7 +769,11 @@ enum pkcs11_rc generate_rsa_keys(struct pkcs11_attribute_head *proc_params,
 	if (res) {
 		DMSG("TEE_AllocateTransientObject failed %#"PRIx32, res);
 
-		rc = tee2pkcs_error(res);
+		if (res == TEE_ERROR_NOT_SUPPORTED)
+			rc = PKCS11_CKR_TEMPLATE_INCONSISTENT;
+		else
+			rc = tee2pkcs_error(res);
+
 		goto out;
 	}
 


### PR DESCRIPTION
Fix the TEE return value when command PKCS11_CMD_GET_ATTRIBUTE_VALUE sets PKCS#11 return code CKR_BUFFER_TOO_SMALL. For this command and return value, non-secure client output buffer do contain valid data client can read, hence the TA should return TEE_SUCCESS, not TEE_ERROR_SHORT_BUFFER. This fixes an issue when client uses TEE temporary buffers.

Fix PKCS#11 return code when attempting to generate a keys based on an elliptic curve that is not supported. The PKCS#11 specification says that in such cases the interface shall return CKR_CURVE_NOT_SUPPORTED.

Fix the PKCS#11 return code set when requesting a RSA key generation while the key modulus is not supported by OP-TEE. In such case return CKR_TEMPLATE_INCONSISTENT instead of CKR_GENERAL_ERROR.