### PR TITLE
drivers: serial8250: bound the TX-empty poll in flush()

### DIFF
--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -8,6 +8,7 @@
 #include <drivers/serial8250_uart.h>
 #include <io.h>
 #include <keep.h>
+#include <kernel/delay.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <util.h>
@@ -41,13 +42,22 @@ static vaddr_t chip_to_base(struct serial_chip *chip)
 static void serial8250_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
+#ifdef CFG_8250_UART_FLUSH_TIMEOUT
+	uint64_t expire = timeout_init_us(CFG_8250_UART_FLUSH_TIMEOUT_US);
+#endif
 
 	while (1) {
 		uint32_t state = io_read32(base + UART_LSR);
 
-		/* Wait until transmit FIFO is empty */
+		/* Wait until the transmit FIFO is empty */
 		if ((state & LSR_EMPTY) == LSR_EMPTY)
 			break;
+
+#ifdef CFG_8250_UART_FLUSH_TIMEOUT
+		/* Prevent blocking a CPU indefinitely if the UART is shared */
+		if (timeout_elapsed(expire))
+			break;
+#endif
 	}
 }
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1166,6 +1166,21 @@ CFG_WDT_SM_HANDLER_ID ?= 0x82003D06
 # the platform code
 CFG_CORE_HAS_GENERIC_TIMER ?= y
 
+# When enabled, serial8250_uart_flush() limits its wait for the TX FIFO to
+# drain with a generic-timer timeout instead of spinning forever. This avoids
+# blocking a CPU when the UART is shared with (and contended by) the non-secure
+# world, at the cost of possibly dropping output if the timeout cuts short. Left
+# disabled by default so the flush keeps its guarantee that a log point was
+# emitted, which is relied on when debugging. Requires CFG_CORE_HAS_GENERIC_TIMER.
+CFG_8250_UART_FLUSH_TIMEOUT ?= n
+$(eval $(call cfg-depends-all,CFG_8250_UART_FLUSH_TIMEOUT,CFG_CORE_HAS_GENERIC_TIMER))
+
+# Upper limit (in microseconds) on how long serial8250_uart_flush() waits for the
+# TX FIFO to drain when CFG_8250_UART_FLUSH_TIMEOUT=y. The default suits a 16-byte
+# FIFO at common baud rates; raise it for slow consoles where a full FIFO takes
+# longer to drain than this bound, otherwise output may be cut short.
+CFG_8250_UART_FLUSH_TIMEOUT_US ?= 10000
+
 # Enable RTC API
 CFG_DRIVERS_RTC ?= n
 


### PR DESCRIPTION
`serial8250_uart_flush()` waits for the UART transmit FIFO to drain by polling the line-status register in a 'while(1)'. It works when OP-TEE owns the UART, but it deadlocks when the UART is shared with the non-secure world.

Where OP-TEE and the OS share a UART — for example a platform whose single debug UART is both the OP-TEE console and the Linux console — the TX-empty status can stay clear indefinitely while the non-secure driver is trying to gain control of  the port. A console write issued from inside a secure call (e.g. an `IMSG` during a standard SMC) then spins forever, wedging that CPU: the non-secure scheduler can never run on it, the hard-lockup watchdog fires, and the system panics.

Bound the wait with the generic-timer timeout helper and drop the character on expiry rather than hang. Platforms that do not have `CFG_CORE_HAS_GENERIC_TIMER` keep the original behaviour, so nothing changes for them.

This is a generic fix rather than a platform one; I came across it bringing up a platform that shares its UART (RK3506), but it applies to any device with a shared UART configuration.

Tested on a RK3506B (Cortex-A7). It caused an intermittent hard lockup under xtest.