### PR TITLE
ci: add Rockchip PX30 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
               _make PLATFORM=qcom-lemans
           - name: arm rockchip
             make_commands: |
+              _make PLATFORM=rockchip-px30
               _make PLATFORM=rockchip-rk322x
               _make PLATFORM=rockchip-rk3399
               _make PLATFORM=rockchip-rk3588


### PR DESCRIPTION
All other Arm-based Rockchip SoCs are built in CI, so let's add one build with PLATFORM=rockchip-px30.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
