### PR TITLE
plat-rockchip: add support for RV1106

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
               _make PLATFORM=rockchip-rk3506
               _make PLATFORM=rockchip-rk3576
               _make PLATFORM=rockchip-rk3588
+              _make PLATFORM=rockchip-rv1106
           - name: arm sam
             make_commands: |
               _make PLATFORM=sam

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -328,6 +328,11 @@ R:	Owen O'Hehir <electronicconsult1@gmail.com> [@OOHehir]
 S:	Maintained
 F:	core/arch/arm/plat-rockchip/*rk3506*
 
+Rockchip RV1106
+R:	Owen O'Hehir <electronicconsult1@gmail.com> [@OOHehir]
+S:	Maintained
+F:	core/arch/arm/plat-rockchip/*rv1106*
+
 Socionext DeveloperBox (Synquacer SC2A11)
 R:	Sumit Garg <sumit.garg@kernel.org> [@b49020]
 S:	Maintained

--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -33,6 +33,58 @@ CFG_EARLY_CONSOLE_BAUDRATE ?= 1500000
 CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
 endif
 
+ifeq ($(PLATFORM_FLAVOR),rv1106)
+include ./core/arch/arm/cpu/cortex-a7.mk
+$(call force,CFG_TEE_CORE_NB_CORE,1)
+
+# The kernel DT declares psci { method = "smc"; }, so Linux issues a PSCI SMC
+# before its console is up. Enable CFG_PSCI_ARM32 so the generic __weak PSCI
+# defaults answer (version 1.1, CPU_ON not supported), correct for a single
+# core; without a handler the SMC is mishandled and the kernel hangs.
+# psci_rk322x.c is rk322x-specific and not built here.
+$(call force,CFG_PSCI_ARM32,y)
+
+# No TF-A in the boot chain, so sm_init() must zero CNTVOFF.
+$(call force,CFG_INIT_CNTVOFF,y)
+
+# Cortex-A7 supports LPAE; use it for the 2 MB page-directory granule the
+# CFG_DYN_CONFIG core layout needs (the 1 MB short-descriptor granule does
+# not leave enough room for boot_mem on this platform).
+$(call force,CFG_WITH_LPAE,y)
+
+# OP-TEE parses the DTB from non-secure DRAM; a secure master's non-secure
+# access is rejected once the MMU is on, so map it secure.
+CFG_MAP_EXT_DT_SECURE ?= y
+
+# TEE region. TZDRAM base 0x03d00000 matches the vendor firmware layout
+# (rkbin RV1106TOS.ini); non-secure shared memory sits immediately above it.
+CFG_TZDRAM_START ?= 0x03d00000
+CFG_TZDRAM_SIZE  ?= 0x01000000
+CFG_SHMEM_START  ?= 0x04d00000
+CFG_SHMEM_SIZE   ?= 0x00100000
+
+# Optional HW isolation of TZDRAM from the non-secure Cortex-A7. The secure
+# region alone does not gate the A7 (single core, no DSU firewall); enabling
+# this also programs the FW_DDR per-master bank. Off by default: it requires
+# the non-secure DTB to reserve TZDRAM (reserved-memory, no-map), or the
+# kernel faults on the isolated region. See platform_rv1106.c.
+CFG_RV1106_TEE_HW_ISOLATE ?= n
+
+# UART2 debug console (24 MHz ref). Early console is off by default; OP-TEE
+# switches to the DT console. Enable with CFG_EARLY_CONSOLE=y.
+CFG_EARLY_CONSOLE_BASE ?= UART2_BASE
+CFG_EARLY_CONSOLE_SIZE ?= UART2_SIZE
+CFG_EARLY_CONSOLE_BAUDRATE ?= 115200
+CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
+
+# Non-secure handoff: enter the NS payload at CFG_NS_ENTRY_ADDR with its DTB at
+# CFG_DT_ADDR, and describe the 256 MB DRAM (atags are not passed on).
+CFG_DT_ADDR ?= 0x08000000
+CFG_NS_ENTRY_ADDR ?= 0x00200000
+CFG_DRAM_BASE ?= 0x00000000
+CFG_DRAM_SIZE ?= 0x10000000
+endif
+
 ifeq ($(PLATFORM_FLAVOR),rk3399)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,6)

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -16,11 +16,11 @@
 
 #if defined(CFG_EARLY_CONSOLE)
 static struct serial8250_uart_data early_console_data;
-#if defined(PLATFORM_FLAVOR_rk3506)
+#if defined(PLATFORM_FLAVOR_rk3506) || defined(PLATFORM_FLAVOR_rv1106)
 /*
- * rk3506: map the early console UART secure (NS=0), not IO_NSEC. The
- * system firewall rejects a secure master issuing a non-secure access
- * to UART0 once the MMU is enabled (sync external abort), so the
+ * rk3506 / rv1106: map the early console UART secure (NS=0), not IO_NSEC.
+ * The system firewall rejects a secure master issuing a non-secure access
+ * to the UART once the MMU is enabled (sync external abort), so the
  * post-MMU mapping must keep the same secure attribute as the working
  * pre-MMU access. OP-TEE owns the debug UART during bring-up, so a
  * secure mapping is appropriate.

--- a/core/arch/arm/plat-rockchip/plat_init.S
+++ b/core/arch/arm/plat-rockchip/plat_init.S
@@ -6,8 +6,53 @@
 #include <asm.S>
 #include <arm.h>
 #include <arm32_macros.S>
+#include <kernel/cache_helpers.h>
 
 FUNC plat_cpu_reset_early , :
+
+#if defined(PLATFORM_FLAVOR_rv1106)
+	/*
+	 * The boot loader loads OP-TEE and the images it hands on into DRAM
+	 * through its write-back D-cache without cleaning to the Point of
+	 * Coherency, and OP-TEE's early boot invalidates the D-cache, which
+	 * would discard those still-dirty lines. Clean the whole D-cache to
+	 * PoC first. dcache_op_all needs a stack and preserves r4-r12 (so the
+	 * boot args _start stashed there survive); sp is set up for real later
+	 * in _start, so borrow the top of TZDRAM as a temporary stack.
+	 * r4 is filler for alignment.
+	 */
+	ldr	sp, =(CFG_TZDRAM_START + CFG_TZDRAM_SIZE)
+	push	{r4, lr}
+	mov	r0, #DCACHE_OP_CLEAN
+	bl	dcache_op_all
+	pop	{r4, lr}
+	dsb
+	isb
+
+	/*
+	 * Program CNTFRQ (the SPL leaves it at 0). The non-secure zImage
+	 * decompressor and the kernel arch-timer read it for delay loops,
+	 * so a zero value hangs the decompressor before start_kernel. With
+	 * no TF-A in the boot chain, programming it is the secure monitor's
+	 * duty. CNTFRQ is secure-writable.
+	 */
+	mov_imm	r0, 24000000
+	write_cntfrq r0
+
+	/*
+	 * Grant the non-secure world access to the FPU / Advanced SIMD
+	 * (CP10/CP11) and set NS-SMP. The reset value denies NS any
+	 * floating-point, so the non-secure zImage decompressor and kernel
+	 * would fault on the first NEON instruction (there is no TF-A to
+	 * set this up). CNTVOFF is zeroed by sm_init() via CFG_INIT_CNTVOFF,
+	 * so it is not handled here.
+	 */
+	read_nsacr r0
+	orr	r0, r0, #(NSACR_CP10 | NSACR_CP11)
+	orr	r0, r0, #NSACR_NS_SMP
+	write_nsacr r0
+	isb
+#endif
 
 	/* Enable SMP bit */
 	read_actlr  r0
@@ -15,4 +60,3 @@ FUNC plat_cpu_reset_early , :
 	write_actlr r0
 	bx	lr
 END_FUNC plat_cpu_reset_early
-

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -209,6 +209,35 @@
 #define PMU1SGRF_FW_BASE	0x26003000
 #define PMU1SGRF_FW_SIZE	SIZE_K(4)
 
+#elif defined(PLATFORM_FLAVOR_rv1106)
+
+/* GIC-400 (GICv2) */
+#define GIC_BASE		0xff1f0000
+#define GIC_SIZE		SIZE_K(64)
+#define GICD_BASE		(GIC_BASE + 0x1000)
+#define GICC_BASE		(GIC_BASE + 0x2000)
+
+/* UART2 debug console */
+#define UART2_BASE		0xff4c0000
+#define UART2_SIZE		SIZE_K(64)
+
+/*
+ * System-firewall (SGRF) bases. PERI_SGRF gates the peripherals the NS world
+ * owns (including the UART2 console); CORE_SGRF gates the core/HPMCU domain.
+ * A 4 KiB page each covers the register offsets used here.
+ */
+#define PERI_SGRF_BASE		0xff070000
+#define PERI_SGRF_SIZE		SIZE_K(4)
+#define CORE_SGRF_BASE		0xff076000
+#define CORE_SGRF_SIZE		SIZE_K(4)
+
+/*
+ * DDR-firewall base. The FW_DDR region (RGN) and enable (CON) layout is the
+ * same IP as the upstream plat-rk3588 FW_DDR block; see platform_rv1106.c.
+ */
+#define FW_DDR_BASE		0xff900000
+#define FW_DDR_SIZE		SIZE_K(64)
+
 #else
 #error "Unknown platform flavor"
 #endif

--- a/core/arch/arm/plat-rockchip/platform_rv1106.c
+++ b/core/arch/arm/plat-rockchip/platform_rv1106.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2026, Owen O'Hehir
+ *
+ * RV1106G3 system-firewall (SGRF) and DDR-firewall (FW_DDR) setup. The code
+ * follows the upstream plat-rk322x platform_secure_init() and the plat-rk3588
+ * FW_DDR block.
+ *
+ * A prior boot stage opens every SGRF slave to the non-secure world before
+ * OP-TEE runs, so the NS world can reach its peripherals (the UART2 console
+ * etc.) after the hand-off. platform_secure_init() re-asserts that all-NS
+ * state so OP-TEE owns the gate configuration explicitly; at v1 OP-TEE keeps
+ * no peripheral secure (software crypto, no secure CE).
+ *
+ * platform_secure_ddr_region() isolates TZDRAM via the FW_DDR block, the same
+ * IP as the upstream plat-rk3588 (RGN(i) = i*4, CON = 0xf0; RG_MAP_SECURE packs
+ * (top-1) into [30:16] and base into [14:0], both in MB), but without rk3588's
+ * DSU channels (RV1106 is single core, no DSU).
+ */
+
+#include <assert.h>
+#include <io.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform.h>
+#include <platform_config.h>
+#include <trace.h>
+#include <types_ext.h>
+#include <util.h>
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, PERI_SGRF_BASE, PERI_SGRF_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, CORE_SGRF_BASE, CORE_SGRF_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, FW_DDR_BASE, FW_DDR_SIZE);
+
+/* SGRF firewall control registers (FIREWALL_CON0..4) */
+#define SGRF_FIREWALL_CON(n)	(0x20 + (n) * 4)
+#define SGRF_FIREWALL_CON_NUM	5
+
+/*
+ * Rockchip masked write: bits 31:16 are the per-bit write-enable, bits 15:0
+ * the value. Driving all 16 slave bits to 0 under the write mask marks every
+ * slave non-secure - the same idiom as plat-rk322x SLAVE_ALL_NS.
+ */
+#define SLAVE_ALL_NS		GENMASK_32(31, 16)
+
+int platform_secure_init(void)
+{
+	vaddr_t peri = (vaddr_t)phys_to_virt_io(PERI_SGRF_BASE, PERI_SGRF_SIZE);
+	vaddr_t core = (vaddr_t)phys_to_virt_io(CORE_SGRF_BASE, CORE_SGRF_SIZE);
+	unsigned int n = 0;
+
+	if (!peri || !core)
+		panic();
+
+	for (n = 0; n < SGRF_FIREWALL_CON_NUM; n++) {
+		io_write32(peri + SGRF_FIREWALL_CON(n), SLAVE_ALL_NS);
+		io_write32(core + SGRF_FIREWALL_CON(n), SLAVE_ALL_NS);
+	}
+
+	return 0;
+}
+
+/*
+ * FW_DDR region/enable layout, the same IP as the upstream plat-rk3588 FW_DDR
+ * block (RV1106 has no DSU channels).
+ */
+#define FW_DDR_RGN(i)		((i) * 0x4)
+#define FW_DDR_CON		0xf0
+#define FW_DDR_RGN_NUM		16
+#define FW_DDR_RGN_MASK		GENMASK_32(14, 0)
+#define RG_MAP_SECURE(top, base) \
+	(SHIFT_U32(((top) - 1) & FW_DDR_RGN_MASK, 16) | \
+	 ((base) & FW_DDR_RGN_MASK))
+
+/*
+ * FW_DDR per-master access-control bank (MST0..MST11 at 0x40 + i*4). These
+ * registers permit masters to reach DRAM; a latched secure region (RGN + CON)
+ * overrides them for non-secure transactions, so permitting all masters lets
+ * the NS world run while the NS Cortex-A7 still aborts on the secure window.
+ * (On the ARMv8 rk3506/rk3588 the CPU is additionally gated by the DSU
+ * firewall, which a single-A7 RV1106 lacks.)
+ *
+ * Permit every master fully; masters are 16 or 32 permit bits wide.
+ */
+#define FW_DDR_MST(i)		(0x40 + (i) * 0x4)
+
+static void rv1106_fw_ddr_permit_masters(vaddr_t fw_ddr)
+{
+	static const uint32_t mst[] = {
+		GENMASK_32(15, 0), GENMASK_32(15, 0), GENMASK_32(15, 0),
+		GENMASK_32(31, 0), GENMASK_32(31, 0), GENMASK_32(31, 0),
+		GENMASK_32(31, 0), GENMASK_32(31, 0), GENMASK_32(31, 0),
+		GENMASK_32(15, 0), GENMASK_32(15, 0), GENMASK_32(31, 0),
+	};
+	unsigned int i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(mst); i++)
+		io_write32(fw_ddr + FW_DDR_MST(i), mst[i]);
+}
+
+int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
+{
+	vaddr_t fw_ddr = (vaddr_t)phys_to_virt_io(FW_DDR_BASE, FW_DDR_SIZE);
+	paddr_t ed = st + sz;
+	uint32_t st_mb = st / SIZE_M(1);
+	uint32_t ed_mb = ed / SIZE_M(1);
+
+	if (!fw_ddr)
+		panic();
+
+	assert(rgn >= 0 && rgn < FW_DDR_RGN_NUM);
+	assert(st < ed);
+	/* FW_DDR regions are 1 MB-granular */
+	assert(st % SIZE_M(1) == 0);
+	assert(ed % SIZE_M(1) == 0);
+
+	DMSG("protecting region %d: 0x%"PRIxPA"-0x%"PRIxPA, rgn, st, ed);
+
+	if (IS_ENABLED(CFG_RV1106_TEE_HW_ISOLATE)) {
+		unsigned int i = 0;
+
+		/*
+		 * Start from an empty firewall: a prior boot stage may hand
+		 * over with a region already defined and enabled (e.g. region
+		 * 0 covering all of DRAM). Once the master-permit writes below
+		 * arm the firewall, such an inherited region would lock the NS
+		 * world out of its own DRAM, so clear every region definition
+		 * and the enable register first.
+		 */
+		for (i = 0; i < FW_DDR_RGN_NUM; i++)
+			io_write32(fw_ddr + FW_DDR_RGN(i), 0);
+		io_write32(fw_ddr + FW_DDR_CON, 0);
+	}
+
+	/* Define the secure DDR window, then latch it (before the masters) */
+	io_write32(fw_ddr + FW_DDR_RGN(rgn), RG_MAP_SECURE(ed_mb, st_mb));
+	io_setbits32(fw_ddr + FW_DDR_CON, BIT(rgn));
+
+	if (IS_ENABLED(CFG_RV1106_TEE_HW_ISOLATE)) {
+		/*
+		 * Permit all masters across DRAM; the latched secure region
+		 * above overrides for NS, so the NS A7 keeps its own DRAM but
+		 * aborts on the secure window.
+		 */
+		rv1106_fw_ddr_permit_masters(fw_ddr);
+	}
+
+	return 0;
+}

--- a/core/arch/arm/plat-rockchip/sub.mk
+++ b/core/arch/arm/plat-rockchip/sub.mk
@@ -7,12 +7,14 @@ srcs-$(PLATFORM_FLAVOR_rk3399) += platform_rk3399.c
 srcs-$(PLATFORM_FLAVOR_rk3506) += platform_rk3506.c
 srcs-$(PLATFORM_FLAVOR_rk3576) += platform_rk3576.c
 srcs-$(PLATFORM_FLAVOR_rk3588) += platform_rk3588.c
+srcs-$(PLATFORM_FLAVOR_rv1106) += platform_rv1106.c
 
-ifeq ($(PLATFORM_FLAVOR),rk322x)
+ifneq ($(filter rk322x rv1106, $(PLATFORM_FLAVOR)),)
 srcs-y += plat_init.S
 srcs-y += core_pos_a32.S
-srcs-$(CFG_PSCI_ARM32) += psci_rk322x.c
 endif
+
+srcs-$(PLATFORM_FLAVOR_rk322x) += psci_rk322x.c
 
 ifeq ($(PLATFORM_FLAVOR),rk3506)
 # rk3506-specific plat_init programs CNTFRQ_EL0 (the RK3506 boot chain


### PR DESCRIPTION
Summary
=======

This adds an OP-TEE platform flavor for the Rockchip RV1106G3, a single-core ARMv7-A Cortex-A7 SoC with 256 MB of DDR3L. It is the single-core sibling of the recently merged RK3506 port (#7848) and reuses the existing plat-rockchip infrastructure.

As on RK3506, there is no ARM Trusted Firmware on this platform: OP-TEE is the secure monitor. The vendor boot chain is BootROM -> DDR init + SPL (both Rockchip blobs) -> OP-TEE (secure) -> non-secure U-Boot -> Linux. This port replaces the closed vendor TEE binary with upstream OP-TEE.

Development and testing was done on a Luckfox Pico Ultra.


What the port adds
==================

- Secure-monitor bring-up in plat_init.S (shared with rk322x): programs CNTFRQ (24 MHz xin24m; the boot chain leaves it at its reset default and there is no TF-A to do it), grants the non-secure world FPU/Advanced-SIMD and NS-SMP via NSACR, and cleans the D-cache to the point of coherency before OP-TEE's early cache invalidate (the Rockchip SPL hands over with the loaded images still dirty in its write-back D-cache). CNTVOFF is handled by sm_init() (CFG_INIT_CNTVOFF).

- System-firewall (SGRF) and DDR-firewall (FW_DDR) setup in platform_rv1106.c. platform_secure_init() re-asserts the all-non-secure SGRF state that the boot chain leaves, so OP-TEE owns the gate configuration explicitly; at v1 no peripheral is kept secure (software crypto, no secure crypto engine).

- Optional hardware isolation of TZDRAM from the non-secure Cortex-A7 behind CFG_RV1106_TEE_HW_ISOLATE (default off). A single-A7 RV1106 has no DSU firewall, so a secure region alone does not gate the CPU; enabling this also programs the FW_DDR per-master access block. It is off by default because it requires the non-secure device tree to reserve TZDRAM (reserved-memory, no-map), otherwise the kernel faults on the isolated region.

- Single-core PSCI: CFG_PSCI_ARM32 is enabled (the kernel device tree issues a PSCI-over-SMC before its console is up), answered by OP-TEE's generic __weak PSCI defaults (version 1.1, CPU_ON not supported) - correct for a single core. psci_rk322x.c is not built for this flavor. There is no PSCI back end, no secondary-core pen, and no ARM-Trusted-Firmware-derived code; every file is BSD-2-Clause and originally authored.

- Device-tree consumption with a secure mapping (CFG_MAP_EXT_DT_SECURE), and LPAE (the CFG_DYN_CONFIG core layout needs the 2 MB page-directory granule).

- Build/CI integration and a MAINTAINERS entry.


Memory map
==========

256 MB DRAM at physical 0x0.

  TZDRAM (secure)     0x03d00000, 16 MB
  Non-secure SHMEM    0x04d00000, 1 MB
  Non-secure entry    0x00200000 (U-Boot)
  Device tree         0x08000000

With CFG_RV1106_TEE_HW_ISOLATE=y the FW_DDR block enforces TZDRAM against the non-secure Cortex-A7; otherwise the TEE relies on the kernel device-tree no-map reservation.

Fuses
================

I didn't burn any fuses, CFG_INSECURE=y


Provenance
==========

As I went along in this effort I tried to record where I got individual register values; if a reviewer requires any, please let me know.


Testing (Luckfox Pico Ultra)
============================

Boots through OP-TEE to Linux (single core, maxcpus=1); the in-kernel OP-TEE driver binds to the port (optee: revision 4.10, dynamic shared memory enabled).

Full regression run, tee-supplicant + xtest -l 0:
```
Run test suite with level=0

TEE test application started over default TEE instance
######################################################
#
# regression
#
######################################################
 
* regression_1001 Core self tests
 - 1001 -   skip test, pseudo TA not found
  regression_1001 OK
 
* regression_1002 PTA parameters
 - 1002 -   skip test, pseudo TA not found
  regression_1002 OK
 
* regression_1003 Core internal read/write mutex
 - 1003 -   skip test, pseudo TA not found
  regression_1003 OK
 
* regression_1004 Test User Crypt TA
o regression_1004.1 AES encrypt
  regression_1004.1 OK
o regression_1004.2 AES decrypt
  regression_1004.2 OK
o regression_1004.3 SHA-256 test, 3 bytes input
  regression_1004.3 OK
o regression_1004.4 AES-256 ECB encrypt (32B, fixed key)
  regression_1004.4 OK
o regression_1004.5 AES-256 ECB decrypt (32B, fixed key)
  regression_1004.5 OK

<snip>

  35637 subtests of which 1 failed
  114 test cases of which 1 failed
  0 test cases were skipped
```

The single failure is regression_1033 (a tee-supplicant plugin not packaged in the test root filesystem), not anything in the port - the same non-port failure accepted for the RK3506 submission.

Hardware isolation: with CFG_RV1106_TEE_HW_ISOLATE=y, a non-secure read of TZDRAM (0x03d00000) external-aborts ("Unhandled fault: external abort on non-linefetch", faulting pte -> 0x03d00xxx) while xtest still passes - enforcement plus a passing xtest together show the firewall configuration is functionally correct.

checkpatch (linux-next checkpatch.pl + spelling.txt + const_structs) is clean on the commit; the sibling rockchip flavors (rk322x, rk3506) still build; the port is otherwise confined to core/arch/arm/plat-rockchip/.