### PR TITLE
ta: pkcs11: fix cppcheck warnings in attributes and object handling

### DIFF
--- a/ta/pkcs11/src/attributes.h
+++ b/ta/pkcs11/src/attributes.h
@@ -216,8 +216,8 @@ static inline enum pkcs11_rc get_u32_attribute(struct obj_attrs *head,
  * Return true if all attributes from the reference are found and match value
  * in the candidate attribute list.
  */
-bool attributes_match_reference(struct obj_attrs *ref,
-				struct obj_attrs *candidate);
+bool attributes_match_reference(struct obj_attrs *candidate,
+				struct obj_attrs *ref);
 
 /*
  * Check attributes from @ref are all found or added in @head


### PR DESCRIPTION
Two minor code quality fixes found by cppcheck 2.17.1:

1. **`identicalConditionAfterEarlyExit`** in `add_attribute()` and `entry_destroy_object()` -- the final `return rc` is reached only after early-exit guards guarantee `rc == PKCS11_CKR_OK`. Return the constant directly.

2. **`funcArgOrderDifferent`** in `attributes_match_reference()` -- the declaration in `attributes.h` had parameter names `(ref, candidate)` in opposite order to the definition in `attributes.c` `(candidate, ref)`. Aligned the declaration to match.