### PR TITLE
core: spmc: fix missing addr_dst increment in retrieve response

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -612,6 +612,7 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 		dst_region->address_range_count++;
 
 		dst_region->total_page_count += addr_dst->page_count;
+		addr_dst++;
 	}
 }
 


### PR DESCRIPTION
## Summary

`create_retrieve_response()` in `core/arch/arm/kernel/spmc_sp_handler.c` sets `addr_dst` to the start of `dst_region->address_range_array` before the `SLIST_FOREACH` loop but never advances the pointer inside the loop body. Every iteration overwrites slot `[0]`, while `address_range_count` is correctly incremented to `N`. Receiving SPs are handed a descriptor that declares `N` regions but only carries valid data in slot `[0]`; slots `[1..N-1]` remain zero-initialised.

## Trigger

- Single-region shares are unaffected — all NW-originated shares produce exactly one region via `spmc_sp_add_nw_region()`, so the bug is invisible there.
- Multi-region SP-to-SP shares produced by `spmc_sp_add_sp_region()` (sender VA range spanning multiple mobjs) hit the bug. The receiving SP, on `FFA_MEM_RETRIEVE`, reads `address_range_count = N` but only finds the last-iterated region's address/page_count in slot `[0]`.

`total_page_count` is unaffected because it sums `addr_dst->page_count`, which always reflects the current iteration's data.

## Fix

One-line change — advance `addr_dst` at the end of the loop body, mirroring the per-region descriptor write pattern used elsewhere in the SPMC.

## How found

Source-code review of `core/arch/arm/kernel/spmc_sp_handler.c`.

## Notes

- Not triggerable from the normal world; prerequisite is a sender SP that constructs a multi-mobj share, so the in-TEE trust-boundary disqualifies this as a security issue per `optee_docs` `general/security_scope.rst`. Filed as a correctness fix rather than a security advisory.
- Confirmed present on `master` HEAD `e81ace97` at the time of writing.