### PR TITLE
plat-rockchip: add RK3576 platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
             make_commands: |
               _make PLATFORM=rockchip-rk322x
               _make PLATFORM=rockchip-rk3399
+              _make PLATFORM=rockchip-rk3576
               _make PLATFORM=rockchip-rk3588
           - name: arm sam
             make_commands: |

--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -83,6 +83,17 @@ CFG_EARLY_CONSOLE_BAUDRATE ?= 1500000
 CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
 endif
 
+ifeq ($(PLATFORM_FLAVOR),rk3576)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+$(call force,CFG_AUTO_MAX_PA_BITS,y)
+
+CFG_TZDRAM_START ?= 0x70000000
+CFG_TZDRAM_SIZE  ?= 0x02000000
+CFG_SHMEM_START  ?= 0x72000000
+CFG_SHMEM_SIZE   ?= 0x00400000
+endif
+
 ifeq ($(platform-flavor-armv8),1)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -127,6 +127,31 @@
 #define ROCKCHIP_OTP_RSA_HASH_INDEX		0x270
 #define ROCKCHIP_OTP_RSA_HASH_SIZE		0x8
 
+#elif defined(PLATFORM_FLAVOR_rk3576)
+
+#define GIC_BASE		0x2a700000
+#define GIC_SIZE		SIZE_K(64)
+#define GICD_BASE		(GIC_BASE + 0x1000)
+#define GICC_BASE		(GIC_BASE + 0x2000)
+
+#define UART0_BASE		0x2ad40000
+#define UART0_SIZE		SIZE_K(64)
+
+#define SYS_SGRF_BASE		0x26004000
+#define SYS_SGRF_SIZE		SIZE_K(4)
+
+#define SYS_SGRF_FW_BASE	0x26005000
+#define SYS_SGRF_FW_SIZE	SIZE_K(4)
+
+#define PMU0SGRF_BASE		0x26000000
+#define PMU0SGRF_SIZE		SIZE_K(4)
+
+#define PMU1SGRF_BASE		0x26002000
+#define PMU1SGRF_SIZE		SIZE_K(4)
+
+#define PMU1SGRF_FW_BASE	0x26003000
+#define PMU1SGRF_FW_SIZE	SIZE_K(4)
+
 #else
 #error "Unknown platform flavor"
 #endif

--- a/core/arch/arm/plat-rockchip/platform_rk3576.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3576.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Jiaxing Hu <huhuvmb88@outlook.com>
+ */
+
+#include <common.h>
+#include <io.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform.h>
+#include <platform_config.h>
+#include <trace.h>
+#include <util.h>
+
+/* DDR firewall offsets (from TF-A rk3576/drivers/secure/firewall.h) */
+#define FW_SGRF_DDR_RGN(i)		(0x0100 + (i) * 0x4)
+#define FW_SGRF_DDR_RGN_CNT		16
+#define FW_SGRF_DDR_CON			0x0168
+
+/* base / (top - 1) encoded in 1 MB units, both clamped to 15 bits. */
+#define RG_MAP_SECURE(top_mb, base_mb) \
+	(((((top_mb) - 1) & 0x7fff) << 16) | ((base_mb) & 0x7fff))
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SYS_SGRF_FW_BASE, SYS_SGRF_FW_SIZE);
+
+int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
+{
+	vaddr_t fw_base = (vaddr_t)phys_to_virt_io(SYS_SGRF_FW_BASE,
+						   SYS_SGRF_FW_SIZE);
+	paddr_t ed = st + sz;
+	uint32_t st_mb = st / SIZE_M(1);
+	uint32_t ed_mb = ed / SIZE_M(1);
+
+	if (!fw_base)
+		panic("SYS_SGRF_FW_BASE not mapped");
+
+	assert(rgn >= 1 && rgn < FW_SGRF_DDR_RGN_CNT);
+	assert(st < ed);
+	assert(st % SIZE_M(1) == 0);
+	assert(ed % SIZE_M(1) == 0);
+
+	DMSG("protecting region %d: 0x%" PRIxPA "-0x%" PRIxPA,
+	     rgn, st, ed);
+
+	io_write32(fw_base + FW_SGRF_DDR_RGN(rgn),
+		   RG_MAP_SECURE(ed_mb, st_mb));
+	io_setbits32(fw_base + FW_SGRF_DDR_CON, BIT(rgn));
+
+	return 0;
+}

--- a/core/arch/arm/plat-rockchip/sub.mk
+++ b/core/arch/arm/plat-rockchip/sub.mk
@@ -4,6 +4,7 @@ srcs-y += platform.c
 srcs-$(PLATFORM_FLAVOR_px30) += platform_px30.c
 srcs-$(PLATFORM_FLAVOR_rk322x) += platform_rk322x.c
 srcs-$(PLATFORM_FLAVOR_rk3399) += platform_rk3399.c
+srcs-$(PLATFORM_FLAVOR_rk3576) += platform_rk3576.c
 srcs-$(PLATFORM_FLAVOR_rk3588) += platform_rk3588.c
 
 ifeq ($(PLATFORM_FLAVOR),rk322x)


### PR DESCRIPTION
Add initial OP-TEE support for the Rockchip RK3576 SoC (4×A72 + 4×A53, GIC-400).

New files under `plat-rockchip`:
- `conf.mk`: 8 cores, TZDRAM @ 0x70000000 (32 MiB), SHMEM @ 0x72000000 (4 MiB)
- `platform_config.h`: GIC-400 at 0x2a700000, UART0 at 0x2ad40000, SGRF/firewall register addresses
- `platform_rk3576.c`: `platform_secure_ddr_region()` via SYS_SGRF_FW_BASE
- `sub.mk`: wire into build

Not yet included: early console, TRNG driver (secure base unconfirmed), OTP HUK (OTP index unverified).

Tested on Radxa Rock 4D (RK3576, 12 GiB LPDDR5) with TF-A v2.14 and U-Boot 2026.04.