### PR TITLE
plat-rockchip: add support for RK3506

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
               _make PLATFORM=rockchip-px30
               _make PLATFORM=rockchip-rk322x
               _make PLATFORM=rockchip-rk3399
+              _make PLATFORM=rockchip-rk3506
               _make PLATFORM=rockchip-rk3576
               _make PLATFORM=rockchip-rk3588
           - name: arm sam

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -305,8 +305,14 @@ F:	core/arch/arm/plat-rzn1/
 
 Rockchip RK322X
 R:	Rockchip <op-tee@rock-chips.com>
+R:	Owen O'Hehir <electronicconsult1@gmail.com> [@OOHehir]
 S:	Maintained
 F:	core/arch/arm/plat-rockchip/
+
+Rockchip RK3506
+R:	Owen O'Hehir <electronicconsult1@gmail.com> [@OOHehir]
+S:	Maintained
+F:	core/arch/arm/plat-rockchip/*rk3506*
 
 Socionext DeveloperBox (Synquacer SC2A11)
 R:	Sumit Garg <sumit.garg@kernel.org> [@b49020]

--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -5,9 +5,12 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_8250_UART,y)
 
 CFG_DT ?= y
+ifeq ($(PLATFORM_FLAVOR),rk3506)
+# DTB sits in non-secure DRAM; map it secure (cf. UART0 in main.c).
+CFG_MAP_EXT_DT_SECURE ?= y
+endif
 CFG_WITH_STATS ?= y
 CFG_NUM_THREADS ?= 4
-CFG_EARLY_CONSOLE ?= n
 
 ifneq ($(PLATFORM_FLAVOR),rk322x)
 CFG_DTB_MAX_SIZE ?= 0x60000
@@ -58,6 +61,79 @@ CFG_SHMEM_START  ?= 0x32000000
 CFG_SHMEM_SIZE   ?= 0x00400000
 endif
 
+ifeq ($(PLATFORM_FLAVOR),rk3506)
+include ./core/arch/arm/cpu/cortex-a7.mk
+$(call force,CFG_TEE_CORE_NB_CORE,3)
+
+# SMP via the OP-TEE-provided ARM32 PSCI back end: the kernel DT uses
+# enable-method = "psci" / method = "smc", so OP-TEE implements CPU_ON
+# (psci_rk3506.c), as the upstream rk322x port does.
+# CFG_BOOT_SECONDARY_REQUEST exports boot_set_core_ns_entry() for it.
+$(call force,CFG_PSCI_ARM32,y)
+$(call force,CFG_BOOT_SECONDARY_REQUEST,y)
+
+# The RK3506B boot chain leaves CNTVOFF at its reset value; sm_init()
+# zeroes it (Monitor mode, SCR.NS=1) on every core via this option, so
+# the non-secure virtual counter starts aligned with the physical one.
+$(call force,CFG_INIT_CNTVOFF,y)
+
+# TZDRAM can start at a 4 KiB-aligned address, which the ARMv7
+# short-descriptor MMU (1 MiB sections) cannot describe; Cortex-A7
+# supports LPAE (4 KiB granularity).
+$(call force,CFG_WITH_LPAE,y)
+
+# CFG_CORE_ASLR is left at its global default (y, see mk/config.mk) for
+# security hardening; it is not required by this port. The early console
+# survives the MMU-enable transition via the standard io_pa_or_va()
+# remap of its MEM_AREA_IO_SEC mapping (see main.c), not via the ASLR
+# relocation path's console re-init.
+
+# Memory layout. Board = 512 MB DRAM at [0, 0x20000000).
+# CFG_RK3506_TEE_HW_ISOLATE selects the secure-RAM placement:
+#  - n (default): software isolated via reservation in DT, 32 MB.
+#    FW_DDR left open; the secure RAM kept off the NS world.
+#  - y: hardware isolated via FW_DDR slot-0, 16 MB.
+#    Requires matching U-Boot memory-map patch
+#    so the NS boot structures sit above the protected region.
+CFG_RK3506_TEE_HW_ISOLATE ?= n
+ifeq ($(CFG_RK3506_TEE_HW_ISOLATE),y)
+CFG_TZDRAM_START ?= 0x00001000
+CFG_TZDRAM_SIZE  ?= 0x01000000
+else
+CFG_TZDRAM_START ?= 0x18000000
+CFG_TZDRAM_SIZE  ?= 0x02000000
+endif
+
+# Register the full non-secure DRAM; OP-TEE carves the secure TEE_RAM
+# out of this range and accepts the remainder as non-secure.
+CFG_DRAM_BASE    ?= 0x00000000
+CFG_DRAM_SIZE    ?= 0x20000000
+
+# Non-secure entry = the FIT `uboot` load address (U-Boot proper is PIE
+# and self-relocates), so it must equal that load address. HW-isolate
+# places U-Boot clear of the protected low region.
+ifeq ($(CFG_RK3506_TEE_HW_ISOLATE),y)
+CFG_NS_ENTRY_ADDR ?= 0x01100000
+else
+CFG_NS_ENTRY_ADDR ?= 0x00400000
+endif
+
+# Shared memory, well clear of the early-boot low DRAM.
+CFG_SHMEM_START  ?= 0x10000000
+CFG_SHMEM_SIZE   ?= 0x00080000
+
+# Early console: UART0 (115200, 24 MHz xin), already clocked + muxed by
+# the SPL. This is the board debug console (U-Boot CONFIG_DEBUG_UART_BASE,
+# kernel earlycon uart8250,mmio32,0xff0a0000 and ttyFIQ0 / fiq-debugger
+# serial-id 0 all target UART0). The main.c console MEM_AREA mapping is
+# gated on it.
+CFG_EARLY_CONSOLE ?= y
+CFG_EARLY_CONSOLE_BASE ?= UART0_BASE
+CFG_EARLY_CONSOLE_SIZE ?= UART0_SIZE
+CFG_EARLY_CONSOLE_BAUDRATE ?= 115200
+CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
+endif
+
 ifeq ($(PLATFORM_FLAVOR),rk3588)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,8)
@@ -99,3 +175,6 @@ $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 ta-targets = ta_arm64
 endif
+
+# Default the early console off; flavors that need it (rk3506) enable it above.
+CFG_EARLY_CONSOLE ?= n

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -16,8 +16,21 @@
 
 #if defined(CFG_EARLY_CONSOLE)
 static struct serial8250_uart_data early_console_data;
+#if defined(PLATFORM_FLAVOR_rk3506)
+/*
+ * rk3506: map the early console UART secure (NS=0), not IO_NSEC. The
+ * system firewall rejects a secure master issuing a non-secure access
+ * to UART0 once the MMU is enabled (sync external abort), so the
+ * post-MMU mapping must keep the same secure attribute as the working
+ * pre-MMU access. OP-TEE owns the debug UART during bring-up, so a
+ * secure mapping is appropriate.
+ */
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			CFG_EARLY_CONSOLE_BASE, CFG_EARLY_CONSOLE_SIZE);
+#else
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC,
 			CFG_EARLY_CONSOLE_BASE, CFG_EARLY_CONSOLE_SIZE);
+#endif
 #endif
 
 #ifdef CFG_DRAM_BASE

--- a/core/arch/arm/plat-rockchip/pen_rk3506.S
+++ b/core/arch/arm/plat-rockchip/pen_rk3506.S
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2019, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2026, Owen O'Hehir
+ *
+ * RK3506B secondary-core boot pen.
+ *
+ * Ported in structure from the upstream BSD-3 ARM-TF plat/rockchip
+ * pmusram pen (common/aarch32/pmu_sram_cpus_on.S +
+ * common/pmusram/cpus_on_fixed_addr.S — the Rockchip "cpuson" model;
+ * rk3288 is the ARMv7 analogue).
+ *
+ * The BootROM releases a parked secondary to RK3506_PEN_PA (a 64 KiB-
+ * aligned IRAM slot). The pen long-jumps the core into OP-TEE
+ * (TEE_LOAD_ADDR), where the generic CFG_BOOT_SECONDARY_REQUEST path
+ * takes over.
+ *
+ * The blob is fully position-independent (MPIDR read, a PC-relative
+ * literal load that stays inside the copied blob, and a patched
+ * indirect branch — no relocations, no external literal pool) so
+ * psci_rk3506.c copies [rk3506_pen_start, rk3506_pen_end) verbatim into
+ * IRAM and patches the single trailing data word.
+ *
+ * Runs with MMU/caches OFF (BootROM context): all addresses are
+ * physical.
+ */
+
+	.section .text, "ax"
+	.arm
+	.balign 8
+	.globl rk3506_pen_start
+	.globl rk3506_pen_end
+
+/*
+ * ARM-TF cpuson per-core gate. The shared BootROM mailbox frees
+ * ALL secondaries at once (the first psci_cpu_on), so a core may
+ * arrive here before its own psci_cpu_on. It must therefore
+ * WFE-poll its own slot and only jump once psci_cpu_on(core) has set
+ * slot[core] = OP-TEE secondary entry PA. MMU/caches OFF; all
+ * addresses physical; fully position-independent (the trailing data
+ * word is patched by psci_rk3506.c after the blob is copied).
+ */
+rk3506_pen_start:
+	mrc	p15, 0, r0, c0, c0, 5	/* r0 = MPIDR */
+	and	r0, r0, #0xf		/* r0 = core index (Aff0) */
+	ldr	r2, rk3506_pen_slots	/* r2 = RK3506_SLOTS_PA (patched) */
+	add	r2, r2, r0, lsl #2	/* r2 = &slot[core] */
+1:
+	ldr	r3, [r2]		/* r3 = slot[core] */
+	cmp	r3, #0			/* set yet? */
+	wfeeq				/* no: wait for event (SEV) */
+	beq	1b			/* re-check after wake */
+	bx	r3			/* yes: -> OP-TEE secondary entry */
+
+	.balign 4
+rk3506_pen_slots:
+	.word	0			/* patched: RK3506_SLOTS_PA */
+rk3506_pen_end:

--- a/core/arch/arm/plat-rockchip/pen_rk3506.h
+++ b/core/arch/arm/plat-rockchip/pen_rk3506.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2026, Owen O'Hehir
+ *
+ * Symbols that psci_rk3506.c needs from the two assembly files: the
+ * secondary-CPU wait loop in pen_rk3506.S and the CPU power-down
+ * routine in plat_init_rk3506.S.
+ */
+
+#ifndef PLAT_ROCKCHIP_PEN_RK3506_H
+#define PLAT_ROCKCHIP_PEN_RK3506_H
+
+#include <compiler.h>
+#include <stdint.h>
+#include <types_ext.h>
+
+/*
+ * Start and end of the small wait loop in pen_rk3506.S. psci_rk3506.c
+ * copies the code between these symbols into IRAM, so it is written to
+ * run correctly from any address.
+ */
+extern const uint8_t rk3506_pen_start[];
+extern const uint8_t rk3506_pen_end[];
+
+/*
+ * Takes the calling CPU offline: turns off its MMU and sends it back to
+ * the wait loop. Defined in plat_init_rk3506.S.
+ */
+void __noreturn rk3506_cpu_down(vaddr_t pen_pa);
+
+#endif /* PLAT_ROCKCHIP_PEN_RK3506_H */

--- a/core/arch/arm/plat-rockchip/plat_init_rk3506.S
+++ b/core/arch/arm/plat-rockchip/plat_init_rk3506.S
@@ -1,0 +1,136 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Owen O'Hehir
+ *
+ * RK3506B-specific per-core early init (plat_cpu_reset_early).
+ *
+ * RK3506 runs OP-TEE as the highest-privilege secure monitor with no
+ * TF-A beneath it, so this performs the per-core CPU init that TF-A
+ * does on the AArch64 rockchip flavors (rk3399/px30/rk3588). The ARM32
+ * rk322x port is the minimal sibling (plat_init.S sets ACTLR.SMP only);
+ * rk3506's boot chain leaves more unprogrammed, so it does more.
+ *
+ * Notably, unlike rk322x (whose loader programs the architected-timer
+ * CNTFRQ before OP-TEE runs), the RK3506B boot chain leaves CNTFRQ at
+ * its reset default. Upstream OP-TEE's primary_save_cntfrq()
+ * (core/arch/arm/kernel/boot.c) reads CNTFRQ at primary-CPU boot time
+ * and stashes it for secondary CPUs; if it reads 0 the timer subsystem
+ * fails. Setting CNTFRQ here, before any C runtime, is the standard
+ * remedy. The value is 24 MHz (the xin24m crystal frequency).
+ */
+
+#include <asm.S>
+#include <arm.h>
+#include <arm32_macros.S>
+
+FUNC plat_cpu_reset_early , :
+	/*
+	 * 1) Program CNTFRQ_EL0 = 24 MHz (xin24m crystal). The
+	 *    architected-timer frequency register must be initialised by a
+	 *    higher exception level. On RK3506 we are it.
+	 */
+	mov_imm	r0, 0x016E3600	/* 24000000 = 24 MHz */
+	write_cntfrq r0
+
+	/*
+	 * 2) ACTLR.SMP — required for Cortex-A7 multi-core coherency
+	 *    (Cortex-A7 ARM TRM "Auxiliary Control Register" section).
+	 */
+	read_actlr  r0
+	orr	r0, r0, #ACTLR_SMP
+	write_actlr r0
+
+	/*
+	 * 3) NSACR — grant the non-secure world access to CP10/CP11
+	 *    (FPU/NEON; without these, NS use of FPU/NEON traps to Undef)
+	 *    and to NSACR.NS_SMP (bit 18), which permits the non-secure
+	 *    world to set ACTLR.SMP for cache coherency on its cores.
+	 *    (Bit definitions in core/arch/arm/include/arm32.h.)
+	 */
+	read_nsacr r0
+	orr	r0, r0, #NSACR_CP10	/* NS FPU            */
+	orr	r0, r0, #NSACR_CP11	/* NS NEON           */
+	orr	r0, r0, #NSACR_NS_SMP	/* NS ACTLR.SMP write */
+	write_nsacr r0
+
+	/*
+	 * 4) Clear SCTLR.V — use VBAR-based vector base rather than the
+	 *    high-vector default 0xffff0000 (ARMv7-A ARM "System Control
+	 *    Register" §B4.1.130). Upstream OP-TEE installs its own
+	 *    VBAR shortly, so V must be 0 for VBAR to be effective.
+	 */
+	read_sctlr r0
+	bic	r0, r0, #SCTLR_V
+	write_sctlr r0
+
+	/*
+	 * 5) Enter Monitor mode with SCR.NS = 1 so the non-secure banked
+	 *    SCTLR is reachable for the clear below. CNTVOFF is zeroed by
+	 *    sm_init() (CFG_INIT_CNTVOFF), so it is not done here.
+	 */
+	cps	#CPSR_MODE_MON		/* enter Monitor mode */
+	read_scr r0
+	orr	r0, r0, #SCR_NS		/* set NS bit */
+	write_scr r0
+	isb
+
+	/*
+	 * With SCR.NS=1, SCTLR refers to the non-secure banked copy. Clear
+	 * NS MMU + caches (M/C/I) so a core entering the non-secure world
+	 * does so MMU-off, as the kernel's physical secondary entry expects.
+	 * A fresh-from-BootROM core already has these clear (no-op); a core
+	 * that ran Linux and was offlined via PSCI CPU_OFF would otherwise
+	 * re-enter NS with a stale NS MMU enabled and the kernel's secondary
+	 * bring-up would fault on the old page tables.
+	 */
+	read_sctlr r2
+	bic	r2, r2, #(SCTLR_M | SCTLR_C)
+	bic	r2, r2, #SCTLR_I
+	write_sctlr r2
+	isb
+
+	read_scr r0
+	bic	r0, r0, #SCR_NS		/* clear NS bit */
+	write_scr r0
+	isb
+	cps	#CPSR_MODE_SVC		/* back to Secure SVC */
+
+	bx	lr
+END_FUNC plat_cpu_reset_early
+
+/*
+ * void __noreturn rk3506_cpu_down(vaddr_t pen_pa);
+ *
+ * Hand a secondary core back from OP-TEE (MMU on) to the BootROM pen so it
+ * re-parks in WFE on its per-core slot, ready for the next psci_cpu_on() to
+ * release it as at cold boot. The caller (psci_cpu_off) has already cleared
+ * slot[core], cleaned and disabled the D-cache, and exited SMP coherency.
+ *
+ * Placed in .identity_map so virtual == physical across the MMU disable: once
+ * SCTLR.M is cleared the core fetches from physical addresses, and the branch
+ * target pen_pa is physical. psci_cpu_off() enters this routine through its
+ * physical address, so it runs at VA==PA regardless of CFG_CORE_ASLR.
+ *
+ *	r0 = pen_pa (physical pen entry)
+ */
+FUNC rk3506_cpu_down , : , .identity_map
+	dsb
+	isb
+
+	/* Disable MMU and I-cache (D-cache already off from cpu_off). */
+	read_sctlr r1
+	bic	r1, r1, #(SCTLR_M | SCTLR_C)
+	bic	r1, r1, #SCTLR_I
+	write_sctlr r1
+	isb
+
+	/* MMU now off: flush TLB, I-cache and branch predictor. */
+	write_tlbiall
+	write_iciallu
+	write_bpiall
+	dsb
+	isb
+
+	/* Re-enter the pen; it WFE-polls slot[core] (now 0) until cpu_on. */
+	bx	r0
+END_FUNC rk3506_cpu_down

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -86,6 +86,63 @@
 #define FIREWALL_DDR_BASE	0xff534000
 #define FIREWALL_DDR_SIZE	SIZE_K(16)
 
+#elif defined(PLATFORM_FLAVOR_rk3506)
+
+/*
+ * RK3506B: Cortex-A7 x3, ARMv7-A, GICv2 (gic-400). DRAM at 0x0; the
+ * U-Boot FIT loads tee.bin at CFG_TZDRAM_START (0x18000000 default,
+ * 0x1000 with CFG_RK3506_TEE_HW_ISOLATE).
+ */
+
+#define GIC_BASE		0xff580000
+#define GIC_SIZE		SIZE_K(64)
+#define GICD_BASE		(GIC_BASE + 0x1000)
+#define GICC_BASE		(GIC_BASE + 0x2000)
+
+#define UART0_BASE		0xff0a0000
+#define UART0_SIZE		SIZE_K(64)
+
+/*
+ * Internal SRAM (48 KB) at 0xfff80000.
+ *
+ * The BootROM parks the secondary cores in a WFE spin on a shared SRAM
+ * mailbox at IRAM_BASE (flag word +0x04 polled for 0xdeadbeaf, entry
+ * word +0x08). To release a core, write the pen PA to the entry word,
+ * the magic to the flag word, then SEV. The pen and the per-core gate
+ * slots sit clear of the mailbox stub (IRAM_BASE..+0x0f) and of each
+ * other. See psci_rk3506.c / pen_rk3506.S.
+ */
+#define IRAM_BASE		0xfff80000
+#define IRAM_SIZE		SIZE_K(48)
+/* BootROM mailbox words (BootROM-defined; do not relocate). */
+#define RK3506_BROM_FLAG_PA	(IRAM_BASE + 0x04)	/* poll word */
+#define RK3506_BROM_ENTRY_PA	(IRAM_BASE + 0x08)	/* entry PA  */
+#define RK3506_BROM_MAGIC	0xdeadbeafu		/* release   */
+#define RK3506_PEN_PA		(IRAM_BASE + 0x0800)
+#define RK3506_SLOTS_PA		(IRAM_BASE + 0x0d00)
+
+/*
+ * System firewall / SGRF "slave-security" block at 0xff210000.
+ * Programmed by platform_secure_init() with the rk322x SLAVE_ALL_NS
+ * masked-write idiom to make peripherals (notably the UART0 console)
+ * non-secure-accessible; without it the NS world's first UART0 access
+ * external-aborts.
+ */
+#define FIREWALL_SYS_BASE	0xff210000
+#define FIREWALL_SYS_SIZE	SIZE_K(64)
+
+/*
+ * DDR firewall (FW_DDR) at 0xff5f0000. Register layout:
+ *   +0x00.. : region-map regs (128 KB granule, 0x7fff field encoding)
+ *   +0x20.. : per-master access regs (0xffffffff = NS-allow)
+ *   +0x30   : access reg (low byte significant)
+ *   +0x40   : control/enable reg, bit N = region N enable
+ * Field encodings follow the BSD-2 OP-TEE px30/rk3588 ports. See
+ * platform_rk3506.c.
+ */
+#define FIREWALL_DDR_BASE	0xff5f0000
+#define FIREWALL_DDR_SIZE	SIZE_K(64)
+
 #elif defined(PLATFORM_FLAVOR_rk3588)
 
 #define GIC_BASE		0xfe600000

--- a/core/arch/arm/plat-rockchip/platform_rk3506.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3506.c
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2026, Owen O'Hehir
+ *
+ * RK3506B DDR-firewall (FW_DDR) and system-firewall (SGRF) setup.
+ *
+ * Code structure follows the upstream BSD-2 rk3399/rk3588/px30
+ * platform_secure_*() implementations.
+ *
+ * platform_secure_init() opens the SGRF so the non-secure world can
+ * reach its peripherals (notably the UART0 console); without it the
+ * first NS UART0 access external-aborts after the hand-off to U-Boot.
+ *
+ * platform_secure_ddr_region(): with CFG_RK3506_TEE_HW_ISOLATE the
+ * FW_DDR slot-0 region HW-isolates a low-DRAM TEE_RAM from the
+ * non-secure Cortex-A7 (the firewall only covers low DRAM); otherwise
+ * it opens DRAM and the TEE relies on the kernel-DT no-map reservation.
+ */
+
+#include <assert.h>
+#include <common.h>
+#include <io.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform.h>
+#include <platform_config.h>
+#include <trace.h>
+#include <util.h>
+
+/*
+ * FW_DDR register offsets (relative to FIREWALL_DDR_BASE). The region
+ * slots and the 0x7fff field encoding follow the BSD-2 OP-TEE rk3588
+ * port; the per-master access regs and the control reg follow the
+ * BSD-2 px30 port.
+ */
+#define FW_DDR_RGN(i)		((i) * 0x4)		/* region slots 0..7 */
+#define FW_DDR_ACC(i)		(0x20 + ((i) * 0x4))	/* per-master, i=0..3 */
+#define FW_DDR_ACC_X		0x30
+#define FW_DDR_CON		0x40
+
+#define FW_DDR_ACC_ALL		U(0xffffffff)
+#define FW_DDR_ACC_X_NSMASK	U(0xff)
+
+/*
+ * FW_DDR region slot value (128 KB-granule, 15-bit fields):
+ *	val = (base / 128K) | (((size / 128K) - 1) << 16), each field masked
+ *	to 15 bits (the hardware 0x7fff field width).
+ */
+#define FW_DDR_RG_128K(base, size) \
+	((((base) / SIZE_K(128)) & GENMASK_32(14, 0)) | \
+	 (((((size) / SIZE_K(128)) - 1) & GENMASK_32(14, 0)) << 16))
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, FIREWALL_DDR_BASE,
+			FIREWALL_DDR_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, FIREWALL_SYS_BASE,
+			FIREWALL_SYS_SIZE);
+
+/*
+ * Open the SGRF gates to the non-secure world so it can reach UART0 and
+ * the rest of the peripherals it owns.
+ *
+ * Slave-security CON block: Rockchip masked-write semantics - hi16 =
+ * per-bit write-enable, lo16 = value; a slave's bit set under the write
+ * mask = secure. SLAVE_ALL_NS (0xffff0000) enables all 16 bits to 0 =
+ * all slaves non-secure - the public upstream idiom, identical to
+ * plat-rk322x platform_secure_init().
+ *
+ * The two extra gates at +0x140/+0x144 (the secure_conf region, DT
+ * secure_conf = <0xff210100> = base + 0x100) are opened all-ways; the
+ * slave-CON config alone leaves UART0 inaccessible to NS on this
+ * silicon, so they are required.
+ */
+#define SLAVE_ALL_NS		GENMASK_32(31, 16)
+#define SGRF_GATE_OPEN_FULL	U(0xffffffff)
+
+static const uint32_t rk3506_sgrf_slave_con[] = {
+	0x020, 0x024, 0x028, 0x02c, 0x030, 0x034, 0x038, 0x03c,
+	0x040, 0x044, 0x048, 0x04c,
+};
+
+static const uint32_t rk3506_sgrf_extra_open[] = { 0x140, 0x144 };
+
+int platform_secure_init(void)
+{
+	vaddr_t fw = (vaddr_t)phys_to_virt_io(FIREWALL_SYS_BASE,
+					      FIREWALL_SYS_SIZE);
+	size_t i = 0;
+
+	if (!fw)
+		panic();
+
+	MSG("rk3506 SGRF: opening all slaves non-secure (UART0 etc.)");
+
+	for (i = 0; i < ARRAY_SIZE(rk3506_sgrf_slave_con); i++)
+		io_write32(fw + rk3506_sgrf_slave_con[i], SLAVE_ALL_NS);
+
+	for (i = 0; i < ARRAY_SIZE(rk3506_sgrf_extra_open); i++)
+		io_write32(fw + rk3506_sgrf_extra_open[i], SGRF_GATE_OPEN_FULL);
+
+	return 0;
+}
+
+int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
+{
+	vaddr_t fw = (vaddr_t)phys_to_virt_io(FIREWALL_DDR_BASE,
+					      FIREWALL_DDR_SIZE);
+	unsigned int i = 0;
+
+	if (!fw)
+		panic();
+
+	/*
+	 * The generic rockchip caller requests region slot 1 (platform.c).
+	 * This port instead programs a single low-DRAM region in FW_DDR
+	 * slot 0 (see the HW-isolate note below) and does not use the
+	 * caller's slot selector. Assert the expected request so an
+	 * unexpected caller is caught in debug builds.
+	 */
+	assert(rgn == 1);
+
+	/*
+	 * Start from a known-empty firewall. On RK3506 the enable register
+	 * (FW_DDR_CON) is re-derived from the region *definitions* on every
+	 * access-permit write below, so clearing the enable alone is not
+	 * enough: a region left defined+enabled by the upstream DDR-init
+	 * stage (some boards hand over with region 0 covering all of DRAM)
+	 * would be re-armed by the master-permit writes and lock the normal
+	 * world out of DRAM. Clear the region definitions too so the result
+	 * is independent of the prior stage's firewall state.
+	 */
+	for (i = 0; i < 8; i++)
+		io_write32(fw + FW_DDR_RGN(i), 0);
+	io_write32(fw + FW_DDR_CON, 0);
+
+	if (IS_ENABLED(CFG_RK3506_TEE_HW_ISOLATE)) {
+		/*
+		 * HW-isolate the TEE region.
+		 *
+		 * The FW_DDR only gates the NS Cortex-A7 for regions in low
+		 * DRAM; a high placement such as 0x18000000 is outside its
+		 * coverage and is never enforced. This path therefore keeps
+		 * TEE_RAM low (CFG_TZDRAM_START, near the bottom of DRAM but
+		 * clear of PA 0, which the boot chain uses) and secures it via
+		 * slot 0. Latch RGN -> CON before opening the masters (an
+		 * unlatched region is clobbered by a master write); NS reads of
+		 * the protected window then abort.
+		 *
+		 * The slot encodes base and size in 128 KB units (size as
+		 * size/128K - 1); see FW_DDR_RG_128K(). This is an opt-in path
+		 * that must be paired with a boot loader whose non-secure
+		 * memory map sits clear of the protected low region.
+		 */
+		assert(sz);
+		assert(st / SIZE_M(1) == 0); /* low-DRAM coverage */
+		MSG("rk3506 FW_DDR: HW-isolating TEE [0x%" PRIxPA
+		    ",0x%" PRIxPA ")", st, st + sz);
+		io_write32(fw + FW_DDR_RGN(0), FW_DDR_RG_128K(st, sz));
+		io_setbits32(fw + FW_DDR_CON, BIT(0));
+	} else {
+		MSG("rk3506 FW_DDR: opening NS DRAM (TEE 0x%" PRIxPA
+		    "-0x%" PRIxPA ")", st, st + sz);
+	}
+
+	/*
+	 * Permit all masters / NS access across the rest of DRAM so the NS
+	 * world runs; any latched secure region above overrides this.
+	 */
+	for (i = 0; i < 4; i++)
+		io_write32(fw + FW_DDR_ACC(i), FW_DDR_ACC_ALL);
+
+	io_setbits32(fw + FW_DDR_ACC_X, FW_DDR_ACC_X_NSMASK);
+
+	return 0;
+}

--- a/core/arch/arm/plat-rockchip/psci_rk3506.c
+++ b/core/arch/arm/plat-rockchip/psci_rk3506.c
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2026, Owen O'Hehir
+ *
+ * RK3506B PSCI back end.
+ *
+ * Secondary-core release follows the Rockchip "cpuson" model, ported in
+ * structure from the BSD-3-Clause TF-A plat/rockchip pmusram pen (rk3288
+ * is the ARMv7 analogue). The BootROM parks the secondaries in a WFE
+ * spin polling a shared SRAM mailbox at IRAM_BASE:
+ *
+ *	while (*(uint32_t *)(IRAM_BASE + 0x04) != 0xdeadbeaf)
+ *		wfe();
+ *	pc = *(uint32_t *)(IRAM_BASE + 0x08);
+ *
+ * We install a small position-independent pen (pen_rk3506.S) at a
+ * 64 KiB-aligned SRAM slot and point the mailbox entry word at it. The
+ * first psci_cpu_on() releases all parked secondaries into the pen; each
+ * core then WFE-polls its own per-core slot and only long-jumps into
+ * OP-TEE (TEE_LOAD_ADDR) once psci_cpu_on(core) has set slot[core]. From
+ * there the generic CFG_BOOT_SECONDARY_REQUEST path bounces it to the
+ * non-secure entry. No PMU power-on or CRU soft-reset is needed: the
+ * secondaries are already powered and running the BootROM spin.
+ *
+ * The cpuson pen structure is from BSD-3 TF-A plat/rockchip.
+ */
+
+#include <arm.h>
+#include <assert.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <sm/optee_smc.h>
+#include <sm/psci.h>
+#include <stdint.h>
+#include <tee/entry_fast.h>
+#include <tee/entry_std.h>
+
+#include "pen_rk3506.h"
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, IRAM_BASE, IRAM_SIZE);
+
+/*
+ * Software online-core tracking for psci_affinity_info(). Mutated by
+ * psci_cpu_on() (boot CPU) and psci_cpu_off() (the core going down), so
+ * the read-modify-writes are serialised by a spinlock.
+ */
+static uint32_t online_cores = BIT(0);
+static unsigned int online_cores_lock = SPINLOCK_UNLOCK;
+
+static vaddr_t iram_va(void)
+{
+	return (vaddr_t)phys_to_virt_io(IRAM_BASE, IRAM_SIZE);
+}
+
+/*
+ * Install the pen into IRAM. Runs once on the boot CPU (MMU up) before
+ * any PSCI CPU_ON. The blob is copied verbatim and its single trailing
+ * data word is patched with the per-core slot-table PA; the pen
+ * WFE-polls slot[core] and psci_cpu_on(core) sets it to release a core.
+ */
+static TEE_Result rk3506_pen_install(void)
+{
+	vaddr_t iram = iram_va();
+	size_t len = (size_t)(rk3506_pen_end - rk3506_pen_start);
+	vaddr_t pen = iram + (RK3506_PEN_PA - IRAM_BASE);
+	vaddr_t slots = iram + (RK3506_SLOTS_PA - IRAM_BASE);
+	size_t i = 0;
+
+	if (!iram)
+		panic("rk3506: IRAM not mapped");
+	assert(len >= 8 && len <= 256 && !(len % 4));
+
+	/*
+	 * IRAM is mapped MEM_AREA_IO_SEC, i.e. Device-nGnRE. memcpy()/memset()
+	 * may emit unaligned or multi-word (LDM/STM) accesses, which to Device
+	 * memory are CONSTRAINED UNPREDICTABLE on ARMv7-A; copy/clear with
+	 * explicit aligned word stores instead. The pen blob is word-aligned
+	 * (.balign 8) and a whole number of words.
+	 */
+	for (i = 0; i < len; i += 4)
+		io_write32(pen + i, get_le32(rk3506_pen_start + i));
+	io_write32(pen + len - 4, RK3506_SLOTS_PA);
+
+	/* Clear the per-core gate slots (0 = "not yet released"). */
+	for (i = 0; i < CFG_TEE_CORE_NB_CORE; i++)
+		io_write32(slots + i * 4, 0);
+
+	/* Device-mapped stores reach SRAM directly; no cache maintenance. */
+	dsb();
+
+	DMSG("rk3506: secondary-core pen installed at 0x%x (%zu bytes)",
+	     RK3506_PEN_PA, len);
+	return TEE_SUCCESS;
+}
+
+service_init_late(rk3506_pen_install);
+
+uint32_t psci_version(void)
+{
+	return PSCI_VERSION_1_0;
+}
+
+int psci_features(uint32_t psci_fid)
+{
+	switch (psci_fid) {
+	case PSCI_PSCI_FEATURES:
+	case PSCI_VERSION:
+	case PSCI_CPU_ON:
+	case PSCI_CPU_OFF:
+	case PSCI_AFFINITY_INFO:
+		return PSCI_RET_SUCCESS;
+	default:
+		return PSCI_RET_NOT_SUPPORTED;
+	}
+}
+
+int psci_cpu_on(uint32_t core_idx, uint32_t entry, uint32_t context_id)
+{
+	uint32_t core = core_idx & MPIDR_CPU_MASK;
+	vaddr_t iram = iram_va();
+
+	if (core == 0 || core >= CFG_TEE_CORE_NB_CORE)
+		return PSCI_RET_INVALID_PARAMETERS;
+	if (!iram)
+		return PSCI_RET_INTERNAL_FAILURE;
+
+	/*
+	 * Reject a redundant CPU_ON for an already-online core before
+	 * touching any shared HW. Claim the core under the lock so a
+	 * concurrent call for the same core loses the race cleanly.
+	 */
+	cpu_spin_lock(&online_cores_lock);
+	if (online_cores & BIT(core)) {
+		cpu_spin_unlock(&online_cores_lock);
+		return PSCI_RET_ALREADY_ON;
+	}
+	online_cores |= BIT(core);
+	cpu_spin_unlock(&online_cores_lock);
+
+	/* Generic OP-TEE secondary path: where to bounce to NS. */
+	boot_set_core_ns_entry(core, entry, context_id);
+
+	/*
+	 * Release this core: set slot[core] so the pen jumps it into
+	 * OP-TEE, (re-)arm the shared BootROM mailbox, then SEV to wake
+	 * both the BootROM WFE (first call) and the pen's per-core WFE.
+	 * Runtime + SRAM-only, so it cannot disturb the non-secure boot.
+	 */
+	io_write32(iram + (RK3506_SLOTS_PA - IRAM_BASE) + core * 4,
+		   TEE_LOAD_ADDR);
+	dsb();
+	io_write32(iram + (RK3506_BROM_ENTRY_PA - IRAM_BASE), RK3506_PEN_PA);
+	io_write32(iram + (RK3506_BROM_FLAG_PA - IRAM_BASE), RK3506_BROM_MAGIC);
+	dsb();
+	sev();
+	dsb();
+
+	DMSG("core %" PRIu32 " released (ns_entry 0x%" PRIx32 ")", core, entry);
+
+	return PSCI_RET_SUCCESS;
+}
+
+int psci_cpu_off(void)
+{
+	uint32_t core = get_core_pos();
+	vaddr_t iram = iram_va();
+	void (*cpu_down)(vaddr_t pen);
+	paddr_t down_pa = 0;
+
+	if (core == 0 || core >= CFG_TEE_CORE_NB_CORE)
+		return PSCI_RET_INVALID_PARAMETERS;
+	if (!iram)
+		return PSCI_RET_INTERNAL_FAILURE;
+
+	/*
+	 * Resolve the physical entry of the down-path now, while the MMU and
+	 * caches are still up. rk3506_cpu_down() disables the MMU, so it must
+	 * execute where VA==PA: it lives in the .identity_map region, which the
+	 * core page tables map flat, and entering it via that physical address
+	 * keeps the PC valid across the MMU disable under CFG_CORE_ASLR.
+	 */
+	down_pa = virt_to_phys((void *)(vaddr_t)rk3506_cpu_down);
+	if (!down_pa)
+		return PSCI_RET_INTERNAL_FAILURE;
+	cpu_down = (void (*)(vaddr_t))(vaddr_t)down_pa;
+
+	DMSG("core %" PRIu32, core);
+
+	/*
+	 * Clear our gate slot so that, once the core re-enters the pen, it
+	 * parks in the pen's WFE loop instead of jumping back into OP-TEE. The
+	 * slot is in Device-mapped IRAM, so the store reaches SRAM directly.
+	 */
+	io_write32(iram + (RK3506_SLOTS_PA - IRAM_BASE) + core * 4, 0);
+	dsb();
+
+	cpu_spin_lock(&online_cores_lock);
+	online_cores &= ~BIT(core);
+	cpu_spin_unlock(&online_cores_lock);
+
+	/* Clean+disable the D-cache and exit SMP coherency, then re-park. */
+	psci_armv7_cpu_off();
+	thread_mask_exceptions(THREAD_EXCP_ALL);
+	cpu_down(RK3506_PEN_PA);
+
+	return PSCI_RET_INTERNAL_FAILURE;
+}
+
+int psci_affinity_info(uint32_t affinity,
+		       uint32_t lowest_affinity_level __unused)
+{
+	uint32_t core = affinity & MPIDR_CPU_MASK;
+	uint32_t on = 0;
+
+	if (core >= CFG_TEE_CORE_NB_CORE)
+		return PSCI_AFFINITY_LEVEL_OFF;
+
+	cpu_spin_lock(&online_cores_lock);
+	on = online_cores & BIT(core);
+	cpu_spin_unlock(&online_cores_lock);
+
+	return on ? PSCI_AFFINITY_LEVEL_ON : PSCI_AFFINITY_LEVEL_OFF;
+}

--- a/core/arch/arm/plat-rockchip/sub.mk
+++ b/core/arch/arm/plat-rockchip/sub.mk
@@ -4,6 +4,7 @@ srcs-y += platform.c
 srcs-$(PLATFORM_FLAVOR_px30) += platform_px30.c
 srcs-$(PLATFORM_FLAVOR_rk322x) += platform_rk322x.c
 srcs-$(PLATFORM_FLAVOR_rk3399) += platform_rk3399.c
+srcs-$(PLATFORM_FLAVOR_rk3506) += platform_rk3506.c
 srcs-$(PLATFORM_FLAVOR_rk3576) += platform_rk3576.c
 srcs-$(PLATFORM_FLAVOR_rk3588) += platform_rk3588.c
 
@@ -11,4 +12,17 @@ ifeq ($(PLATFORM_FLAVOR),rk322x)
 srcs-y += plat_init.S
 srcs-y += core_pos_a32.S
 srcs-$(CFG_PSCI_ARM32) += psci_rk322x.c
+endif
+
+ifeq ($(PLATFORM_FLAVOR),rk3506)
+# rk3506-specific plat_init programs CNTFRQ_EL0 (the RK3506 boot chain
+# leaves it at its reset default) in addition to ACTLR.SMP; see the file
+# header in plat_init_rk3506.S. core_pos_a32.S is reused from rk322x
+# (same Rockchip 0xf0X MPIDR layout).
+srcs-y += plat_init_rk3506.S
+srcs-y += core_pos_a32.S
+# PSCI back end (psci_rk3506.c) + position-independent secondary-core
+# boot pen (pen_rk3506.S, copied into IRAM at init).
+srcs-$(CFG_PSCI_ARM32) += psci_rk3506.c
+srcs-$(CFG_PSCI_ARM32) += pen_rk3506.S
 endif


### PR DESCRIPTION
# plat-rockchip: add support for the RK3506B

This platform RK3506B, a triple Cortex-A7. There is no ARM Trusted Firmware on this part, so OP-TEE comes up as the secure monitor itself and hands off to a non-secure U-Boot and Linux.

As I went along in this effort I tried to record where I got individual register values if a reviewer requires any please let me know.

Note: This port depends on serial8250 submitted separately (#7847).

## What the port provides

- Secure-monitor bring-up and hand-off to a non-secure U-Boot and Linux (`main.c`, `plat_init_rk3506.S`). The early init programs `CNTFRQ` (24 MHz xin24m) and the NSACR bits, since nothing runs beneath OP-TEE to do so.
- PSCI 1.0 (`CPU_ON`/`CPU_OFF`, `SYSTEM_RESET`/`SYSTEM_OFF`) bringing all three Cortex-A7 cores online (`psci_rk3506.c`, `pen_rk3506.S`). Secondaries are released through a small position-independent BootROM pen, and `CPU_OFF`/`CPU_ON` hotplug works by recycling that pen. The cpuson model is ported from the BSD-3 ARM Trusted Firmware `plat/rockchip` code, which is the one attribution that stays in-tree.
- System-firewall (SGRF) and DDR-firewall (FW_DDR) setup (`platform_rk3506.c`). The SGRF setup is what makes the non-secure UART0 console reachable after hand-off. FW_DDR optionally hardware-isolates the secure RAM from the non-secure Cortex-A7, behind `CFG_RK3506_TEE_HW_ISOLATE`.
- Device-tree consumption (`CFG_DT=y`). OP-TEE reads the DTB that U-Boot hands over and patches in the standard `/firmware/optee` and PSCI nodes for the non-secure world. Because the DTB lives in non-secure DRAM and the system firewall rejects a secure-master non-secure access to it, the DTB is mapped secure (`CFG_MAP_EXT_DT_SECURE`) — the same treatment the UART0 console already needs. (This may be of interest given the recent move to disable `SPL_ATF_NO_PLATFORM_PARAM` for Rockchip: on RK3506 the DT does reach OP-TEE.)
- Wiring into the build and CI (`sub.mk`, `.github/workflows/ci.yml`) and a `MAINTAINERS` entry.

## Memory map

The board has 512 MB of DRAM based at physical address 0.

- By default the secure RAM sits at `0x18000000` (32 MB), above where U-Boot loads the kernel, initrd and FDT. FW_DDR is left open and the kernel device tree's `no-map` reservation is what keeps Linux off it — software isolation.
- With `CFG_RK3506_TEE_HW_ISOLATE=y` the secure RAM moves low, to `0x1000` (16 MB), and FW_DDR slot 0 hardware-isolates `[0, 16M)` from the non-secure Cortex-A7. This variant needs the matching U-Boot memory-map change so the non-secure boot structures sit clear of the protected region.

## Fuses
This is the standard developer build (CFG_INSECURE=y), so the usual WARNING (insecure configuration) is printed at boot. There's no device-unique HUK and no RPMB, so secure storage is integrity-checked but not confidential or rollback-protected. Turning either on means burning fuses, the RPMB key into eMMC — and I'd rather keep my board as is. I think a reasonable for an initial port.

## Testing

Validated on two boards, covering both isolation modes, with a full `xtest` run from a booted Linux on each:

- **Luckfox Core3506**, non-isolate (`CFG_DT=y`): boots through OP-TEE to Linux, `nproc = 3`, and a full `xtest` run gives **35544 subtests, 1 failed**. The failure is `regression_1033`, a test-packaging gap in the bench rootfs (a tee-supplicant plugin not installed), not anything in the port.
- **Luckfox Lyra Ultra**, HW-isolate (`CFG_RK3506_TEE_HW_ISOLATE=y`): the same full `xtest` result, plus the FW_DDR isolation is confirmed enforcing — a non-secure read of the protected window aborts while xtest still passes, so the region is neither under- nor over-protecting. CPU hotplug (`CPU_OFF`/`CPU_ON`) was exercised across repeated cycles, and the open port was confirmed a drop-in replacement for the vendor blob.

Both build configurations compile cleanly (`PLATFORM=rockchip-rk3506`, with and without `CFG_RK3506_TEE_HW_ISOLATE=y`), and checkpatch is clean apart from two `externs should be avoided` warnings on the pen-blob symbols, which are defined in the accompanying `.S` and necessarily declared in the `.c`.

<details><summary>Boot + xtest log (Core3506, non-isolate, CFG_DT=y)</summary>

```
Jumping to U-Boot(0x00400000) via OP-TEE(0x18000000)
I/TC: Non-secure external DT found
I/TC: OP-TEE version: 4.10.0-123-geddd607c3 (gcc version 13.4.0 (GCC)) #1 Wed Jun 17 18:00:08 UTC 2026 arm
I/TC: Primary CPU initializing
I/TC: Primary CPU switching to normal world boot
Starting kernel ...
[    5.456926] optee: revision 4.10 (eddd607c)
[    5.511341] optee: initialized driver
...
foxbridge login: root
root@foxbridge:~# nproc
3
root@foxbridge:~# ls -l /dev/tee*
crw-------    1 root     root      247,   0 /dev/tee0
crw-------    1 root     root      247,  16 /dev/teepriv0
root@foxbridge:~# xtest
...
35544 subtests of which 1 failed
112 test cases of which 1 failed
```
</details>
