### PR TITLE
core: ffa: do not assume manifest precedes OP-TEE image

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2015-2023, Linaro Limited
  * Copyright (c) 2023, Arm Limited
- * Copyright (c) 2025, NVIDIA Corporation & AFFILIATES.
+ * Copyright (c) 2025-2026, NVIDIA Corporation & AFFILIATES.
  */
 
 #include <arm.h>
@@ -1450,8 +1450,8 @@ void __weak boot_save_args(unsigned long a0, unsigned long a1,
 			}
 			assert((unsigned long)fdt >= base);
 			assert((unsigned long)fdt <= base + size);
-			assert((unsigned long)fdt < VCORE_START_VA);
-			fdt_max_size = VCORE_START_VA - (unsigned long)fdt;
+			fdt_max_size = fdt_totalsize(fdt);
+			assert(fdt_max_size < CFG_DTB_MAX_SIZE);
 		}
 		init_manifest_dt(fdt, fdt_max_size);
 	} else {


### PR DESCRIPTION
The manifest reservation logic assumes the FF-A manifest sits just below VCORE_START_VA, which only holds for the TF-A SP package layout used with Hafnium. Other SPMCs may place the manifest after the OP-TEE image, where assert(fdt < VCORE_START_VA) trips and fdt_max_size = VCORE_START_VA - fdt underflows.

Drop that assert and use fdt_totalsize() (clamped to CFG_DTB_MAX_SIZE) as the manifest's max size so the reservation works regardless of where the SPMC places the manifest within OP-TEE's secure memory.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
