### PR TITLE
plat-rcar: add initial support to Rcar Gen5 ironhide_x5h

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -10,7 +10,9 @@ $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_LPAE,y)
 
-ifeq ($(PLATFORM_FLAVOR), spider_s4)
+ifeq ($(PLATFORM_FLAVOR), ironhide_x5h)
+$(call force,CFG_RCAR_GEN5, y)
+else ifeq ($(PLATFORM_FLAVOR), spider_s4)
 $(call force,CFG_RCAR_GEN4, y)
 else
 $(call force,CFG_RCAR_GEN3, y)
@@ -48,3 +50,20 @@ $(call force,CFG_CORE_CLUSTER_SHIFT, 1)
 $(call force,CFG_ARM_GICV3, y)
 endif
 
+ifeq ($(CFG_RCAR_GEN5), y)
+CFG_TZDRAM_START ?= 0x8C400000
+CFG_TZDRAM_SIZE  ?= 0x02000000
+CFG_TEE_RAM_VA_SIZE ?= 0x300000
+CFG_SHMEM_START ?= 0x90100000
+CFG_SHMEM_SIZE ?= 0x00100000
+CFG_CORE_HEAP_SIZE ?= 131072
+CFG_TEE_DYN_VASPACE_SIZE ?= (1024 * 1024 * 2)
+CFG_DT ?= n
+$(call force,CFG_CORE_ARM64_PA_BITS,37)
+$(call force,CFG_TEE_CORE_NB_CORE,32)
+CFG_NUM_THREADS ?= $(CFG_TEE_CORE_NB_CORE)
+$(call force,CFG_CORE_CLUSTER_SHIFT, 2)
+$(call force,CFG_ARM_GICV3, y)
+$(call force,CFG_CORE_ASLR,n)
+$(call force,CFG_RCAR_ROMAPI, n)
+endif

--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -7,8 +7,6 @@ $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_SCIF,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
-$(call force,CFG_CORE_ARM64_PA_BITS,36)
-$(call force,CFG_TEE_CORE_NB_CORE,8)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_LPAE,y)
 
@@ -18,13 +16,15 @@ else
 $(call force,CFG_RCAR_GEN3, y)
 endif
 
-CFG_TZDRAM_START ?= 0x44100000
-CFG_TZDRAM_SIZE	 ?= 0x03D00000
-CFG_TEE_RAM_VA_SIZE ?= 0x100000
 supported-ta-targets = ta_arm64
 
 ifeq ($(CFG_RCAR_GEN3), y)
+CFG_TZDRAM_START ?= 0x44100000
+CFG_TZDRAM_SIZE  ?= 0x03D00000
+CFG_TEE_RAM_VA_SIZE ?= 0x100000
 CFG_DT ?= y
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+$(call force,CFG_TEE_CORE_NB_CORE,8)
 ifeq ($(CFG_RCAR_GEN3_HWRNG), y)
 $(warning "Warning: Use of HWRNG can cause crashes on some Renesas SoCs")
 CFG_WITH_SOFTWARE_PRNG ?= n
@@ -35,10 +35,14 @@ endif
 endif
 
 ifeq ($(CFG_RCAR_GEN4), y)
+CFG_TZDRAM_START ?= 0x44100000
+CFG_TZDRAM_SIZE  ?= 0x2200000
+CFG_TEE_RAM_VA_SIZE ?= 0x100000
 # 1xx - for SCIFxx
 # 2xx - for HSCIFxx
-CFG_TZDRAM_SIZE	= 0x2200000
 CFG_RCAR_UART ?= 200
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+$(call force,CFG_TEE_CORE_NB_CORE,8)
 $(call force,CFG_RCAR_ROMAPI, n)
 $(call force,CFG_CORE_CLUSTER_SHIFT, 1)
 $(call force,CFG_ARM_GICV3, y)

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -38,7 +38,12 @@
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, SCIF_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+#ifdef _CFG_ARM_V3_OR_V4
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
+			GIC_REDIST_REG_SIZE * CFG_TEE_CORE_NB_CORE);
+#else
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
+#endif
 #ifdef PRR_BASE
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, PRR_BASE, SMALL_PAGE_SIZE);
 #endif
@@ -57,6 +62,16 @@ register_ddr(NSEC_DDR_2_BASE, NSEC_DDR_2_SIZE);
 #ifdef NSEC_DDR_3_BASE
 register_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
 #endif
+#elif defined(PLATFORM_FLAVOR_ironhide_x5h)
+register_ddr(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
+register_ddr(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
+register_ddr(NSEC_DDR_2_BASE, NSEC_DDR_2_SIZE);
+register_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
+register_ddr(NSEC_DDR_4_BASE, NSEC_DDR_4_SIZE);
+register_ddr(NSEC_DDR_5_BASE, NSEC_DDR_5_SIZE);
+register_ddr(NSEC_DDR_6_BASE, NSEC_DDR_6_SIZE);
+register_ddr(NSEC_DDR_7_BASE, NSEC_DDR_7_SIZE);
+register_ddr(NSEC_DDR_8_BASE, NSEC_DDR_8_SIZE);
 #endif
 
 static struct scif_uart_data console_data __nex_bss;
@@ -89,7 +104,11 @@ unsigned long plat_get_aslr_seed(void)
 
 void boot_primary_init_intc(void)
 {
+#ifdef _CFG_ARM_V3_OR_V4
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+#else
 	gic_init(GICC_BASE, GICD_BASE);
+#endif
 }
 
 void boot_secondary_init_intc(void)

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -57,6 +57,23 @@
 #define CONSOLE_UART_BASE	0xE6540000
 #endif
 
+#elif defined(CFG_RCAR_GEN5)
+
+#define GICD_BASE		0x39000000
+#define GICR_BASE		0x39080000
+
+/* HSCIF0 */
+#define CONSOLE_UART_BASE	0xC0710000
+
+#define TA_RAM_START		(TEE_RAM_START + TEE_RAM_VA_SIZE)
+#define TA_RAM_SIZE		0x01400000
+
+#define PRR_BASE		0xFFF00000
+
+#ifdef CFG_WITH_LPAE
+#define MAX_XLAT_TABLES         CFG_MMAP_REGIONS
+#endif
+
 #endif	/* CFG_RCAR_GENx */
 
 #if defined(PLATFORM_FLAVOR_salvator_h3)
@@ -99,14 +116,36 @@
 #define NSEC_DDR_1_BASE		0x480000000U
 #define NSEC_DDR_1_SIZE		0x80000000U
 
+#elif defined(PLATFORM_FLAVOR_ironhide_x5h)
+#define NSEC_DDR_0_BASE         0x40000000
+#define NSEC_DDR_0_SIZE         0x80000000
+#define NSEC_DDR_1_BASE         0x1080000000
+#define NSEC_DDR_1_SIZE         0x80000000
+#define NSEC_DDR_2_BASE         0x1200000000
+#define NSEC_DDR_2_SIZE         0x100000000
+#define NSEC_DDR_3_BASE         0x1400000000
+#define NSEC_DDR_3_SIZE         0x100000000
+#define NSEC_DDR_4_BASE         0x1600000000
+#define NSEC_DDR_4_SIZE         0x100000000
+#define NSEC_DDR_5_BASE         0x1800000000
+#define NSEC_DDR_5_SIZE         0x100000000
+#define NSEC_DDR_6_BASE         0x1A00000000
+#define NSEC_DDR_6_SIZE         0x100000000
+#define NSEC_DDR_7_BASE         0x1C00000000
+#define NSEC_DDR_7_SIZE         0x100000000
+#define NSEC_DDR_8_BASE         0x1E00000000
+#define NSEC_DDR_8_SIZE         0x100000000
+
 #else
 
 /* Generic DT-based platform */
 
 #endif
 
+#ifndef CFG_SHMEM_START
 /* Full GlobalPlatform test suite requires TEE_SHMEM_SIZE to be at least 2MB */
 #define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
 #define TEE_SHMEM_SIZE		0x100000
+#endif
 
 #endif /*PLATFORM_CONFIG_H*/


### PR DESCRIPTION
RCar Gen5 is the next generation of Renesas automotive chips. Currently only RCar X5H on board Ironhide is available. 
This platform has 8 clusters x 4 Cortex-A720AE cores with GICv4.                             
                                                                           
This is patch adds minimal support, so not all Gen5 features are available.
Namely, RSIP-M (Renesas Secure IP Module - HSM) is not supported right now, so HW RNG and ASLR are disabled.
Also, ATF does not provide DTB, so non-secure DDR ranges are hardcoded.                                       
                                                                           
Built with PLATFORM="rcar", PLATFORM_FLAVOR="ironhide_x5h".
Tested along with R-Car X5H SDK v4.27, booting and xtest.
```
+-----------------------------------------------------
333930 subtests of which 0 failed
112 test cases of which 0 failed
0 test cases were skipped
TEE test application done!
```