### PR TITLE
Validate ECDH peer public key before shared secret derivation

### DIFF
--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -416,6 +416,7 @@ struct crypto_ecc_public_ops {
 			     const uint8_t *sig, size_t sig_len);
 	TEE_Result (*encrypt)(struct ecc_public_key *key, const uint8_t *src,
 			      size_t src_len, uint8_t *dst, size_t *dst_len);
+	TEE_Result (*validate_public_key)(struct ecc_public_key *key);
 };
 
 /*

--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014-2019, Linaro Limited
+ * Copyright 2026 NXP
  */
 
 #include <config.h>
@@ -312,6 +313,34 @@ out:
 	return res;
 }
 
+static TEE_Result _ltc_ecc_validate_public_key(struct ecc_public_key *key)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int ltc_res = 0;
+	size_t key_size_bytes = 0;
+	ecc_key ltc_key = {};
+
+	if (!key)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = ecc_populate_ltc_public_key(&ltc_key, key, 0, &key_size_bytes);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	ltc_res = ltc_ecc_verify_key(&ltc_key);
+	if (ltc_res != CRYPT_OK) {
+		EMSG("ECDH: invalid public key rejected (ltc_res=%d)", ltc_res);
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	res = TEE_SUCCESS;
+
+out:
+	ecc_free(&ltc_key);
+	return res;
+}
+
 static TEE_Result _ltc_ecc_shared_secret(struct ecc_keypair *private_key,
 					 struct ecc_public_key *public_key,
 					 void *secret,
@@ -358,6 +387,7 @@ static const struct crypto_ecc_keypair_ops ecc_keypair_ops = {
 static const struct crypto_ecc_public_ops ecc_public_key_ops = {
 	.free = _ltc_ecc_free_public_key,
 	.verify = _ltc_ecc_verify,
+	.validate_public_key = _ltc_ecc_validate_public_key,
 };
 
 static const struct crypto_ecc_keypair_ops sm2_dsa_keypair_ops = {

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -332,6 +332,7 @@ srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ecc_ssh_ecdsa_encode_name.c
 srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ecc_verify_hash.c
 srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ltc_ecc_is_point.c
 srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ltc_ecc_is_point_at_infinity.c
+srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ltc_ecc_verify_key.c
 srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ltc_ecc_map.c
 srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ltc_ecc_mulmod.c
 srcs-$(_CFG_CORE_LTC_ECC) += src/pk/ecc/ltc_ecc_mulmod_timing.c

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2020, 2022-2023 Linaro Limited
  * Copyright (c) 2022, Technology Innovation Institute (TII)
+ * Copyright 2026 NXP
  */
 
 #include <assert.h>
@@ -10,6 +11,7 @@
 #include <compiler.h>
 #include <config.h>
 #include <crypto/crypto.h>
+#include <crypto/crypto_impl.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/user_access.h>
 #include <memtag.h>
@@ -3786,6 +3788,7 @@ dh_out:
 		crypto_bignum_free(&ss);
 	} else if (cs->algo == TEE_ALG_ECDH_DERIVE_SHARED_SECRET) {
 		uint32_t curve = ((struct ecc_keypair *)ko->attr)->curve;
+		const struct crypto_ecc_public_ops *ecc_public_key_ops = NULL;
 		struct ecc_public_key key_public = { };
 		uint8_t *pt_secret = NULL;
 		unsigned long pt_secret_len = 0;
@@ -3843,6 +3846,22 @@ dh_out:
 				     key_public.x);
 		crypto_bignum_bin2bn(y_bbuf, params[1].content.ref.length,
 				     key_public.y);
+
+		/*
+		 * Validate peer's public key before passing to any crypto
+		 * backend. This prevents invalid-curve attacks regardless
+		 * of whether the backend is hardware (CAAM) or software
+		 * (libtomcrypt, mbedTLS).
+		 */
+		ecc_public_key_ops = crypto_asym_get_ecc_public_ops(key_type);
+		if (!ecc_public_key_ops) {
+			res = TEE_ERROR_GENERIC;
+			goto out;
+		}
+
+		res = ecc_public_key_ops->validate_public_key(&key_public);
+		if (res)
+			goto out;
 
 		pt_secret = (uint8_t *)(sk + 1);
 		pt_secret_len = sk->alloc_size;

--- a/lib/libmbedtls/core/ecc.c
+++ b/lib/libmbedtls/core/ecc.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (C) 2018, ARM Limited
  * Copyright (C) 2019, Linaro Limited
+ * Copyright 2026 NXP
  */
 
 #include <assert.h>
@@ -309,6 +310,117 @@ out:
 	return res;
 }
 
+/*
+ * Validate that an ECC public key point (X, Y) lies on the specified curve.
+ * This provides centralized protection against invalid-curve attacks for
+ * all crypto backends (CAAM, libtomcrypt, mbedTLS, etc.).
+ */
+static TEE_Result validate_ecdh_public_key(struct ecc_public_key *public_key)
+{
+	mbedtls_ecp_group grp = {};
+	mbedtls_ecp_point Q = {};
+	mbedtls_ecp_group_id grp_id = MBEDTLS_ECP_DP_NONE;
+	int ret = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t coord_len = 0;
+	size_t pt_len = 0;
+	uint8_t *pt_buf = NULL;
+	mbedtls_mpi *x = NULL;
+	mbedtls_mpi *y = NULL;
+	size_t x_len = 0;
+	size_t y_len = 0;
+
+	if (!public_key || !public_key->x || !public_key->y)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	x = (mbedtls_mpi *)public_key->x;
+	y = (mbedtls_mpi *)public_key->y;
+	x_len = mbedtls_mpi_size(x);
+	y_len = mbedtls_mpi_size(y);
+
+	switch (public_key->curve) {
+	case TEE_ECC_CURVE_NIST_P192:
+		grp_id = MBEDTLS_ECP_DP_SECP192R1;
+		coord_len = 24;
+		break;
+	case TEE_ECC_CURVE_NIST_P224:
+		grp_id = MBEDTLS_ECP_DP_SECP224R1;
+		coord_len = 28;
+		break;
+	case TEE_ECC_CURVE_NIST_P256:
+		grp_id = MBEDTLS_ECP_DP_SECP256R1;
+		coord_len = 32;
+		break;
+	case TEE_ECC_CURVE_NIST_P384:
+		grp_id = MBEDTLS_ECP_DP_SECP384R1;
+		coord_len = 48;
+		break;
+	case TEE_ECC_CURVE_NIST_P521:
+		grp_id = MBEDTLS_ECP_DP_SECP521R1;
+		coord_len = 66;
+		break;
+	default:
+		EMSG("ECDH: unsupported curve 0x%" PRIx32, public_key->curve);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	if (x_len > coord_len || y_len > coord_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mbedtls_ecp_group_init(&grp);
+	mbedtls_ecp_point_init(&Q);
+
+	ret = mbedtls_ecp_group_load(&grp, grp_id);
+	if (ret) {
+		EMSG("ECDH: failed to load curve group (ret=%d)", ret);
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	/*
+	 * Build uncompressed point buffer: 0x04 || X (padded) || Y (padded)
+	 * mbedtls_ecp_point_read_binary() expects both coordinates to be
+	 * zero-padded to the full field element size, and sets Z = 1
+	 * internally.
+	 */
+	pt_len = 1 + 2 * coord_len;
+	pt_buf = calloc(1, pt_len);
+	if (!pt_buf) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+	pt_buf[0] = 0x04;
+
+	/* Right-align (big-endian pad) each coordinate */
+	mbedtls_mpi_write_binary(x, pt_buf + 1 + (coord_len - x_len), x_len);
+	mbedtls_mpi_write_binary(y, pt_buf + 1 + coord_len + (coord_len - y_len),
+				 y_len);
+
+	ret = mbedtls_ecp_point_read_binary(&grp, &Q, pt_buf, pt_len);
+	free(pt_buf);
+	if (ret) {
+		EMSG("ECDH: failed to read point (ret=%d)", ret);
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	ret = mbedtls_ecp_check_pubkey(&grp, &Q);
+	if (ret) {
+		EMSG("ECDH: invalid public key rejected (ret=%d)", ret);
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	EMSG("ECDH: peer public key validation passed");
+	res = TEE_SUCCESS;
+
+out:
+	mbedtls_ecp_point_free(&Q);
+	mbedtls_ecp_group_free(&grp);
+
+	return res;
+}
+
 static TEE_Result ecc_shared_secret(struct ecc_keypair *private_key,
 				    struct ecc_public_key *public_key,
 				    void *secret, unsigned long *secret_len)
@@ -454,6 +566,7 @@ err:
 static const struct crypto_ecc_public_ops ecc_public_key_ops = {
 	.free = ecc_free_public_key,
 	.verify = ecc_verify,
+	.validate_public_key = validate_ecdh_public_key,
 };
 
 static const struct crypto_ecc_public_ops sm2_pke_public_key_ops = {


### PR DESCRIPTION
This PR adds ECDH peer public key validation to prevent invalid-curve attacks in OP-TEE. 

**Problem:** Hardware accelerators like CAAM may not validate that peer public keys lie on the expected curve, making them vulnerable to attacks where crafted points on weaker curves can leak private keys.

**Solution:** 
- Extended the crypto API with an optional `validate_public_key` callback
- Implemented validation in libtomcrypt (using `ltc_ecc_verify_key`) and mbedTLS (using `mbedtls_ecp_check_pubkey`) backends
- Added validation at the TEE service layer before ECDH shared secret derivation

**Result:** All crypto backends (CAAM, libtomcrypt, mbedTLS) are now uniformly protected against invalid-curve attacks through centralized validation in `tee_svc_cryp.c`.