### PR TITLE
Fix possible supplicant heap leak in TEE supplicant rpc

### DIFF
--- a/core/tee/tee_supp_plugin_rpc.c
+++ b/core/tee/tee_supp_plugin_rpc.c
@@ -77,10 +77,12 @@ TEE_Result tee_invoke_supp_plugin_rpc(const TEE_UUID *uuid, uint32_t cmd,
 		*outlen = params[2].u.value.b;
 
 	if (len && outlen && *outlen) {
+		size_t resp_len = MIN(*outlen, len);
+
 		if (buf_core)
-			memcpy(buf_core, va, *outlen <= len ? *outlen : len);
+			memcpy(buf_core, va, resp_len);
 		if (buf_user)
-			res = copy_to_user(buf_user, va, len);
+			res = copy_to_user(buf_user, va, resp_len);
 	}
 
 out:


### PR DESCRIPTION
Copies only the smaller of the plugin’s reported output length (outlen) and the requested length. This prevents leaking leftover secure-world heap data when the plugin returns fewer bytes than the caller requested.

Previously, tee_invoke_supp_plugin_rpc() copied `len` bytes regardless of the actual number of bytes produced by the plugin, resulting in kernel / secure heap disclosure into the REE.

Supersedes #7644 