### PR TITLE
Se050 fix

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -125,6 +125,8 @@ TEE_Result crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
 	rsa_data.key.key = key;
 	rsa_data.key.isprivate = true;
 	rsa_data.key.n_size = crypto_bignum_num_bytes(key->n);
+	if (cipher_len > rsa_data.key.n_size)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	rsa = drvcrypt_get_ops(CRYPTO_RSA);
 	if (rsa) {
@@ -164,6 +166,8 @@ TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
 	rsa_data.key.key = key;
 	rsa_data.key.isprivate = false;
 	rsa_data.key.n_size = crypto_bignum_num_bytes(key->n);
+	if (msg_len > rsa_data.key.n_size)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	if (rsa_data.key.n_size > *cipher_len) {
 		CRYPTO_TRACE("Cipher length (%zu) too short expected %zu bytes",

--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -332,6 +332,10 @@ static TEE_Result decrypt_nopad(struct rsa_keypair *key, const uint8_t *src,
 	size_t blen = 0;
 	size_t rsa_len = 0;
 
+	rsa_len = crypto_bignum_num_bytes(key->n);
+	if (src_len > rsa_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	res = se050_inject_keypair(&kobject, key);
 	if (res)
 		return res;
@@ -352,7 +356,6 @@ static TEE_Result decrypt_nopad(struct rsa_keypair *key, const uint8_t *src,
 		goto out;
 	}
 
-	rsa_len = crypto_bignum_num_bytes(key->n);
 	memcpy(buf + rsa_len - src_len, src, src_len);
 
 	st = sss_se05x_asymmetric_decrypt(&ctx, buf, rsa_len, buf, &blen);
@@ -396,6 +399,10 @@ static TEE_Result encrypt_nopad(struct rsa_public_key *key, const uint8_t *src,
 	size_t blen = 0;
 	size_t rsa_len = 0;
 
+	rsa_len = crypto_bignum_num_bytes(key->n);
+	if (src_len > rsa_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	if (se050_inject_public_key(&kobject, key))
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -414,7 +421,6 @@ static TEE_Result encrypt_nopad(struct rsa_public_key *key, const uint8_t *src,
 		goto out;
 	}
 
-	rsa_len = crypto_bignum_num_bytes(key->n);
 	memcpy(buf + rsa_len - src_len, src, src_len);
 
 	st = sss_se05x_asymmetric_encrypt(&ctx, buf, rsa_len, buf, &blen);


### PR DESCRIPTION
I've tested this on an imx-mx8mqevk for the "drivers: crypto: harden crypto_acipher_rsanopad_{de,en}crypt()" patch. The SE050 patch is compile-tested only.
@ldts, might you be able to test it?

@ramtine, FYI