### PR TITLE
Skip AOSP ELF check for signed TA prebuilts

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -144,6 +144,12 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib/optee_armtz
 LOCAL_MODULE_CLASS := $(call ta_class,$(local_module))
 LOCAL_MODULE_TAGS := optional
 LOCAL_REQUIRED_MODULES := $(local_module_deps)
+# A signed TA is an ELF binary wrapped in a signed header, so it does not start
+# with the ELF magic. Disable the AOSP prebuilt ELF check for the .ta module to
+# avoid a "must have a valid ELF magic word" build failure.
+ifeq ($(call ta_class,$(local_module)),EXECUTABLES)
+LOCAL_CHECK_ELF_FILES := false
+endif
 
 TA_TMP_DIR := $(addsuffix _$(TA_TARGET), $(subst /,_,$(LOCAL_PATH)))
 TA_TMP_FILE := $(OPTEE_TA_OUT_DIR)/$(TA_TMP_DIR)/$(LOCAL_MODULE)


### PR DESCRIPTION
In `mk/aosp_optee.mk` the signed TA (.ta) is registered as an EXECUTABLES prebuilt, so AOSP runs check_elf_file on it. A signed TA is an ELF binary wrapped in a signed header and does not start with the ELF magic.
On Android 17 the build no longer passes `--skip-bad-elf-magic` to check_elf_file, so this is now fatal:

```
error: File "<uuid>.ta" must have a valid ELF magic word.
```

Set `LOCAL_CHECK_ELF_FILES := false` for the .ta module in `mk/aosp_optee.mk` to skip this check.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
