### PR TITLE
ta: pkcs11: bounds-check EC_POINT DER header before indexing

### DIFF
--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -601,8 +601,8 @@ bool pkcs2tee_load_attr(TEE_Attribute *tee_ref, uint32_t tee_id,
 
 		der_ptr = (uint8_t *)a_ptr;
 
-		if (der_ptr[0] != 0x04) {
-			EMSG("Unsupported DER type");
+		if (a_size < 2 || der_ptr[0] != 0x04) {
+			EMSG("Invalid or too short EC_POINT attribute");
 			return false;
 		}
 
@@ -612,10 +612,19 @@ bool pkcs2tee_load_attr(TEE_Attribute *tee_ref, uint32_t tee_id,
 			hsize = 2 /* der */ + 1 /* point compression */;
 		} else if (der_ptr[1] == 0x81) {
 			/* DER long definitive form up to 255 bytes */
+			if (a_size < 3) {
+				EMSG("Invalid or too short EC_POINT attribute");
+				return false;
+			}
 			qsize = der_ptr[2];
 			hsize = 3 /* der */ + 1 /* point compression */;
 		} else {
 			EMSG("Unsupported DER long form");
+			return false;
+		}
+
+		if (a_size < hsize) {
+			EMSG("Invalid or too short EC_POINT attribute");
 			return false;
 		}
 


### PR DESCRIPTION
### What
`pkcs2tee_load_attr()` (`ta/pkcs11/src/pkcs11_helpers.c`) indexes `der_ptr[1]` (and `der_ptr[2]` for the DER long form) of a client-supplied `CKA_EC_POINT` before checking the attribute is long enough. `CKA_EC_POINT` has no minimum length, so a 1-byte value `{0x04}` makes `der_ptr[1]` a read past the declared value length, and `{0x04, 0x81}` makes `der_ptr[2]` one past.

### Scope
Defensive hardening, not an exploitable issue: the value pointer is inside the object's serialized attribute blob, so in practice this reads adjacent in-blob bytes and the later `a_size` consistency checks reject inconsistent input. Still worth tightening index only after validating the length.

### Fix
Check `a_size` before each `der_ptr[]` access (`a_size < 2` before `der_ptr[0..1]`, `a_size < 3` before `der_ptr[2]`); the existing consistency checks are unchanged.

Addresses #7877 