### PR TITLE
core: Rename internal config switch _CFG_ARM_V3_OR_V4

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -166,10 +166,10 @@ endif
 ifeq ($(CFG_CORE_FFA)-$(CFG_WITH_PAGER),y-y)
 $(error CFG_CORE_FFA and CFG_WITH_PAGER are not compatible)
 endif
-_CFG_ARM_V3_OR_V4 := $(call cfg-one-enabled, CFG_ARM_GICV3 CFG_ARM_GICV4)
+_CFG_ARM_GIC_V3_OR_V4 := $(call cfg-one-enabled, CFG_ARM_GICV3 CFG_ARM_GICV4)
 
 ifeq ($(CFG_GIC),y)
-ifeq ($(_CFG_ARM_V3_OR_V4),y)
+ifeq ($(_CFG_ARM_GIC_V3_OR_V4),y)
 $(call force,CFG_CORE_IRQ_IS_NATIVE_INTR,y)
 else
 $(call force,CFG_CORE_IRQ_IS_NATIVE_INTR,n)
@@ -472,7 +472,7 @@ arm32-sysregs-$(arm32-sysreg-txt)-h := arm32_sysreg.h
 arm32-sysregs-$(arm32-sysreg-txt)-s := arm32_sysreg.S
 arm32-sysregs += $(arm32-sysreg-txt)
 
-ifeq ($(_CFG_ARM_V3_OR_V4),y)
+ifeq ($(_CFG_ARM_GIC_V3_OR_V4),y)
 arm32-gicv3-sysreg-txt = core/arch/arm/kernel/arm32_gicv3_sysreg.txt
 arm32-sysregs-$(arm32-gicv3-sysreg-txt)-h := arm32_gicv3_sysreg.h
 arm32-sysregs-$(arm32-gicv3-sysreg-txt)-s := arm32_gicv3_sysreg.S

--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -166,7 +166,7 @@
 
 #ifndef __ASSEMBLER__
 #include <generated/arm32_sysreg.h>
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 #include <generated/arm32_gicv3_sysreg.h>
 #endif
 

--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -5,7 +5,7 @@
  */
 
 #include <generated/arm32_sysreg.S>
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 #include <generated/arm32_gicv3_sysreg.S>
 #endif
 

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -69,7 +69,7 @@ asm-defines-y += asm-defines.c
 #     <asm.h> includes <generated/arm32_sysreg.h>
 #                  and <generated/arm32_gicv3_sysreg.h> (optional)
 asm-defines-asm-defines.c-deps += $(out-dir)/core/include/generated/arm32_sysreg.h
-ifeq ($(_CFG_ARM_V3_OR_V4),y)
+ifeq ($(_CFG_ARM_GIC_V3_OR_V4),y)
 asm-defines-asm-defines.c-deps += $(out-dir)/core/include/generated/arm32_gicv3_sysreg.h
 endif
 

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -19,7 +19,7 @@ register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
 			GIC_REDIST_REG_SIZE * CFG_TEE_CORE_NB_CORE);
 #else
@@ -28,7 +28,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 
 void boot_primary_init_intc(void)
 {
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	gic_init_v3(0, GICD_BASE, GICR_BASE);
 #else
 	gic_init(GICC_BASE, GICD_BASE);

--- a/core/arch/arm/plat-corstone1000/platform_config.h
+++ b/core/arch/arm/plat-corstone1000/platform_config.h
@@ -20,7 +20,7 @@
 #define DRAM0_BASE		0x80000000
 #define DRAM0_SIZE		CFG_DDR_SIZE
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 #define GICD_OFFSET		0x00000
 #define GICR_OFFSET		0x40000
 #else
@@ -28,7 +28,7 @@
 #define GICC_OFFSET		0x2F000
 #endif
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 #define GICR_BASE		(GIC_BASE + GICR_OFFSET)
 #else
 #define GICC_BASE		(GIC_BASE + GICC_OFFSET)

--- a/core/arch/arm/plat-qcom/main.c
+++ b/core/arch/arm/plat-qcom/main.c
@@ -21,7 +21,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, GENI_UART_REG_BASE,
 			GENI_UART_REG_SIZE);
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
 			GIC_REDIST_REG_SIZE * CFG_TEE_CORE_NB_CORE);
 #else
@@ -62,7 +62,7 @@ boot_final(platform_banner);
 
 void boot_primary_init_intc(void)
 {
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	gic_init_v3(0, GICD_BASE, GICR_BASE);
 #else
 	gic_init(GICC_BASE, GICD_BASE);

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -38,7 +38,7 @@
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, SCIF_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
 			GIC_REDIST_REG_SIZE * CFG_TEE_CORE_NB_CORE);
 #else
@@ -104,7 +104,7 @@ unsigned long plat_get_aslr_seed(void)
 
 void boot_primary_init_intc(void)
 {
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	gic_init_v3(0, GICD_BASE, GICR_BASE);
 #else
 	gic_init(GICC_BASE, GICD_BASE);

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -50,7 +50,7 @@
 #define GICD_IGROUPMODR(n)	(0xd00 + (n) * 4)
 #define GICD_SGIR		(0xF00)
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 #define GICD_PIDR2		(0xFFE8)
 #else
 /*
@@ -151,7 +151,7 @@
 struct gic_data {
 	vaddr_t gicc_base;
 	vaddr_t gicd_base;
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	vaddr_t gicr_base[CFG_TEE_CORE_NB_CORE];
 #endif
 	size_t max_it;
@@ -189,7 +189,7 @@ DECLARE_KEEP_PAGER(gic_ops);
 
 static vaddr_t __maybe_unused get_gicr_base(struct gic_data *gd __maybe_unused)
 {
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	return gd->gicr_base[get_core_pos()];
 #else
 	return 0;
@@ -198,7 +198,7 @@ static vaddr_t __maybe_unused get_gicr_base(struct gic_data *gd __maybe_unused)
 
 static bool affinity_routing_is_enabled(struct gic_data *gd)
 {
-	return IS_ENABLED2(_CFG_ARM_V3_OR_V4) &&
+	return IS_ENABLED2(_CFG_ARM_GIC_V3_OR_V4) &&
 	       io_read32(gd->gicd_base + GICD_CTLR) & GICD_CTLR_ARE_S;
 }
 
@@ -213,7 +213,7 @@ static size_t probe_max_it(vaddr_t gicc_base __maybe_unused, vaddr_t gicd_base)
 	/*
 	 * Probe which interrupt number is the largest.
 	 */
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	old_ctlr = read_icc_ctlr();
 	write_icc_ctlr(0);
 #else
@@ -237,7 +237,7 @@ static size_t probe_max_it(vaddr_t gicc_base __maybe_unused, vaddr_t gicd_base)
 		}
 	}
 out:
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	write_icc_ctlr(old_ctlr);
 #else
 	io_write32(gicc_base + GICC_CTLR, old_ctlr);
@@ -357,7 +357,7 @@ static void init_gic_per_cpu(struct gic_data *gd)
 	 * Set the priority mask to permit Non-secure interrupts, and to
 	 * allow the Non-secure world to adjust the priority mask itself
 	 */
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	write_icc_pmr(0x80);
 	write_icc_igrpen1(1);
 #else
@@ -374,7 +374,7 @@ void gic_init_per_cpu(void)
 {
 	struct gic_data *gd = &gic_data;
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	assert(gd->gicd_base);
 #else
 	assert(gd->gicd_base && gd->gicc_base);
@@ -553,7 +553,7 @@ static void gic_init_base_addr(paddr_t gicc_base_pa, paddr_t gicd_base_pa,
 	vers >>= GICD_PIDR2_ARCHREV_SHIFT;
 	vers &= GICD_PIDR2_ARCHREV_MASK;
 
-	if (IS_ENABLED2(_CFG_ARM_V3_OR_V4)) {
+	if (IS_ENABLED2(_CFG_ARM_GIC_V3_OR_V4)) {
 		assert(vers == 4 || vers == 3);
 	} else {
 		assert(vers == 2 || vers == 1);
@@ -566,7 +566,7 @@ static void gic_init_base_addr(paddr_t gicc_base_pa, paddr_t gicd_base_pa,
 	gd->gicc_base = gicc_base;
 	gd->gicd_base = gicd_base;
 	gd->max_it = probe_max_it(gicc_base, gicd_base);
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	if (affinity_routing_is_enabled(gd) && gicr_base_pa)
 		probe_redist_base_addrs(gd->gicr_base, gicr_base_pa);
 #endif
@@ -638,7 +638,7 @@ void gic_init_v3(paddr_t gicc_base_pa, paddr_t gicd_base_pa,
 	/* Set the priority mask to permit Non-secure interrupts, and to
 	 * allow the Non-secure world to adjust the priority mask itself
 	 */
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	write_icc_pmr(0x80);
 	write_icc_igrpen1(1);
 	io_setbits32(gd->gicd_base + GICD_CTLR, GICD_CTLR_ENABLEGRP1S);
@@ -669,7 +669,7 @@ static void gic_it_configure(struct gic_data *gd, size_t it)
 	io_write32(gd->gicd_base + GICD_ICPENDR(idx), mask);
 	/* Assign it to group0 */
 	io_clrbits32(gd->gicd_base + GICD_IGROUPR(idx), mask);
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	/* Assign it to group1S */
 	io_setbits32(gd->gicd_base + GICD_IGROUPMODR(idx), mask);
 #endif
@@ -791,7 +791,7 @@ static void assert_cpu_mask_is_valid(uint32_t cpu_mask)
 static void gic_it_raise_sgi(struct gic_data *gd __maybe_unused, size_t it,
 			     uint32_t cpu_mask, bool ns)
 {
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	uint32_t mask_id = it & 0xf;
 	uint64_t mask = SHIFT_U64(mask_id, 24);
 
@@ -856,7 +856,7 @@ static uint32_t gic_read_iar(struct gic_data *gd __maybe_unused)
 {
 	assert(gd == &gic_data);
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	return read_icc_iar1();
 #else
 	return io_read32(gd->gicc_base + GICC_IAR);
@@ -867,7 +867,7 @@ static void gic_write_eoir(struct gic_data *gd __maybe_unused, uint32_t eoir)
 {
 	assert(gd == &gic_data);
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	write_icc_eoir1(eoir);
 #else
 	io_write32(gd->gicc_base + GICC_EOIR, eoir);
@@ -909,7 +909,7 @@ void gic_dump_state(void)
 	struct gic_data *gd = &gic_data;
 	int i = 0;
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	DMSG("GICC_CTLR: %#"PRIx32, read_icc_ctlr());
 #else
 	DMSG("GICC_CTLR: %#"PRIx32, io_read32(gd->gicc_base + GICC_CTLR));
@@ -947,7 +947,7 @@ TEE_Result gic_spi_release_to_ns(size_t it)
 	io_write32(gd->gicd_base + GICD_ICPENDR(idx), mask);
 	/* Assign it to NS Group1 */
 	io_setbits32(gd->gicd_base + GICD_IGROUPR(idx), mask);
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 	io_clrbits32(gd->gicd_base + GICD_IGROUPMODR(idx), mask);
 #endif
 	mutex_unlock(&gic_mutex);

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -10,7 +10,7 @@
 #include <types_ext.h>
 #include <kernel/interrupt.h>
 
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 #define GICD_FRAME_SIZE         (64 * 1024)
 #define GICC_FRAME_SIZE         (64 * 1024)
 #define GICR_FRAME_SIZE         (64 * 1024)
@@ -22,7 +22,7 @@
 
 #define GIC_CPU_REG_SIZE        GICC_FRAME_SIZE
 #define GIC_DIST_REG_SIZE       GICD_FRAME_SIZE
-#ifdef _CFG_ARM_V3_OR_V4
+#ifdef _CFG_ARM_GIC_V3_OR_V4
 /*
  * The frames for each Redistributor are contiguous and are ordered as
  * follows:


### PR DESCRIPTION
Rename internal config `switch_CFG_ARM_V3_OR_V4` to `_CFG_ARM_GIC_V3_OR_V4` to clearly state it relates to the GIC.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
