### PR TITLE
ta: pkcs11: bounds-check EC_POINT DER header before indexing

### DIFF
--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -601,8 +601,8 @@ bool pkcs2tee_load_attr(TEE_Attribute *tee_ref, uint32_t tee_id,
 
 		der_ptr = (uint8_t *)a_ptr;
 
-		if (der_ptr[0] != 0x04) {
-			EMSG("Unsupported DER type");
+		if (a_size < 2 || der_ptr[0] != 0x04) {
+			EMSG("Invalid or too short EC_POINT attribute");
 			return false;
 		}
 
@@ -612,6 +612,10 @@ bool pkcs2tee_load_attr(TEE_Attribute *tee_ref, uint32_t tee_id,
 			hsize = 2 /* der */ + 1 /* point compression */;
 		} else if (der_ptr[1] == 0x81) {
 			/* DER long definitive form up to 255 bytes */
+			if (a_size < 3) {
+				EMSG("Invalid or too short EC_POINT attribute");
+				return false;
+			}
 			qsize = der_ptr[2];
 			hsize = 3 /* der */ + 1 /* point compression */;
 		} else {


### PR DESCRIPTION
 `pkcs2tee_load_attr()` reads `der_ptr[1]` (and `der_ptr[2]` for the `DER` long form) of a client-supplied `CKA_EC_POINT` attribute before checking that the value is long enough.  

 `CKA_EC_POINT` has no minimum length, so a 1-byte value {0x04} makes `der_ptr[1]` a read past the declared value length (and {0x04,0x81} makes `der_ptr[2]` one past).  

This is a defensive hardening fix, not a security vulnerability: the value pointer lies inside the object's serialized attribute blob, so in practice this reads adjacent in-blob bytes of the same allocation (no crash observed), and the later `a_size` consistency checks reject the input nothing derived from the over-read is returned to the client. 

The fix guards a_size before each der_ptr[] access. No functional change for valid inputs.



