### PR TITLE
plat-qcom: Add support for Nord based on Wildcat arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
               _make PLATFORM=qcom-lemans CFG_QCOM_DIAG_LOG=y CFG_QFPROM_PROGRAMMING=y CFG_QCOM_QFPROM_FUSEPROV=y
               _make PLATFORM=qcom-ipq96xx
               _make PLATFORM=qcom-ipq52xx
+              _make PLATFORM=qcom-nord
           - name: arm rockchip
             make_commands: |
               _make PLATFORM=rockchip-px30

--- a/core/arch/arm/plat-qcom/bobcat/sub.mk
+++ b/core/arch/arm/plat-qcom/bobcat/sub.mk
@@ -1,0 +1,1 @@
+# Placeholder for Qcom architecture specific makefile

--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -31,11 +31,14 @@ supported-ta-targets ?= ta_arm64
 # Architecture family mapping
 HOYA_ARCH_CHIPSETS := kodiak lemans
 BOBCAT_ARCH_CHIPSETS := ipq96xx ipq52xx
+WILDCAT_ARCH_CHIPSETS := nord
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),$(HOYA_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := hoya
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(BOBCAT_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := bobcat
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(WILDCAT_ARCH_CHIPSETS)))
+QCOM_ARCH_FAMILY := wildcat
 else
 $(error Unsupported PLATFORM_FLAVOR: $(PLATFORM_FLAVOR))
 endif

--- a/core/arch/arm/plat-qcom/diag_log.c
+++ b/core/arch/arm/plat-qcom/diag_log.c
@@ -79,11 +79,6 @@ void qcom_diag_log_init(void)
 	struct diag *diag = NULL;
 	uint32_t *diag_info_addr = NULL;
 
-	if (!IS_ENABLED(CFG_QCOM_DIAG_LOG)) {
-		IMSG("DIAG: Feature not available");
-		return;
-	}
-
 	diag = get_diag_region();
 	if (!diag)
 		return;

--- a/core/arch/arm/plat-qcom/diag_log.h
+++ b/core/arch/arm/plat-qcom/diag_log.h
@@ -11,7 +11,12 @@
 #include <platform_config.h>
 #include <util.h>
 
+#if defined(CFG_QCOM_DIAG_LOG)
 void qcom_diag_log_init(void);
 void qcom_diag_log_puts(const char *str);
+#else
+static inline void qcom_diag_log_init(void) { }
+static inline void qcom_diag_log_puts(const char *str __unused) { }
+#endif
 
 #endif /* __DIAG_LOG_H */

--- a/core/arch/arm/plat-qcom/hoya/sub.mk
+++ b/core/arch/arm/plat-qcom/hoya/sub.mk
@@ -1,0 +1,1 @@
+# Placeholder for Qcom architecture specific makefile

--- a/core/arch/arm/plat-qcom/main.c
+++ b/core/arch/arm/plat-qcom/main.c
@@ -21,8 +21,9 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, GENI_UART_REG_BASE,
 			GENI_UART_REG_SIZE);
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
-#ifdef CFG_ARM_GICV3
-register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE, GIC_REDIST_REG_SIZE);
+#ifdef _CFG_ARM_V3_OR_V4
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
+			GIC_REDIST_REG_SIZE * CFG_TEE_CORE_NB_CORE);
 #else
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 #endif
@@ -61,7 +62,7 @@ boot_final(platform_banner);
 
 void boot_primary_init_intc(void)
 {
-#ifdef CFG_ARM_GICV3
+#ifdef _CFG_ARM_V3_OR_V4
 	gic_init_v3(0, GICD_BASE, GICR_BASE);
 #else
 	gic_init(GICC_BASE, GICD_BASE);

--- a/core/arch/arm/plat-qcom/sub.mk
+++ b/core/arch/arm/plat-qcom/sub.mk
@@ -5,4 +5,4 @@ srcs-y += main.c
 
 subdirs-$(CFG_QCOM_QFPROM_FUSEPROV) += provision
 
-srcs-y += diag_log.c
+srcs-$(CFG_QCOM_DIAG_LOG) += diag_log.c

--- a/core/arch/arm/plat-qcom/sub.mk
+++ b/core/arch/arm/plat-qcom/sub.mk
@@ -2,7 +2,7 @@ global-incdirs-y += .
 global-incdirs-y += $(QCOM_ARCH_FAMILY)
 global-incdirs-y += $(QCOM_ARCH_FAMILY)/$(PLATFORM_FLAVOR)
 srcs-y += main.c
+srcs-$(CFG_QCOM_DIAG_LOG) += diag_log.c
 
 subdirs-$(CFG_QCOM_QFPROM_FUSEPROV) += provision
-
-srcs-$(CFG_QCOM_DIAG_LOG) += diag_log.c
+subdirs-y += $(QCOM_ARCH_FAMILY)

--- a/core/arch/arm/plat-qcom/wildcat/arch_config.h
+++ b/core/arch/arm/plat-qcom/wildcat/arch_config.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef ARCH_CONFIG_H
+#define ARCH_CONFIG_H
+
+#define GICD_BASE			UL(0x17000000)
+#define GICR_BASE			UL(0x17080000)
+
+#endif /* ARCH_CONFIG_H */

--- a/core/arch/arm/plat-qcom/wildcat/core_pos_a64.S
+++ b/core/arch/arm/plat-qcom/wildcat/core_pos_a64.S
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * Nord (Oryon "NCC") get_core_pos override.
+ *
+ * Oryon MPIDR has the MT bit set but uses one thread per core with
+ * AFF0 = thread (always 0), AFF1 = core (0..5), AFF2 = cluster (0..2).
+ * The generic get_core_pos_mpidr left-shifts the MPIDR by one affinity
+ * level when MT is set; on this layout that promotes the CORE into the
+ * cluster slot and drops the real cluster, collapsing all clusters to the
+ * same value and yielding CorePos = core * 4 (so cores 2..5 map to
+ * 8/12/16/20, exceeding CFG_TEE_CORE_NB_CORE and getting their GIC
+ * redistributors skipped -> secondaries crash). Read AFF1/AFF2 from the
+ * raw MPIDR instead and produce a contiguous CorePos = cluster*6 + core
+ * (0..17) for the 3 x 6 topology.
+ */
+
+#include <asm.S>
+#include <arm.h>
+#include <arm64_macros.S>
+
+FUNC get_core_pos_mpidr , :
+	/* AFF1 = core (0..5) */
+	ubfx	x1, x0, #MPIDR_AFF1_SHIFT, #MPIDR_AFFINITY_BITS
+	/* AFF2 = cluster (0..2) */
+	ubfx	x2, x0, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
+	add	x2, x2, x2, lsl #1	/* x2 = cluster * 3 */
+	add	x0, x1, x2, lsl #1	/* CorePos = core + cluster * 6 */
+	ret
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-qcom/wildcat/nord/target.mk
+++ b/core/arch/arm/plat-qcom/wildcat/nord/target.mk
@@ -1,0 +1,5 @@
+# Nord (SA8797P / Oryon) OP-TEE platform.
+
+# Threads are expensive in OP-TEE, so they don't have
+# to be same as number of cores.
+$(call force,CFG_TEE_CORE_NB_CORE,18)

--- a/core/arch/arm/plat-qcom/wildcat/nord/target_config.h
+++ b/core/arch/arm/plat-qcom/wildcat/nord/target_config.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef TARGET_CONFIG_H
+#define TARGET_CONFIG_H
+
+#define GENI_UART_REG_BASE		UL(0x884000)
+
+#define DRAM0_BASE			UL(0x80000000)
+#define DRAM0_SIZE			UL(0x380000000)
+#define DRAM1_BASE			ULL(0x800000000)
+#define DRAM1_SIZE			ULL(0x800000000)
+
+#endif /* TARGET_CONFIG_H */

--- a/core/arch/arm/plat-qcom/wildcat/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/wildcat/qcom-arch.mk
@@ -1,0 +1,15 @@
+# Wildcat architecture configuration
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_ARM_GICV4,y)
+
+# DARE-TZ secure memory regions. DARE is another in-line
+# memory encryption IP similar to pIMEM but on wildcat arch
+# it is setup by TME root-of-trust, no specific driver needed
+# in OP-TEE for that.
+CFG_TZDRAM_START ?= 0xBC280000
+CFG_TEE_RAM_VA_SIZE ?= 0x00200000
+CFG_TA_RAM_VA_SIZE ?= 0x07B80000
+CFG_TZDRAM_SIZE ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)
+CFG_NUM_THREADS ?= 8

--- a/core/arch/arm/plat-qcom/wildcat/sub.mk
+++ b/core/arch/arm/plat-qcom/wildcat/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += core_pos_a64.S


### PR DESCRIPTION
Nord is also referenced as IQ-10 as the marketing name, more details about the platform can be found on link below. It is based on wildcat architecture and base support is being added for 18 Oryon cores along with GICv4.

Link: https://www.qualcomm.com/internet-of-things/products/iq10-series