### PR TITLE
crypto: core: Remove ce_aes_ctr_encrypt() to fix AES-GCM compliance

### DIFF
--- a/core/arch/arm/crypto/aes-gcm-ce.c
+++ b/core/arch/arm/crypto/aes-gcm-ce.c
@@ -121,10 +121,24 @@ static void decrypt_pl(struct internal_aes_gcm_state *state,
 		       const struct internal_aes_gcm_key *ek, uint64_t dg[2],
 		       const uint8_t *src, size_t num_blocks, uint8_t *dst)
 {
+	void *buf_cryp = state->buf_cryp;
+	uint8_t src_tmp[TEE_AES_BLOCK_SIZE] = { 0 };
+
 	while (num_blocks) {
-		pmull_ghash_update(1, dg, src, &state->ghash_key, NULL);
-		ce_aes_ctr_encrypt(dst, src, (const uint8_t *)ek->data,
-				   ek->rounds, 1, (uint8_t *)state->ctr, 1);
+		/*
+		 * Copy from untrusted memory 'src' into a temporary buffer
+		 * to prevent a double-fetch vulnerability.
+		 */
+		memcpy(src_tmp, src, TEE_AES_BLOCK_SIZE);
+
+		pmull_ghash_update(1, dg, src_tmp, &state->ghash_key, NULL);
+
+		ce_aes_ecb_encrypt(buf_cryp, (const uint8_t *)state->ctr,
+				   (const uint8_t *)ek->data, ek->rounds,
+				   1, 1);
+		internal_aes_gcm_inc_ctr(state);
+
+		ce_aes_xor_block(dst, buf_cryp, src_tmp);
 
 		src += TEE_AES_BLOCK_SIZE;
 		dst += TEE_AES_BLOCK_SIZE;


### PR DESCRIPTION
AES-GCM (as per NIST SP 800-38D) specifically requires an Inc32 operation. This means only the least significant 32 bits are incremented modulo 2^32, and the increment must not carry over into the upper 96 bits.

Introduce ce_aes_gcm_ctr_encrypt() to implement this behavior instead of using the generic ce_aes_ctr_encrypt().

Add a test case for ARM64 to reproduce this issue 
https://github.com/OP-TEE/optee_test/pull/817

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
