### PR TITLE
Proposition of fix for the issue 7871 that have unbalanced refcount ree_fs_dirh_refcount

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -1102,6 +1102,7 @@ static TEE_Result ree_fs_readdir_rpc(struct tee_fs_dir *d,
 {
 	struct tee_fs_dirfile_dirh *dirh = NULL;
 	TEE_Result res = TEE_SUCCESS;
+	bool close = false;
 
 	mutex_lock(&ree_fs_mutex);
 
@@ -1115,7 +1116,9 @@ static TEE_Result ree_fs_readdir_rpc(struct tee_fs_dir *d,
 	if (res == TEE_SUCCESS)
 		*ent = &d->d;
 
-	put_dirh(dirh, res);
+	close = (res != TEE_SUCCESS && res != TEE_ERROR_ITEM_NOT_FOUND);
+
+	put_dirh(dirh, close);
 out:
 	mutex_unlock(&ree_fs_mutex);
 

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -710,10 +710,11 @@ static void put_dirh_primitive(bool close)
 	 * another thread may get an error or something causing that fop
 	 * to do a put with close=1.
 	 *
-	 * For all fops but ree_fs_close() there's a call to get_dirh() to
-	 * get a new dirh which will open it again if it was closed before.
-	 * But in the ree_fs_close() case there's no call to get_dirh()
-	 * only to this function, put_dirh_primitive(), and in this case
+	 * For all fops but ree_fs_close() and ree_fs_closedir_rpc() there's a
+	 * call to get_dirh() to get a new dirh which will open it again if it
+	 * was closed before. But in the ree_fs_close() and
+	 * ree_fs_closedir_rpc() cases there's no call to get_dirh() only to
+	 * this function, put_dirh_primitive(), and in this case
 	 * ree_fs_dirh may actually be NULL.
 	 */
 	ree_fs_dirh_refcount--;
@@ -1089,7 +1090,7 @@ static void ree_fs_closedir_rpc(struct tee_fs_dir *d)
 	if (d) {
 		mutex_lock(&ree_fs_mutex);
 
-		put_dirh(ree_fs_dirh, false);
+		put_dirh_primitive(false);
 		free(d);
 
 		mutex_unlock(&ree_fs_mutex);


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

Hello,

Here is a proposition of fixes for the issue : [REE FS unbalanced ree_fs_dirh_refcount due to persistent object enumeration](https://github.com/OP-TEE/optee_os/issues/7871)

This serie of patch : 
   - align the behaviour of ree_fs_closedir_rpc() with ree_fs_close()
   - update ree_fs_readdir_rpc() to not close dirh when tee_fs_dirfile_get_next() return TEE_ERROR_ITEM_NOT_FOUND.