### PR TITLE
mmu: also ignore dyn VA spaces in get_type_by_pa

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1829,7 +1829,9 @@ enum teecore_memtypes core_mmu_get_type_by_pa(paddr_t pa)
 
 	/* VA spaces have no valid PAs in the memory map */
 	if (!map || map->type == MEM_AREA_RES_VASPACE ||
-	    map->type == MEM_AREA_SHM_VASPACE)
+	    map->type == MEM_AREA_SHM_VASPACE ||
+	    map->type == MEM_AREA_TEE_DYN_VASPACE ||
+	    map->type == MEM_AREA_NEX_DYN_VASPACE)
 		return MEM_AREA_MAXTYPE;
 	return map->type;
 }


### PR DESCRIPTION
Extend core_mmu_get_type_by_pa()'s VA-space filter to also skip MEM_AREA_TEE_DYN_VASPACE and MEM_AREA_NEX_DYN_VASPACE. These are already treated as "find VA from PA not yet supported" by the switch in phys_to_virt():

    case MEM_AREA_SHM_VASPACE:
    case MEM_AREA_NEX_DYN_VASPACE:
    case MEM_AREA_TEE_DYN_VASPACE:
        /* Find VA from PA in dynamic SHM is not yet supported */
        va = NULL;
        break;

but the corresponding filter in core_mmu_get_type_by_pa() lists only RES_VASPACE and SHM_VASPACE. The two filters should be consistent: all four area types are VA-space placeholders that have no valid PAs in the memory map.

This was discovered when init_external_dt() panicked because find_map_by_pa(CFG_DT_ADDR) returned the TEE_DYN_VASPACE placeholder entry first instead of the EXT_DT mapping. Adding TEE_DYN_VASPACE and NEX_DYN_VASPACE to the same filter that already skips RES_VASPACE and SHM_VASPACE matches the precedent from commit e06a9ea52ab0 ("mmu: ignore VA spaces in core_mmu_get_type_by_pa").

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
