### PR TITLE
drivers: clk: stm32mp15: force clk_op_compute_rate() in unpaged memory

### DIFF
--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1304,6 +1304,7 @@ static unsigned long clk_op_compute_rate(struct clk *clk,
 {
 	return _stm32_clock_get_rate(clk_to_clock_id(clk));
 }
+DECLARE_KEEP_PAGER(clk_op_compute_rate);
 
 static TEE_Result clk_op_enable(struct clk *clk)
 {


### PR DESCRIPTION
This function can be used during low power sequences. Force it into unpaged memory.
This is also required when enabling Arm SMC watchdog in U-Boot or Linux.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
