### PR TITLE
core: lpae: retry ASLR when no user mapping entry remains

### DIFF
--- a/core/arch/arm/include/mm/core_mmu_arch.h
+++ b/core/arch/arm/include/mm/core_mmu_arch.h
@@ -206,6 +206,19 @@ static inline bool core_mmu_va_is_valid(vaddr_t va)
 	return va < BIT64(core_mmu_get_va_width());
 }
 
+#ifdef CFG_WITH_LPAE
+bool arch_mem_map_allows_user_va(const struct memory_map *mem_map,
+				 vaddr_t id_map_start, vaddr_t id_map_end);
+#else
+static inline bool
+arch_mem_map_allows_user_va(const struct memory_map *mem_map __unused,
+			    vaddr_t id_map_start __unused,
+			    vaddr_t id_map_end __unused)
+{
+	return true;
+}
+#endif
+
 static inline bool core_mmu_level_in_range(unsigned int level)
 {
 #if CORE_MMU_BASE_TABLE_LEVEL == 0

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -68,6 +68,7 @@
 #include <kernel/linker.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
+#include <kernel/tee_misc.h>
 #include <kernel/thread.h>
 #include <kernel/tlb_helpers.h>
 #include <memtag.h>
@@ -290,6 +291,13 @@ static uint64_t xlat_tables_ul1[XLAT_TABLE_SIZE * CFG_NUM_THREADS /
 static l1_idx_t user_l1_table_idx[NUM_BASE_TABLES * CFG_TEE_CORE_NB_CORE];
 #endif
 #endif
+
+/*
+ * Level 1 entries at this index and above start outside the 32-bit VA space.
+ * Use it as the exclusive upper bound when selecting a slot for 32-bit TAs.
+ */
+#define ARM32_USER_VA_SLOT_LIMIT \
+	((UINT32_MAX >> L1_XLAT_ADDRESS_SHIFT) + 1)
 
 /*
  * TAs page table entry inside a level 1 page table.
@@ -887,6 +895,37 @@ static void core_init_mmu_prtn_tee(struct mmu_partition *prtn,
 	}
 }
 
+bool arch_mem_map_allows_user_va(const struct memory_map *mem_map,
+				 vaddr_t id_map_start, vaddr_t id_map_end)
+{
+	const size_t slot_size = BIT64(L1_XLAT_ADDRESS_SHIFT);
+	vaddr_t id_start = ROUNDDOWN(id_map_start, SMALL_PAGE_SIZE);
+	size_t id_size = ROUNDUP(id_map_end, SMALL_PAGE_SIZE) - id_start;
+	unsigned int slot = 0;
+	size_t n = 0;
+
+	/*
+	 * The user mapping must occupy an unused level 1 entry in the 32-bit
+	 * VA range [1GB, 4GB[. Account for the identity mapping too, since it
+	 * has not yet been added to @mem_map.
+	 */
+	for (slot = 1; slot < ARM32_USER_VA_SLOT_LIMIT; slot++) {
+		vaddr_t slot_base = (vaddr_t)slot * slot_size;
+		bool used = core_is_buffer_intersect(slot_base, slot_size,
+						     id_start, id_size);
+
+		for (n = 0; !used && n < mem_map->count; n++)
+			used = core_is_buffer_intersect(slot_base, slot_size,
+							mem_map->map[n].va,
+							mem_map->map[n].size);
+
+		if (!used)
+			return true;
+	}
+
+	return false;
+}
+
 /*
  * In order to support 32-bit TAs we will have to find
  * a user VA base in the region [1GB, 4GB[.
@@ -944,7 +983,7 @@ static void set_user_va_idx(struct mmu_partition *prtn)
 	 * Search level 1 table (i.e. 1GB mapping per entry) for
 	 * an empty entry in the range [1GB, 4GB[.
 	 */
-	for (n = 1; n < 4; n++) {
+	for (n = 1; n < ARM32_USER_VA_SLOT_LIMIT; n++) {
 		if ((tbl[n] & DESC_ENTRY_TYPE_MASK) == INVALID_DESC) {
 			user_va_idx = n;
 			break;

--- a/core/arch/riscv/include/mm/core_mmu_arch.h
+++ b/core/arch/riscv/include/mm/core_mmu_arch.h
@@ -223,6 +223,19 @@ static inline bool core_mmu_va_is_valid(vaddr_t va)
 #endif
 }
 
+static inline bool
+arch_mem_map_allows_user_va(const struct memory_map *mem_map __unused,
+			    vaddr_t id_map_start __unused,
+			    vaddr_t id_map_end __unused)
+{
+	/*
+	 * RV32 TAs on an RV64 core aren't currently supported, so the user VA
+	 * isn't restricted to the 32-bit VA range. The final selector may use
+	 * any unused VPN[2] entry without an additional layout constraint.
+	 */
+	return true;
+}
+
 static inline bool core_mmu_level_in_range(unsigned int level)
 {
 	return level <= CORE_MMU_BASE_TABLE_LEVEL;

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1540,6 +1540,9 @@ static struct memory_map *init_mem_map(struct memory_map *mem_map,
 		for (n = 0; n < 3; n++) {
 			ba = arch_aslr_base_addr(start_addr, seed, n);
 			if (assign_mem_va(ba, mem_map) &&
+			    arch_mem_map_allows_user_va(mem_map,
+							id_map_start,
+							id_map_end) &&
 			    mem_map_add_id_map(mem_map, id_map_start,
 					       id_map_end)) {
 				offs = ba - start_addr;


### PR DESCRIPTION
# LPAE User VA Exhaustion During Core ASLR

## Background

With a 4KB granule, each LPAE level 1 entry covers 1GB of virtual address space. The total number of level 1 entries depends on the configured VA space size, but only entries below 4GB can be used for 32-bit TA user mappings.

```text
L1[0]: [0GB, 1GB)
L1[1]: [1GB, 2GB)
L1[2]: [2GB, 3GB)
L1[3]: [3GB, 4GB)
```

### Why L1[0] Is Excluded

Although L1[0] exists, the OP-TEE LPAE user-mapping implementation intentionally does not use it. A user VA base of zero would include the NULL and low-address region in the user VA range and could conflict with existing user VA allocation and mapping paths that use address zero as an invalid or failure value.

This is not an architectural LPAE restriction, but a long-standing OP-TEE implementation constraint. Since the following upstream commit, the first top-level entry has been excluded from the user-mapping candidates:

```text
83651fcd11e8 ("core: lpae workaround for user mapping")
```

The search for a user VA entry therefore starts at L1[1] instead of L1[0]:

```c
for (n = 1; n < 4; n++) {
    if (tbl[n] == INVALID_DESC) {
        user_va_idx = n;
        break;
    }
}
```

All L1 entries with an index greater than or equal to 4 cannot be used because supporting 32-bit TAs requires the user VA to remain below 4GB. Together with the exclusion of L1[0], this leaves only L1[1] through L1[3] as user-mapping candidates.

## Problem

A randomized core memory map can cross a 1GB boundary and consume two of the available user-mapping entries. If the initial identity mapping consumes the remaining entry, the following corner case occurs:

```text
L1[0] = excluded from user-mapping candidates
L1[1] = used by the core mapping
L1[2] = used by the core mapping
L1[3] = used by the identity mapping
```

### Failure Sequence

1. The randomized core mapping crosses a 1GB boundary and uses two of the three L1 entries available for user mappings.
2. The identity mapping uses the remaining entry. Since it does not directly overlap the core mapping, the layout is accepted and installed in the translation tables.
3. OP-TEE then tries to select an unused L1 entry for user mappings, but none is available, so `set_user_va_idx()` triggers the assertion.

The failure occurs before any individual TA is mapped, while selecting the common L1 entry that all TA mappings would reuse, and triggers the following assertion:

```c
assert(user_va_idx != -1);
```

## Fix

Check the tentative core mapping together with the pending identity mapping before accepting an ASLR candidate.

If no level 1 entry remains available for user mappings:

1. Reject the current ASLR candidate.
2. Calculate the next ASLR candidate.
3. Reassign the tentative core virtual addresses.
4. Accept only a layout that leaves at least one user-mapping entry available.

This prevents `set_user_va_idx()` from receiving a memory layout in which all usable user VA entries are already occupied.
