### PR TITLE
RPMB: support UFS 

### DIFF
--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -195,20 +195,23 @@
 /*
  * Probe next RPMB device
  *
- * value[0].a indicates kind of RPMB device found, currently is only
- * OPTEE_RPC_RPMB_EMMC supported. If another kind of RPMB device is found
- * it will have a new unique value in value[0].a and the other
- * out-parameters will be defined specifically for that device.
+ * value[0].a indicates the kind of RPMB device found (OPTEE_RPC_RPMB_*).
+ * eMMC and UFS RPMB devices are described with the same set of
+ * out-parameters: the RPMB size in units of 128 kB, the reliable write
+ * count and the raw device identifier.
  *
- * If an eMMC/RPMB partition is found:
- * [out]    value[0].a	    OPTEE_RPC_RPMB_EMMC
- * [out]    value[0].b	    EXT CSD-slice 168 "RPMB Size"
- * [out]    value[0].c	    EXT CSD-slice 222 "Reliable Write Sector Count"
+ * [out]    value[0].a	    OPTEE_RPC_RPMB_{EMMC,UFS}
+ * [out]    value[0].b	    RPMB size in units of 128 kB
+ *			    (eMMC: EXT CSD-slice 168 "RPMB Size")
+ * [out]    value[0].c	    Reliable write count
+ *			    (eMMC: EXT CSD-slice 222 "Reliable Write Sector
+ *			    Count")
  * [out]    memref[1]       Buffer with the raw CID
  */
 #define OPTEE_RPC_CMD_RPMB_PROBE_NEXT	U(23)
 
 #define OPTEE_RPC_RPMB_EMMC		U(0)
+#define OPTEE_RPC_RPMB_UFS		U(1)
 
 /*
  * Replay Protected Memory Block access

--- a/core/pta/device.c
+++ b/core/pta/device.c
@@ -105,12 +105,10 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 			rflags |= TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE;
 		break;
 	case PTA_CMD_GET_DEVICES_RPMB:
-		if (!IS_ENABLED(CFG_REE_FS)) {
-			res = tee_rpmb_reinit();
-			if (res)
-				return TEE_ERROR_STORAGE_NOT_AVAILABLE;
-			rflags = TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE;
-		}
+		res = tee_rpmb_reinit();
+		if (res)
+			return TEE_ERROR_STORAGE_NOT_AVAILABLE;
+		rflags = TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE;
 		break;
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;

--- a/core/pta/device.c
+++ b/core/pta/device.c
@@ -105,12 +105,35 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 			rflags |= TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE;
 		break;
 	case PTA_CMD_GET_DEVICES_RPMB:
-		if (!IS_ENABLED(CFG_REE_FS)) {
-			res = tee_rpmb_reinit();
-			if (res)
-				return TEE_ERROR_STORAGE_NOT_AVAILABLE;
+		/*
+		 * Issued by the kernel once it can route RPMB itself
+		 * (CFG_RPMB_ANNOUNCE_PROBE_CAP). This probe exists only to
+		 * bring up RPMB and enumerate RPMB-dependent devices, so
+		 * without CFG_RPMB_FS there is no RPMB device to init and
+		 * nothing to announce: rflags stays 0 and an empty list is
+		 * returned with TEE_SUCCESS (the probe completes cleanly
+		 * rather than erroring).
+		 *
+		 * tee_rpmb_reinit() brings up the RPMB device; failure means no
+		 * RPMB-backed storage, so fail the call.
+		 *
+		 * The DEVICE_ENUM_TEE_STORAGE_PRIVATE devices follow whatever
+		 * TEE_STORAGE_PRIVATE resolves to (tee_svc_storage_file_ops()):
+		 *   - no REE FS: it maps to RPMB, so announce them here.
+		 *   - REE FS enabled: it maps to REE FS, already announced on
+		 *     the SUPP path; announcing them here too would enumerate
+		 *     the same device twice, so rflags stays 0.
+		 */
+		if (!IS_ENABLED(CFG_RPMB_FS))
+			break;
+
+		res = tee_rpmb_reinit();
+		if (res)
+			return TEE_ERROR_STORAGE_NOT_AVAILABLE;
+
+		if (!IS_ENABLED(CFG_REE_FS))
 			rflags = TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE;
-		}
+
 		break;
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -245,9 +245,13 @@ struct rpmb_raw_data {
 #define RPMB_CID_SIZE RPMB_EMMC_CID_SIZE
 struct rpmb_dev_info {
 	uint8_t cid[RPMB_CID_SIZE];
-	/* EXT CSD-slice 168 "RPMB Size" */
+
+	/* RPMB size in units of 128 kB (eMMC: EXT CSD-slice 168 "RPMB Size") */
 	uint8_t rpmb_size_mult;
-	/* EXT CSD-slice 222 "Reliable Write Sector Count" */
+	/*
+	 * Reliable write count. eMMC: EXT CSD-slice 222 "Reliable Write Sector
+	 * Count" in 512-byte sectors. UFS: number of 256-byte RPMB frames.
+	 */
 	uint8_t rel_wr_sec_c;
 	/* Check the ret code and accept the data only if it is OK. */
 	uint8_t ret_code;
@@ -261,6 +265,7 @@ struct rpmb_dev_info {
  * @wr_cnt           Current write counter.
  * @max_blk_idx      The highest block index supported by current device.
  * @rel_wr_blkcnt    Max number of data blocks for each reliable write.
+ * @dev_type         Kind of RPMB device in use (OPTEE_RPC_RPMB_*).
  * @dev_id           Device ID of the eMMC device.
  * @wr_cnt_synced    Flag indicating if write counter is synced to RPMB.
  * @key_derived      Flag indicating if key has been generated.
@@ -276,6 +281,7 @@ struct tee_rpmb_ctx {
 	uint32_t wr_cnt;
 	uint16_t max_blk_idx;
 	uint16_t rel_wr_blkcnt;
+	uint8_t dev_type;
 	uint16_t dev_id;
 	bool wr_cnt_synced;
 	bool key_derived;
@@ -334,17 +340,22 @@ static TEE_Result tee_rpmb_key_gen(uint8_t *key, uint32_t len)
 
 	IMSG("RPMB: Using generated key");
 
+	memcpy(message, rpmb_ctx->cid, RPMB_CID_SIZE);
+
 	/*
-	 * PRV/CRC would be changed when doing eMMC FFU
-	 * The following fields should be masked off when deriving RPMB key
+	 * PRV/CRC would be changed when doing eMMC FFU, so those fields must be
+	 * masked off before deriving the RPMB key. UFS has no equivalent
+	 * mutable fields in its CID, so its raw identifier is used as-is.
 	 *
 	 * CID [55: 48]: PRV (Product revision)
 	 * CID [07: 01]: CRC (CRC7 checksum)
 	 * CID [00]: not used
 	 */
-	memcpy(message, rpmb_ctx->cid, RPMB_CID_SIZE);
-	memset(message + RPMB_CID_PRV_OFFSET, 0, 1);
-	memset(message + RPMB_CID_CRC_OFFSET, 0, 1);
+	if (rpmb_ctx->dev_type == OPTEE_RPC_RPMB_EMMC) {
+		memset(message + RPMB_CID_PRV_OFFSET, 0, 1);
+		memset(message + RPMB_CID_CRC_OFFSET, 0, 1);
+	}
+
 	return huk_subkey_derive(HUK_SUBKEY_RPMB, message, sizeof(message),
 				 key, len);
 }
@@ -543,8 +554,14 @@ static TEE_Result rpmb_probe_next(struct rpmb_dev_info *dev_info)
 	if (res)
 		return res;
 
-	if (params[0].u.value.a != OPTEE_RPC_RPMB_EMMC)
+	switch (params[0].u.value.a) {
+	case OPTEE_RPC_RPMB_EMMC:
+	case OPTEE_RPC_RPMB_UFS:
+		break;
+	default:
 		return TEE_ERROR_NOT_SUPPORTED;
+	}
+	rpmb_ctx->dev_type = params[0].u.value.a;
 
 	*dev_info = (struct rpmb_dev_info){
 		.rpmb_size_mult = params[0].u.value.b,
@@ -1137,10 +1154,21 @@ static TEE_Result rpmb_set_dev_info(const struct rpmb_dev_info *dev_info)
 
 	memcpy(rpmb_ctx->cid, dev_info->cid, RPMB_CID_SIZE);
 
-	if (IS_ENABLED(CFG_RPMB_DRIVER_MULTIPLE_WRITE_FIXED))
-		rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c * 2;
-	else
+	if (IS_ENABLED(CFG_RPMB_DRIVER_MULTIPLE_WRITE_FIXED)) {
+		/*
+		 * eMMC reports the count in 512-byte sectors (two 256-byte RPMB
+		 * blocks each), so it is doubled; UFS already reports the block
+		 * count. Clamp to one block to avoid a divide-by-zero later.
+		 */
+		if (rpmb_ctx->dev_type == OPTEE_RPC_RPMB_EMMC)
+			rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c * 2;
+		else
+			rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c;
+		if (!rpmb_ctx->rel_wr_blkcnt)
+			rpmb_ctx->rel_wr_blkcnt = 1;
+	} else {
 		rpmb_ctx->rel_wr_blkcnt = 1;
+	}
 
 	return TEE_SUCCESS;
 }
@@ -1152,6 +1180,8 @@ static TEE_Result legacy_rpmb_init(void)
 
 	DMSG("Trying legacy RPMB init");
 	rpmb_ctx->legacy_operation = true;
+	/* The legacy interface only ever describes eMMC devices. */
+	rpmb_ctx->dev_type = OPTEE_RPC_RPMB_EMMC;
 	rpmb_ctx->dev_id = CFG_RPMB_FS_DEV_ID;
 	rpmb_ctx->shm_type = THREAD_SHM_TYPE_APPLICATION;
 

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1136,7 +1136,7 @@ static TEE_Result rpmb_set_dev_info(const struct rpmb_dev_info *dev_info)
 
 	memcpy(rpmb_ctx->cid, dev_info->cid, RPMB_EMMC_CID_SIZE);
 
-	if (IS_ENABLED(RPMB_DRIVER_MULTIPLE_WRITE_FIXED))
+	if (IS_ENABLED(CFG_RPMB_DRIVER_MULTIPLE_WRITE_FIXED))
 		rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c * 2;
 	else
 		rpmb_ctx->rel_wr_blkcnt = 1;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -294,6 +294,19 @@ struct tee_rpmb_ctx {
 
 static struct tee_rpmb_ctx *rpmb_ctx;
 
+/*
+ * List of RPMB device contexts that were probed but have no authentication
+ * key written yet. While probing we defer key provisioning until every device
+ * has been examined: if some device already has a working key we use it as is.
+ */
+struct rpmb_ctx_candidate {
+	struct tee_rpmb_ctx ctx;
+	TAILQ_ENTRY(rpmb_ctx_candidate) link;
+};
+
+static TAILQ_HEAD(rpmb_ctx_candidates_head, rpmb_ctx_candidate)
+	rpmb_ctx_candidates = TAILQ_HEAD_INITIALIZER(rpmb_ctx_candidates);
+
 /* If set to true, don't try to access RPMB until rebooted */
 static bool rpmb_dead;
 
@@ -1237,6 +1250,43 @@ static TEE_Result legacy_rpmb_init(void)
 	return res;
 }
 
+static bool rpmb_ctx_list_empty(void)
+{
+	return TAILQ_EMPTY(&rpmb_ctx_candidates);
+}
+
+static TEE_Result add_rpmb_ctx_to_list(void)
+{
+	struct rpmb_ctx_candidate *cand = calloc(1, sizeof(*cand));
+
+	if (!cand)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	memcpy(&cand->ctx, rpmb_ctx, sizeof(cand->ctx));
+	TAILQ_INSERT_TAIL(&rpmb_ctx_candidates, cand, link);
+
+	return TEE_SUCCESS;
+}
+
+static void restore_rpmb_ctx_candidate(void)
+{
+	struct rpmb_ctx_candidate *cand = TAILQ_FIRST(&rpmb_ctx_candidates);
+
+	/* current trivial algorithm is to pick the first candidate */
+	assert(cand);
+	memcpy(rpmb_ctx, &cand->ctx, sizeof(*rpmb_ctx));
+}
+
+static void delete_all_rpmb_ctx_in_list(void)
+{
+	struct rpmb_ctx_candidate *cand = NULL;
+
+	while ((cand = TAILQ_FIRST(&rpmb_ctx_candidates))) {
+		TAILQ_REMOVE(&rpmb_ctx_candidates, cand, link);
+		free(cand);
+	}
+}
+
 /* This function must never return TEE_SUCCESS if rpmb_ctx == NULL */
 static TEE_Result tee_rpmb_init(void)
 {
@@ -1285,9 +1335,6 @@ static TEE_Result tee_rpmb_init(void)
 		return TEE_SUCCESS;
 
 next:
-	if (IS_ENABLED(CFG_RPMB_WRITE_KEY))
-		return legacy_rpmb_init();
-
 	res = rpmb_probe_reset();
 	if (res) {
 		if (res != TEE_ERROR_NOT_SUPPORTED &&
@@ -1299,9 +1346,18 @@ next:
 	while (true) {
 		res = rpmb_probe_next(&dev_info);
 		if (res) {
+			if (!rpmb_ctx_list_empty()) {
+				restore_rpmb_ctx_candidate();
+
+				DMSG("RPMB INIT: Auth key not yet written");
+				res = tee_rpmb_write_and_verify_key();
+				if (res == TEE_SUCCESS)
+					goto done;
+			}
 			DMSG("rpmb_probe_next error %#"PRIx32, res);
-			return res;
+			goto out;
 		}
+
 		res = rpmb_set_dev_info(&dev_info);
 		if (res) {
 			DMSG("Invalid device info, looking for another device");
@@ -1310,19 +1366,32 @@ next:
 
 		res = tee_rpmb_key_gen(rpmb_ctx->key, RPMB_KEY_MAC_SIZE);
 		if (res)
-			return res;
+			goto out;
 
 		res = tee_rpmb_init_read_wr_cnt(&rpmb_ctx->wr_cnt);
-		if (res)
-			continue;
-		break;
-	}
+		if (res == TEE_SUCCESS) {
+			DMSG("Found working RPMB device");
+			goto done;
+		}
 
-	DMSG("Found working RPMB device");
+		if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+			/* Found a disk candidate to be provisioned */
+			if (!IS_ENABLED(CFG_RPMB_WRITE_KEY))
+				continue;
+
+			res = add_rpmb_ctx_to_list();
+			if (res)
+				goto out;
+		}
+	}
+done:
 	rpmb_ctx->key_verified = true;
 	rpmb_ctx->wr_cnt_synced = true;
+	res = TEE_SUCCESS;
 
-	return TEE_SUCCESS;
+out:
+	delete_all_rpmb_ctx_in_list();
+	return res;
 }
 
 TEE_Result tee_rpmb_reinit(void)

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -242,8 +242,9 @@ struct rpmb_raw_data {
 };
 
 #define RPMB_EMMC_CID_SIZE 16
+#define RPMB_CID_SIZE RPMB_EMMC_CID_SIZE
 struct rpmb_dev_info {
-	uint8_t cid[RPMB_EMMC_CID_SIZE];
+	uint8_t cid[RPMB_CID_SIZE];
 	/* EXT CSD-slice 168 "RPMB Size" */
 	uint8_t rpmb_size_mult;
 	/* EXT CSD-slice 222 "Reliable Write Sector Count" */
@@ -271,7 +272,7 @@ struct rpmb_dev_info {
  */
 struct tee_rpmb_ctx {
 	uint8_t key[RPMB_KEY_MAC_SIZE];
-	uint8_t cid[RPMB_EMMC_CID_SIZE];
+	uint8_t cid[RPMB_CID_SIZE];
 	uint32_t wr_cnt;
 	uint16_t max_blk_idx;
 	uint16_t rel_wr_blkcnt;
@@ -326,7 +327,7 @@ out:
 
 static TEE_Result tee_rpmb_key_gen(uint8_t *key, uint32_t len)
 {
-	uint8_t message[RPMB_EMMC_CID_SIZE];
+	uint8_t message[RPMB_CID_SIZE];
 
 	if (!key || RPMB_KEY_MAC_SIZE != len)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -341,7 +342,7 @@ static TEE_Result tee_rpmb_key_gen(uint8_t *key, uint32_t len)
 	 * CID [07: 01]: CRC (CRC7 checksum)
 	 * CID [00]: not used
 	 */
-	memcpy(message, rpmb_ctx->cid, RPMB_EMMC_CID_SIZE);
+	memcpy(message, rpmb_ctx->cid, RPMB_CID_SIZE);
 	memset(message + RPMB_CID_PRV_OFFSET, 0, 1);
 	memset(message + RPMB_CID_CRC_OFFSET, 0, 1);
 	return huk_subkey_derive(HUK_SUBKEY_RPMB, message, sizeof(message),
@@ -1134,7 +1135,7 @@ static TEE_Result rpmb_set_dev_info(const struct rpmb_dev_info *dev_info)
 	    SUB_OVERFLOW(nblocks, 1, &rpmb_ctx->max_blk_idx))
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	memcpy(rpmb_ctx->cid, dev_info->cid, RPMB_EMMC_CID_SIZE);
+	memcpy(rpmb_ctx->cid, dev_info->cid, RPMB_CID_SIZE);
 
 	if (IS_ENABLED(CFG_RPMB_DRIVER_MULTIPLE_WRITE_FIXED))
 		rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c * 2;
@@ -1243,7 +1244,7 @@ static TEE_Result tee_rpmb_init(void)
 				return res;
 			}
 			if (!memcmp(rpmb_ctx->cid, dev_info.cid,
-				    RPMB_EMMC_CID_SIZE)) {
+				    RPMB_CID_SIZE)) {
 				rpmb_ctx->reinit = false;
 				return TEE_SUCCESS;
 			}

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -245,9 +245,13 @@ struct rpmb_raw_data {
 #define RPMB_CID_SIZE RPMB_EMMC_CID_SIZE
 struct rpmb_dev_info {
 	uint8_t cid[RPMB_CID_SIZE];
-	/* EXT CSD-slice 168 "RPMB Size" */
+
+	/* RPMB size in units of 128 kB (eMMC: EXT CSD-slice 168 "RPMB Size") */
 	uint8_t rpmb_size_mult;
-	/* EXT CSD-slice 222 "Reliable Write Sector Count" */
+	/*
+	 * Reliable write count. eMMC: EXT CSD-slice 222 "Reliable Write Sector
+	 * Count" in 512-byte sectors. UFS: number of 256-byte RPMB frames.
+	 */
 	uint8_t rel_wr_sec_c;
 	/* Check the ret code and accept the data only if it is OK. */
 	uint8_t ret_code;
@@ -261,6 +265,7 @@ struct rpmb_dev_info {
  * @wr_cnt           Current write counter.
  * @max_blk_idx      The highest block index supported by current device.
  * @rel_wr_blkcnt    Max number of data blocks for each reliable write.
+ * @dev_type         Kind of RPMB device in use (OPTEE_RPC_RPMB_*).
  * @dev_id           Device ID of the eMMC device.
  * @wr_cnt_synced    Flag indicating if write counter is synced to RPMB.
  * @key_derived      Flag indicating if key has been generated.
@@ -276,6 +281,7 @@ struct tee_rpmb_ctx {
 	uint32_t wr_cnt;
 	uint16_t max_blk_idx;
 	uint16_t rel_wr_blkcnt;
+	uint8_t dev_type;
 	uint16_t dev_id;
 	bool wr_cnt_synced;
 	bool key_derived;
@@ -334,17 +340,22 @@ static TEE_Result tee_rpmb_key_gen(uint8_t *key, uint32_t len)
 
 	IMSG("RPMB: Using generated key");
 
+	memcpy(message, rpmb_ctx->cid, RPMB_CID_SIZE);
+
 	/*
-	 * PRV/CRC would be changed when doing eMMC FFU
-	 * The following fields should be masked off when deriving RPMB key
+	 * PRV/CRC would be changed when doing eMMC FFU, so those fields must be
+	 * masked off before deriving the RPMB key. UFS has no equivalent
+	 * mutable fields in its CID, so its raw identifier is used as-is.
 	 *
 	 * CID [55: 48]: PRV (Product revision)
 	 * CID [07: 01]: CRC (CRC7 checksum)
 	 * CID [00]: not used
 	 */
-	memcpy(message, rpmb_ctx->cid, RPMB_CID_SIZE);
-	memset(message + RPMB_CID_PRV_OFFSET, 0, 1);
-	memset(message + RPMB_CID_CRC_OFFSET, 0, 1);
+	if (rpmb_ctx->dev_type == OPTEE_RPC_RPMB_EMMC) {
+		memset(message + RPMB_CID_PRV_OFFSET, 0, 1);
+		memset(message + RPMB_CID_CRC_OFFSET, 0, 1);
+	}
+
 	return huk_subkey_derive(HUK_SUBKEY_RPMB, message, sizeof(message),
 				 key, len);
 }
@@ -543,8 +554,14 @@ static TEE_Result rpmb_probe_next(struct rpmb_dev_info *dev_info)
 	if (res)
 		return res;
 
-	if (params[0].u.value.a != OPTEE_RPC_RPMB_EMMC)
+	switch (params[0].u.value.a) {
+	case OPTEE_RPC_RPMB_EMMC:
+	case OPTEE_RPC_RPMB_UFS:
+		break;
+	default:
 		return TEE_ERROR_NOT_SUPPORTED;
+	}
+	rpmb_ctx->dev_type = params[0].u.value.a;
 
 	*dev_info = (struct rpmb_dev_info){
 		.rpmb_size_mult = params[0].u.value.b,
@@ -1137,10 +1154,25 @@ static TEE_Result rpmb_set_dev_info(const struct rpmb_dev_info *dev_info)
 
 	memcpy(rpmb_ctx->cid, dev_info->cid, RPMB_CID_SIZE);
 
-	if (IS_ENABLED(CFG_RPMB_DRIVER_MULTIPLE_WRITE_FIXED))
-		rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c * 2;
-	else
+	if (IS_ENABLED(CFG_RPMB_DRIVER_MULTIPLE_WRITE_FIXED)) {
+		/*
+		 * eMMC reports the count in 512-byte sectors (two 256-byte RPMB
+		 * blocks each), so it is doubled; UFS already reports the block
+		 * count.
+		 */
+		if (rpmb_ctx->dev_type == OPTEE_RPC_RPMB_EMMC)
+			rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c * 2;
+		else
+			rpmb_ctx->rel_wr_blkcnt = dev_info->rel_wr_sec_c;
+		if (!rpmb_ctx->rel_wr_blkcnt) {
+			/* Not fatal: fall back to single-block writes rather */
+			/* than reject a device that is otherwise usable. */
+			DMSG("RPMB: rel_wr_sec_c 0, using 1 block");
+			rpmb_ctx->rel_wr_blkcnt = 1;
+		}
+	} else {
 		rpmb_ctx->rel_wr_blkcnt = 1;
+	}
 
 	return TEE_SUCCESS;
 }
@@ -1152,6 +1184,8 @@ static TEE_Result legacy_rpmb_init(void)
 
 	DMSG("Trying legacy RPMB init");
 	rpmb_ctx->legacy_operation = true;
+	/* The legacy interface only ever describes eMMC devices. */
+	rpmb_ctx->dev_type = OPTEE_RPC_RPMB_EMMC;
 	rpmb_ctx->dev_id = CFG_RPMB_FS_DEV_ID;
 	rpmb_ctx->shm_type = THREAD_SHM_TYPE_APPLICATION;
 

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1296,9 +1296,15 @@ next:
 
 TEE_Result tee_rpmb_reinit(void)
 {
+	TEE_Result res = TEE_SUCCESS;
+
+	mutex_lock(&rpmb_mutex);
 	if (rpmb_ctx)
 		rpmb_ctx->reinit = true;
-	return tee_rpmb_init();
+	res = tee_rpmb_init();
+	mutex_unlock(&rpmb_mutex);
+
+	return res;
 }
 
 /*

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1177,6 +1177,24 @@ static TEE_Result rpmb_set_dev_info(const struct rpmb_dev_info *dev_info)
 	return TEE_SUCCESS;
 }
 
+static bool rpmb_cid_match(const uint8_t *cid)
+{
+	const char *hs = CFG_RPMB_WRITE_KEY_CID;
+	uint8_t want[RPMB_CID_SIZE] = { };
+	uint32_t n = 0;
+
+	if (!hs[0])
+		return true;
+
+	n = tee_hs2b((uint8_t *)hs, want, strlen(hs), sizeof(want));
+	if (n != RPMB_CID_SIZE) {
+		EMSG("Invalid CFG_RPMB_WRITE_KEY_CID");
+		return false;
+	}
+
+	return !memcmp(cid, want, RPMB_CID_SIZE);
+}
+
 static TEE_Result legacy_rpmb_init(void)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -1231,7 +1249,10 @@ static TEE_Result legacy_rpmb_init(void)
 			 * Need to write the key here and verify it.
 			 */
 			DMSG("RPMB INIT: Auth key not yet written");
-			res = tee_rpmb_write_and_verify_key();
+			if (rpmb_cid_match(rpmb_ctx->cid))
+				res = tee_rpmb_write_and_verify_key();
+			else
+				EMSG("CID mismatch, CFG_RPMB_WRITE_KEY_CID");
 		} else {
 			EMSG("Verify key failed! %#"PRIx32, res);
 			EMSG("Make sure key here matches device key");
@@ -1336,6 +1357,9 @@ next:
 				continue;
 
 			if (!have_cand) {
+				if (!rpmb_cid_match(rpmb_ctx->cid))
+					continue;
+
 				memcpy(&cand, rpmb_ctx, sizeof(cand));
 				have_cand = true;
 			}

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1246,6 +1246,8 @@ static TEE_Result tee_rpmb_init(void)
 {
 	TEE_Result res = TEE_SUCCESS;
 	struct rpmb_dev_info dev_info = { };
+	struct tee_rpmb_ctx cand = { };
+	bool have_cand = false;
 
 	if (rpmb_dead)
 		return TEE_ERROR_COMMUNICATION;
@@ -1289,9 +1291,6 @@ static TEE_Result tee_rpmb_init(void)
 		return TEE_SUCCESS;
 
 next:
-	if (IS_ENABLED(CFG_RPMB_WRITE_KEY))
-		return legacy_rpmb_init();
-
 	res = rpmb_probe_reset();
 	if (res) {
 		if (res != TEE_ERROR_NOT_SUPPORTED &&
@@ -1303,9 +1302,18 @@ next:
 	while (true) {
 		res = rpmb_probe_next(&dev_info);
 		if (res) {
+			if (have_cand) {
+				memcpy(rpmb_ctx, &cand, sizeof(*rpmb_ctx));
+
+				DMSG("RPMB INIT: Auth key not yet written");
+				res = tee_rpmb_write_and_verify_key();
+				if (res == TEE_SUCCESS)
+					goto done;
+			}
 			DMSG("rpmb_probe_next error %#"PRIx32, res);
 			return res;
 		}
+
 		res = rpmb_set_dev_info(&dev_info);
 		if (res) {
 			DMSG("Invalid device info, looking for another device");
@@ -1317,12 +1325,23 @@ next:
 			return res;
 
 		res = tee_rpmb_init_read_wr_cnt(&rpmb_ctx->wr_cnt);
-		if (res)
-			continue;
-		break;
-	}
+		if (res == TEE_SUCCESS) {
+			DMSG("Found working RPMB device");
+			goto done;
+		}
 
-	DMSG("Found working RPMB device");
+		if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+			/* Remember the first candidate to be provisioned */
+			if (!IS_ENABLED(CFG_RPMB_WRITE_KEY))
+				continue;
+
+			if (!have_cand) {
+				memcpy(&cand, rpmb_ctx, sizeof(cand));
+				have_cand = true;
+			}
+		}
+	}
+done:
 	rpmb_ctx->key_verified = true;
 	rpmb_ctx->wr_cnt_synced = true;
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -231,6 +231,12 @@ CFG_RPMB_TESTKEY ?= n
 # - RPMB key provisioning in a controlled environment (factory setup)
 CFG_RPMB_WRITE_KEY ?= n
 
+# Restricts RPMB key provisioning to the device whose CID matches this
+# upper-case hex string (2 * RPMB_CID_SIZE chars). Empty: provision the first.
+# Set as a quoted string, e.g.
+# CFG_RPMB_WRITE_KEY_CID='"112233445566778899AABBCCDDEEFF00"'
+CFG_RPMB_WRITE_KEY_CID ?= ""
+
 # For the kernel driver to enable in-kernel RPMB routing it must know in
 # advance that OP-TEE supports it. Setting CFG_RPMB_ANNOUNCE_PROBE_CAP=y
 # will announce OP-TEE's capability for RPMB probing to the kernel and it


### PR DESCRIPTION
## OP-TEE RPMB on UFS — the key-derivation ABI

This PR lets OP-TEE use RPMB secure storage on **UFS-only** platforms (no eMMC).
RPMB security rests on an authentication key that OP-TEE derives **in the secure
world** from its HUK and a device id (`dev_id`) handed down by the normal world:

```
key    = HMAC(HUK, dev_id)
dev_id = a fixed 16-byte value supplied by the normal world
```

OP-TEE's flow was written for eMMC, where `dev_id` is the 16-byte eMMC **CID**.
To reuse that flow unchanged for UFS, the normal world presents a `dev_id` with
the same fixed 16-byte layout by hashing the (variable-length) UFS identifier.

### The ABI

**OP-TEE consumes `dev_id` verbatim (from MMC or UFS) — it does no hashing itself.** Every normal
world that drives OP-TEE RPMB on UFS therefore has to derive the *same* `dev_id`,
or the derived key changes and the RPMB becomes inaccessible (or is provisioned
with a key the other world cannot reproduce):

```
dev_id = BLAKE2b( "<UFS device_id>-R<region>" )    // unkeyed, 16-byte digest
```

| Element | Value | Why it is ABI |
|---|---|---|
| Algorithm | **BLAKE2b**, unkeyed | chosen so bootloaders (U-Boot) can reproduce it without pulling in BLAKE2s |
| Digest length | **16 bytes** | matches the eMMC CID layout; BLAKE2b folds the output length into its IV, so a 16-byte digest is **not** a truncated 64-byte hash |
| Input string | `"<device_id>-R<region>"` | `device_id` is the kernel's `ufshcd_create_device_id()`; one `dev_id` per RPMB region |


<img width="1670" height="1045" alt="image" src="https://github.com/user-attachments/assets/a2351fb2-88ae-4d17-ad96-25f2bcf8bb41" />

### Who agrees on it

```mermaid
flowchart TB
    UB["U-Boot — boot-time supplicant<br/>builds dev_id"]
    LX["Linux — runtime supplicant<br/>builds dev_id"]
    OT["OP-TEE (this PR)<br/>key = HMAC(HUK, dev_id)"]
    HW["UFS RPMB Well-Known LUN"]
    UB -- "same 16-byte dev_id" --> OT
    LX -- "same 16-byte dev_id" --> OT
    OT --> HW
```

U-Boot and Linux never call each other, but both must compute the **byte-identical**
`dev_id`. OP-TEE alone ever programs the key; the normal world only carries frames.

### Companion series (land together / keep in lockstep)

- **Linux** 
     (`ufs: rpmb`, v3): 
           https://lkml.org/lkml/2026/8/21/1486 
- **U-Boot** 
     (UFS RPMB transport + OP-TEE subsystem supplicant, v4):   
          https://patchwork.ozlabs.org/project/uboot/list/?series=517522

Changing the algorithm, digest length, or input string in any one project is an
**ABI break** that orphans data already written to a provisioned RPMB.


**NOTE**:

I only have one Lemans board so I chose to provision using U-boot instead of Linux: so Linux provisioning is untested.

**Test**
1. provision RPMB key using u-boot 
2. RPMB read/write access from u-boot/linux
