### PR TITLE
ta: pkcs11: bound attribute reads in __trace_attributes()

### DIFF
--- a/ta/pkcs11/src/sanitize_object.c
+++ b/ta/pkcs11/src/sanitize_object.c
@@ -334,19 +334,38 @@ static void __trace_attributes(char *prefix, void *src, void *end)
 		uint8_t data[4] = { 0 };
 		uint32_t data_u32 = 0;
 		char *start = NULL;
+		size_t avail = 0;
+
+		/*
+		 * A malformed template (this helper is also called to dump a
+		 * rejected "bad-template") can leave @cur short of a full
+		 * attribute header before @end. Stop rather than read past the
+		 * client buffer.
+		 */
+		if ((size_t)((char *)end - cur) < sizeof(pkcs11_ref))
+			break;
 
 		TEE_MemMove(&pkcs11_ref, cur, sizeof(pkcs11_ref));
+
+		/*
+		 * Clamp every value read to the bytes actually present before
+		 * @end: pkcs11_ref.size is client-supplied and may point past
+		 * the buffer. data_u32 stays zero-padded when fewer than 4
+		 * bytes remain and is reused below as a bounded value source.
+		 */
+		avail = (size_t)((char *)end - (cur + sizeof(pkcs11_ref)));
 		TEE_MemMove(&data[0], cur + sizeof(pkcs11_ref),
-			    MIN(pkcs11_ref.size, sizeof(data)));
+			    MIN(MIN(pkcs11_ref.size, sizeof(data)), avail));
 		TEE_MemMove(&data_u32, cur + sizeof(pkcs11_ref),
-			    sizeof(data_u32));
+			    MIN(avail, sizeof(data_u32)));
 
 		next = sizeof(pkcs11_ref) + pkcs11_ref.size;
 
 		DMSG_RAW("%s Attr %s / %s (%#04"PRIx32" %"PRIu32"-byte)",
 			 prefix, id2str_attr(pkcs11_ref.id),
-			 id2str_attr_value(pkcs11_ref.id, pkcs11_ref.size,
-					   cur + sizeof(pkcs11_ref)),
+			 id2str_attr_value(pkcs11_ref.id,
+					   MIN(pkcs11_ref.size, avail),
+					   &data_u32),
 			 pkcs11_ref.id, pkcs11_ref.size);
 
 		switch (pkcs11_ref.size) {
@@ -378,8 +397,11 @@ static void __trace_attributes(char *prefix, void *src, void *end)
 		case PKCS11_CKA_UNWRAP_TEMPLATE:
 		case PKCS11_CKA_DERIVE_TEMPLATE:
 			start = cur + sizeof(pkcs11_ref);
-			trace_attributes_from_api_head(prefix2, start,
-						       (char *)end - start);
+			/* nested head must fit in the remaining window */
+			if (avail >= sizeof(struct pkcs11_object_head))
+				trace_attributes_from_api_head(prefix2, start,
+							       (char *)end -
+							       start);
 			break;
 		default:
 			break;


### PR DESCRIPTION
__trace_attributes() walks a client-supplied attribute array, advancing by the
client-controlled stride sizeof(pkcs11_attribute_head) + pkcs11_ref.size, and
reads each attribute value without bounding the access against the end of the
buffer. The unconditional 4-byte data_u32 read and the id2str_attr_value() read
at cur + sizeof(pkcs11_ref) run past the end of the heap-allocated client
template when the last attribute header is within a few bytes of the end. The
helper is reachable on the error path of sanitize_class_and_type() (it dumps a
rejected "bad-template"), so a malformed C_CreateObject template makes it
over-read; a KASAN build faults the TA.

This was reported privately and triaged as a normal hardening bug (no observable
security impact in a production build: the over-read stays within the mapped TA
heap and the bytes are never returned to the client). Submitting as a regular PR
as requested.

Require a full attribute header before each iteration, clamp the value reads to
the bytes remaining before end, read the traced value from the already-bounded
local copy instead of the raw buffer, and only recurse into the
WRAP/UNWRAP/DERIVE_TEMPLATE dump when a nested object head still fits.