### PR TITLE
plat-rockchip: rk3506 enable CFG_8250_UART_FLUSH_TIMEOUT

### DIFF
--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -132,6 +132,11 @@ CFG_EARLY_CONSOLE_BASE ?= UART0_BASE
 CFG_EARLY_CONSOLE_SIZE ?= UART0_SIZE
 CFG_EARLY_CONSOLE_BAUDRATE ?= 115200
 CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
+
+# UART0 is shared with the non-secure world on the RK3506B.
+# Prevent a lockup when the non-secure world is using
+# the UART and OP-TEE is trying to flush it.
+CFG_8250_UART_FLUSH_TIMEOUT ?= y
 endif
 
 ifeq ($(PLATFORM_FLAVOR),rk3588)


### PR DESCRIPTION
Follow-up to the RK3506 port (#7848, merged) and the bounded serial8250
flush (#7847, merged).

`CFG_8250_UART_FLUSH_TIMEOUT` landed in #7847 with a default of `n`, so it
is opt-in per platform. The RK3506 shares UART0 between OP-TEE and the
non-secure world (it is the Linux `ttyS0` console), which is exactly the
configuration that flag guards against: a secure-world console write
issued from inside an SMC can otherwise spin a CPU forever in the
unbounded TX-empty poll while Linux contends the port, tripping the
non-secure hard-lockup watchdog.

This enables the option for the RK3506 so the shipping platform actually
gets that protection. The flag's only dependency, `CFG_CORE_HAS_GENERIC_TIMER`,
is already enabled by the platform.

### Testing

Built `PLATFORM=rockchip-rk3506` (both `CFG_RK3506_TEE_HW_ISOLATE` n and y).

Hardware-validated on a Luckfox Core3506 (RK3506B) running OP-TEE with
this option enabled:

- Boots through OP-TEE to Linux, `nproc = 3`, `/dev/tee0` + `/dev/teepriv0`.
- A full `xtest` run **completes** with no shared-UART hard lockup. With
  the unbounded flush, the same workload reliably hard-locked a CPU
  within ~15 s (the `WARNING (insecure configuration): Failed to get
  monotonic counter` IMSG, emitted from inside a secure call, is the
  trigger). With the bounded flush it prints and the run proceeds.
- Secure-storage suite passes (`regression_6xxx`, 0 failed).
