### PR TITLE
core: mbedtls: fix sha512_process data array bound

### DIFF
--- a/lib/libmbedtls/core/hash.c
+++ b/lib/libmbedtls/core/hash.c
@@ -220,7 +220,7 @@ int mbedtls_internal_sha256_process(mbedtls_sha256_context *ctx,
 
 #if defined(MBEDTLS_SHA512_PROCESS_ALT)
 int mbedtls_internal_sha512_process(mbedtls_sha512_context *ctx,
-				    const unsigned char data[64])
+				    const unsigned char data[128])
 {
 	crypto_accel_sha512_compress(ctx->state, data, 1);
 


### PR DESCRIPTION
The 'data' parameter of mbedtls_internal_sha512_process() was declared as `const unsigned char data[64]` in lib/libmbedtls/core/hash.c, but the prototype in mbedtls/sha512.h declares it as `const unsigned char data[128]` (SHA-512 block size is 128 bytes).

This mismatch triggers a `-Werror=array-parameter` build failure when ARM Crypto Extensions are enabled:

```
$(call force,CFG_CRYPTO_WITH_CE,y)
$(call force,CFG_CRYPTO_WITH_CE82,y)
```

```
lib/libmbedtls/core/hash.c:223:29: error: argument 'data' of type 'const unsigned char[64]' with mismatched bound [-Werror, -Warray-parameter]
lib/libmbedtls/mbedtls/include/mbedtls/sha512.h:144:57: note: previously declared as 'const unsigned char[128]' here
```

Fix the definition to use `data[128]` to match the prototype.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
