### PR TITLE
qualcomm platforms: geni-uart Linux RCU stalls workaround

### DIFF
--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -14,6 +14,11 @@ $(call force,CFG_QCOM_GENI_UART,y)
 $(call force,CFG_CRYPTO_WITH_CE,y)
 $(call force,CFG_HW_UNIQUE_KEY_LENGTH,32)
 
+# The GENI UART is shared with the Linux kernel and an excessively long
+# wait period may lead to RCU stall warnings depending on system load.
+# Make this value configurable per platform.
+CFG_QCOM_GENI_UART_RDY_WAIT_USEC ?= 1000
+
 ta-targets = ta_arm64
 supported-ta-targets ?= ta_arm64
 

--- a/core/drivers/qcom_geni_uart.c
+++ b/core/drivers/qcom_geni_uart.c
@@ -16,7 +16,7 @@
 #define GENI_M_CMD0_REG			0x600
 
 #define GENI_M_CMD_TX			0x8000000
-#define GENI_TIMEOUT_US			1000000
+#define GENI_TIMEOUT_US			CFG_QCOM_GENI_UART_RDY_WAIT_USEC
 
 static void qcom_geni_uart_putc(struct serial_chip *chip, int ch)
 {


### PR DESCRIPTION
The GENI UART is shared with the Linux kernel; a hardcoded 1-second
timeout can cause RCU stall warnings under certain conditions. Introduce
**CFG_QCOM_GENI_UART_RDY_WAIT_USEC** so platforms can tune the value to
avoid these stalls.
    
