### PR TITLE
plat-mediatek: add arm smccc_trng support for mt798x series

### DIFF
--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -88,7 +88,8 @@ $(call force,CFG_TEE_CORE_NB_CORE,2)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_GIC,y)
-$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,n)
+$(call force,CFG_ARM_SMCCC_TRNG,y)
 CFG_TZDRAM_START ?= 0x43021000
 CFG_TZDRAM_SIZE ?=  0x04ff000
 CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
@@ -100,7 +101,8 @@ $(call force,CFG_TEE_CORE_NB_CORE,4)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_GIC,y)
-$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,n)
+$(call force,CFG_ARM_SMCCC_TRNG,y)
 CFG_TZDRAM_START ?= 0x43031000
 CFG_TZDRAM_SIZE ?=  0x04ff000
 CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
@@ -112,7 +114,8 @@ $(call force,CFG_TEE_CORE_NB_CORE,4)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_GIC,y)
-$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,n)
+$(call force,CFG_ARM_SMCCC_TRNG,y)
 CFG_TZDRAM_START ?= 0x4fa01000
 CFG_TZDRAM_SIZE ?=  0x04ff000
 CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
@@ -124,7 +127,8 @@ $(call force,CFG_TEE_CORE_NB_CORE,4)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_GIC,y)
-$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,n)
+$(call force,CFG_ARM_SMCCC_TRNG,y)
 CFG_TZDRAM_START ?= 0x43041000
 CFG_TZDRAM_SIZE ?=  0x04ff000
 CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))


### PR DESCRIPTION
Hi

I want to add smccc trng driver support for mediatek mt798x series

please use mediatek public ATF.
ref: https://github.com/mtk-openwrt/arm-trusted-firmware

Thanks !

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
