### PR TITLE
drivers: crypto: ele: add ECC driver for i.MX91/i.MX93

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -259,10 +259,10 @@ CFG_TEE_CORE_NB_CORE ?= 2
 $(call force,CFG_NXP_SNVS,n)
 $(call force,CFG_IMX_OCOTP,n)
 $(call force,CFG_TZC380,n)
-$(call force,CFG_CRYPTO_DRIVER,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
 CFG_IMX_ELE ?= y
+CFG_IMX_ELE_ECC_DRV ?= y
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx95-flavorlist)))
 $(call force,CFG_MX95,y)
 $(call force,CFG_ARM64_core,y)
@@ -287,6 +287,7 @@ $(call force,CFG_TZC380,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
 CFG_IMX_ELE ?= y
+CFG_IMX_ELE_ECC_DRV ?= y
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx943-flavorlist)))
 $(call force,CFG_MX943,y)
 $(call force,CFG_ARM64_core,y)

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -262,10 +262,10 @@ CFG_TEE_CORE_NB_CORE ?= 2
 $(call force,CFG_NXP_SNVS,n)
 $(call force,CFG_IMX_OCOTP,n)
 $(call force,CFG_TZC380,n)
-$(call force,CFG_CRYPTO_DRIVER,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
 CFG_IMX_ELE ?= y
+CFG_IMX_ELE_ECC_DRV ?= y
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx95-flavorlist)))
 $(call force,CFG_MX95,y)
 $(call force,CFG_ARM64_core,y)
@@ -290,6 +290,7 @@ $(call force,CFG_TZC380,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
 CFG_IMX_ELE ?= y
+CFG_IMX_ELE_ECC_DRV ?= y
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx943-flavorlist)))
 $(call force,CFG_MX943,y)
 $(call force,CFG_ARM64_core,y)

--- a/core/drivers/crypto/ele/acipher/ecc.c
+++ b/core/drivers/crypto/ele/acipher/ecc.c
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2026 NXP
+ */
+#include <config.h>
+#include <crypto/crypto_impl.h>
+#include <drvcrypt.h>
+#include <drvcrypt_acipher.h>
+#include <ecc.h>
+#include <initcall.h>
+#include <key_mgmt.h>
+#include <sign_verify.h>
+#include <string.h>
+#include <tee_api_defines_extensions.h>
+#include <utee_defines.h>
+#include <util.h>
+
+/*
+ * Software fallback ops retrieved once at init time.  Used for curves and
+ * algorithms that ELE does not support (SM2, ECDH, …).
+ */
+static const struct crypto_ecc_keypair_ops *pair_ops;
+static const struct crypto_ecc_public_ops *pub_ops;
+
+/* Map a TEE curve identifier to the key size in bits. */
+static TEE_Result curve_to_bits(uint32_t curve, size_t *key_size_bits)
+{
+	switch (curve) {
+	case TEE_ECC_CURVE_NIST_P224:
+		*key_size_bits = 224;
+		break;
+	case TEE_ECC_CURVE_NIST_P256:
+		*key_size_bits = 256;
+		break;
+	case TEE_ECC_CURVE_NIST_P384:
+		*key_size_bits = 384;
+		break;
+	case TEE_ECC_CURVE_NIST_P521:
+		*key_size_bits = 521;
+		break;
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Derive the ELE algorithm identifier from the TEE algorithm and validate
+ * that the curve size matches the digest size.
+ *
+ * Returns TEE_SUCCESS and sets *key_size_bits / *ele_algo on success, or
+ * TEE_ERROR_NOT_IMPLEMENTED for unsupported combinations.
+ */
+static TEE_Result get_key_size_and_algo(uint32_t curve, uint32_t tee_algo,
+					size_t digest_size,
+					size_t *key_size_bits,
+					uint32_t *ele_algo)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t bits = 0;
+
+	res = curve_to_bits(curve, &bits);
+	if (res)
+		return res;
+
+	switch (tee_algo) {
+	case TEE_ALG_ECDSA_SHA224:
+		if (bits != 224 || digest_size != TEE_SHA224_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA224;
+		break;
+	case TEE_ALG_ECDSA_SHA256:
+		if (bits != 256 || digest_size != TEE_SHA256_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA256;
+		break;
+	case TEE_ALG_ECDSA_SHA384:
+		if (bits != 384 || digest_size != TEE_SHA384_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA384;
+		break;
+	case TEE_ALG_ECDSA_SHA512:
+		if (bits != 521 || digest_size != TEE_SHA512_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA512;
+		break;
+	default:
+		DMSG("Unsupported algorithm %#" PRIx32, tee_algo);
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	*key_size_bits = bits;
+
+	return TEE_SUCCESS;
+
+err:
+	DMSG("Curve size / digest size mismatch for algo %#" PRIx32, tee_algo);
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static TEE_Result do_allocate_keypair(struct ecc_keypair *key, uint32_t type,
+				      size_t size_bits)
+{
+	switch (type) {
+	case TEE_TYPE_ECDH_KEYPAIR:
+	case TEE_TYPE_SM2_PKE_KEYPAIR:
+	case TEE_TYPE_SM2_DSA_KEYPAIR:
+		/* Not supported by ELE — let the framework use software */
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	default:
+		break;
+	}
+
+	if (!key)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(key, 0, sizeof(*key));
+
+	key->d = crypto_bignum_allocate(size_bits);
+	if (!key->d)
+		goto err;
+
+	key->x = crypto_bignum_allocate(size_bits);
+	if (!key->x)
+		goto err;
+
+	key->y = crypto_bignum_allocate(size_bits);
+	if (!key->y)
+		goto err;
+
+	return TEE_SUCCESS;
+
+err:
+	crypto_bignum_free(&key->d);
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
+
+	return TEE_ERROR_OUT_OF_MEMORY;
+}
+
+static TEE_Result do_allocate_publickey(struct ecc_public_key *key,
+					uint32_t type, size_t size_bits)
+{
+	switch (type) {
+	case TEE_TYPE_ECDH_PUBLIC_KEY:
+	case TEE_TYPE_SM2_PKE_PUBLIC_KEY:
+	case TEE_TYPE_SM2_DSA_PUBLIC_KEY:
+		/* Not supported by ELE — let the framework use software */
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	default:
+		break;
+	}
+
+	if (!key)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(key, 0, sizeof(*key));
+
+	key->x = crypto_bignum_allocate(size_bits);
+	if (!key->x)
+		goto err;
+
+	key->y = crypto_bignum_allocate(size_bits);
+	if (!key->y)
+		goto err;
+
+	return TEE_SUCCESS;
+
+err:
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
+
+	return TEE_ERROR_OUT_OF_MEMORY;
+}
+
+static void do_free_publickey(struct ecc_public_key *key)
+{
+	if (!key)
+		return;
+
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
+}
+
+static TEE_Result do_gen_keypair(struct ecc_keypair *key, size_t size_bits)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t key_size_bits = 0;
+	size_t key_size = 0;
+	uint8_t *pub_buf = NULL;
+	uint8_t *priv_buf = NULL;
+
+	if (!key || !size_bits)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = curve_to_bits(key->curve, &key_size_bits);
+	if (res) {
+		if (!IS_ENABLED(CFG_IMX_ELE_ECC_DRV_FALLBACK))
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		DMSG("ELE ECC keygen fallback to software");
+		return pair_ops->generate(key, size_bits);
+	}
+
+	key_size = ROUNDUP_DIV(key_size_bits, 8);
+
+	pub_buf = calloc(1, key_size * 2);
+	if (!pub_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	priv_buf = calloc(1, key_size);
+	if (!priv_buf) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	res = imx_ele_generate_keypair(priv_buf, key_size,
+				       pub_buf, key_size * 2,
+				       ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1,
+				       key_size_bits);
+	if (res) {
+		EMSG("ELE key generation failed");
+		goto out;
+	}
+
+	crypto_bignum_bin2bn(pub_buf, key_size, key->x);
+	crypto_bignum_bin2bn(pub_buf + key_size, key_size, key->y);
+	crypto_bignum_bin2bn(priv_buf, key_size, key->d);
+
+out:
+	free(pub_buf);
+	free(priv_buf);
+
+	return res;
+}
+
+static TEE_Result do_sign(struct drvcrypt_sign_data *sdata)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct ecc_keypair *key = NULL;
+	size_t key_size_bits = 0;
+	size_t key_size = 0;
+	uint32_t ele_algo = 0;
+	uint8_t *priv_buf = NULL;
+	size_t d_size = 0;
+	size_t sig_len = 0;
+
+	if (!sdata || !sdata->key || !sdata->message.data ||
+	    !sdata->signature.data || !sdata->message.length)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	key = sdata->key;
+
+	res = get_key_size_and_algo(key->curve, sdata->algo,
+				    sdata->message.length,
+				    &key_size_bits, &ele_algo);
+	if (res) {
+		if (!IS_ENABLED(CFG_IMX_ELE_ECC_DRV_FALLBACK))
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		DMSG("ELE ECC sign fallback to software");
+		return pair_ops->sign(sdata->algo, sdata->key,
+				      sdata->message.data,
+				      sdata->message.length,
+				      sdata->signature.data,
+				      &sdata->signature.length);
+	}
+
+	key_size = ROUNDUP_DIV(key_size_bits, 8);
+	sig_len = key_size * 2;
+
+	priv_buf = calloc(1, key_size);
+	if (!priv_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/*
+	 * The bignum representation may be shorter than the key size when
+	 * leading zeros are stripped; right-align the scalar in the buffer.
+	 */
+	d_size = crypto_bignum_num_bytes(key->d);
+	crypto_bignum_bn2bin(key->d, priv_buf + key_size - d_size);
+
+	res = imx_ele_signature_generate(priv_buf, key_size,
+					 sdata->message.data,
+					 sdata->message.length,
+					 sdata->signature.data,
+					 sig_len,
+					 ele_algo,
+					 ELE_SIG_GEN_MSG_TYPE_DIGEST,
+					 ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1,
+					 key_size_bits);
+	if (res) {
+		EMSG("ELE signature generation failed");
+		goto out;
+	}
+
+	sdata->signature.length = sig_len;
+
+out:
+	free(priv_buf);
+
+	return res;
+}
+
+static TEE_Result do_verify(struct drvcrypt_sign_data *sdata)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct ecc_public_key *key = NULL;
+	size_t key_size_bits = 0;
+	size_t key_size = 0;
+	uint32_t ele_algo = 0;
+	uint8_t *pub_buf = NULL;
+	size_t x_size = 0;
+	size_t y_size = 0;
+
+	if (!sdata || !sdata->key || !sdata->message.data ||
+	    !sdata->signature.data || !sdata->message.length ||
+	    !sdata->signature.length)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	key = sdata->key;
+
+	res = get_key_size_and_algo(key->curve, sdata->algo,
+				    sdata->message.length,
+				    &key_size_bits, &ele_algo);
+	if (res) {
+		if (!IS_ENABLED(CFG_IMX_ELE_ECC_DRV_FALLBACK))
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		DMSG("ELE ECC verify fallback to software");
+		return pub_ops->verify(sdata->algo, sdata->key,
+				       sdata->message.data,
+				       sdata->message.length,
+				       sdata->signature.data,
+				       sdata->signature.length);
+	}
+
+	key_size = ROUNDUP_DIV(key_size_bits, 8);
+
+	pub_buf = calloc(1, key_size * 2);
+	if (!pub_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/*
+	 * Right-align each coordinate in its half of the buffer to handle
+	 * bignums with stripped leading zeros.
+	 */
+	x_size = crypto_bignum_num_bytes(key->x);
+	crypto_bignum_bn2bin(key->x, pub_buf + key_size - x_size);
+
+	y_size = crypto_bignum_num_bytes(key->y);
+	crypto_bignum_bn2bin(key->y, pub_buf + key_size + (key_size - y_size));
+
+	res = imx_ele_signature_verify(pub_buf, key_size * 2,
+				       sdata->message.data,
+				       sdata->message.length,
+				       sdata->signature.data,
+				       sdata->signature.length,
+				       key_size_bits,
+				       ELE_KEY_TYPE_ECC_PUB_KEY_SECP_R1,
+				       ele_algo,
+				       ELE_SIG_GEN_MSG_TYPE_DIGEST);
+	if (res)
+		EMSG("ELE signature verification failed: res=0x%x", res);
+
+	free(pub_buf);
+
+	return res;
+}
+
+static struct drvcrypt_ecc driver_ecc = {
+	.alloc_keypair   = do_allocate_keypair,
+	.alloc_publickey = do_allocate_publickey,
+	.free_publickey  = do_free_publickey,
+	.gen_keypair     = do_gen_keypair,
+	.sign            = do_sign,
+	.verify          = do_verify,
+};
+
+TEE_Result imx_ele_ecc_init(void)
+{
+	pub_ops = crypto_asym_get_ecc_public_ops(TEE_TYPE_ECDSA_PUBLIC_KEY);
+	if (!pub_ops)
+		return TEE_ERROR_GENERIC;
+
+	pair_ops = crypto_asym_get_ecc_keypair_ops(TEE_TYPE_ECDSA_KEYPAIR);
+	if (!pair_ops)
+		return TEE_ERROR_GENERIC;
+
+	if (drvcrypt_register_ecc(&driver_ecc))
+		return TEE_ERROR_GENERIC;
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/crypto/ele/acipher/ecc.c
+++ b/core/drivers/crypto/ele/acipher/ecc.c
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2026 NXP
+ */
+#include <config.h>
+#include <crypto/crypto_impl.h>
+#include <drvcrypt.h>
+#include <drvcrypt_acipher.h>
+#include <ecc.h>
+#include <initcall.h>
+#include <key_mgmt.h>
+#include <sign_verify.h>
+#include <string.h>
+#include <stdlib_ext.h>
+#include <tee_api_defines_extensions.h>
+#include <utee_defines.h>
+#include <util.h>
+
+/*
+ * Software fallback ops retrieved once at init time.  Used for curves and
+ * algorithms that ELE does not support (SM2, ECDH, …).
+ */
+static const struct crypto_ecc_keypair_ops *pair_ops;
+static const struct crypto_ecc_public_ops *pub_ops;
+
+/* Map a TEE curve identifier to the key size in bits. */
+static TEE_Result curve_to_bits(uint32_t curve, size_t *key_size_bits)
+{
+	switch (curve) {
+	case TEE_ECC_CURVE_NIST_P224:
+		*key_size_bits = 224;
+		break;
+	case TEE_ECC_CURVE_NIST_P256:
+		*key_size_bits = 256;
+		break;
+	case TEE_ECC_CURVE_NIST_P384:
+		*key_size_bits = 384;
+		break;
+	case TEE_ECC_CURVE_NIST_P521:
+		*key_size_bits = 521;
+		break;
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Derive the ELE algorithm identifier from the TEE algorithm and validate
+ * that the curve size matches the digest size.
+ *
+ * Returns TEE_SUCCESS and sets *key_size_bits / *ele_algo on success, or
+ * TEE_ERROR_NOT_IMPLEMENTED for unsupported combinations.
+ */
+static TEE_Result get_key_size_and_algo(uint32_t curve, uint32_t tee_algo,
+					size_t digest_size,
+					size_t *key_size_bits,
+					uint32_t *ele_algo)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t bits = 0;
+
+	res = curve_to_bits(curve, &bits);
+	if (res)
+		return res;
+
+	switch (tee_algo) {
+	case TEE_ALG_ECDSA_SHA224:
+		if (bits != 224 || digest_size != TEE_SHA224_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA224;
+		break;
+	case TEE_ALG_ECDSA_SHA256:
+		if (bits != 256 || digest_size != TEE_SHA256_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA256;
+		break;
+	case TEE_ALG_ECDSA_SHA384:
+		if (bits != 384 || digest_size != TEE_SHA384_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA384;
+		break;
+	case TEE_ALG_ECDSA_SHA512:
+		if (bits != 521 || digest_size != TEE_SHA512_HASH_SIZE)
+			goto err;
+		*ele_algo = ELE_ALGO_ECDSA_SHA512;
+		break;
+	default:
+		DMSG("Unsupported algorithm %#" PRIx32, tee_algo);
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	*key_size_bits = bits;
+
+	return TEE_SUCCESS;
+
+err:
+	DMSG("Curve size / digest size mismatch for algo %#" PRIx32, tee_algo);
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static TEE_Result do_allocate_keypair(struct ecc_keypair *key, uint32_t type,
+				      size_t size_bits)
+{
+	switch (type) {
+	case TEE_TYPE_ECDH_KEYPAIR:
+	case TEE_TYPE_SM2_PKE_KEYPAIR:
+	case TEE_TYPE_SM2_DSA_KEYPAIR:
+		/* Not supported by ELE — let the framework use software */
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	default:
+		break;
+	}
+
+	if (!key)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(key, 0, sizeof(*key));
+
+	key->d = crypto_bignum_allocate(size_bits);
+	if (!key->d)
+		goto err;
+
+	key->x = crypto_bignum_allocate(size_bits);
+	if (!key->x)
+		goto err;
+
+	key->y = crypto_bignum_allocate(size_bits);
+	if (!key->y)
+		goto err;
+
+	return TEE_SUCCESS;
+
+err:
+	crypto_bignum_free(&key->d);
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
+
+	return TEE_ERROR_OUT_OF_MEMORY;
+}
+
+static TEE_Result do_allocate_publickey(struct ecc_public_key *key,
+					uint32_t type, size_t size_bits)
+{
+	switch (type) {
+	case TEE_TYPE_ECDH_PUBLIC_KEY:
+	case TEE_TYPE_SM2_PKE_PUBLIC_KEY:
+	case TEE_TYPE_SM2_DSA_PUBLIC_KEY:
+		/* Not supported by ELE — let the framework use software */
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	default:
+		break;
+	}
+
+	if (!key)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(key, 0, sizeof(*key));
+
+	key->x = crypto_bignum_allocate(size_bits);
+	if (!key->x)
+		goto err;
+
+	key->y = crypto_bignum_allocate(size_bits);
+	if (!key->y)
+		goto err;
+
+	return TEE_SUCCESS;
+
+err:
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
+
+	return TEE_ERROR_OUT_OF_MEMORY;
+}
+
+static void do_free_publickey(struct ecc_public_key *key)
+{
+	if (!key)
+		return;
+
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
+}
+
+static TEE_Result do_gen_keypair(struct ecc_keypair *key, size_t size_bits)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t key_size_bits = 0;
+	size_t key_size = 0;
+	uint8_t *pub_buf = NULL;
+	uint8_t *priv_buf = NULL;
+
+	if (!key || !size_bits)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = curve_to_bits(key->curve, &key_size_bits);
+	if (res) {
+		if (!IS_ENABLED(CFG_IMX_ELE_ECC_DRV_FALLBACK))
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		DMSG("ELE ECC keygen fallback to software");
+		return pair_ops->generate(key, size_bits);
+	}
+
+	key_size = ROUNDUP_DIV(key_size_bits, 8);
+
+	pub_buf = calloc(1, key_size * 2);
+	if (!pub_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	priv_buf = calloc(1, key_size);
+	if (!priv_buf) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	res = imx_ele_generate_keypair(priv_buf, key_size,
+				       pub_buf, key_size * 2,
+				       ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1,
+				       key_size_bits);
+	if (res) {
+		EMSG("ELE key generation failed");
+		goto out;
+	}
+
+	crypto_bignum_bin2bn(pub_buf, key_size, key->x);
+	crypto_bignum_bin2bn(pub_buf + key_size, key_size, key->y);
+	crypto_bignum_bin2bn(priv_buf, key_size, key->d);
+
+out:
+	free(pub_buf);
+	free_wipe(priv_buf);
+
+	return res;
+}
+
+static TEE_Result do_sign(struct drvcrypt_sign_data *sdata)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct ecc_keypair *key = NULL;
+	size_t key_size_bits = 0;
+	size_t key_size = 0;
+	uint32_t ele_algo = 0;
+	uint8_t *priv_buf = NULL;
+	size_t d_size = 0;
+	size_t sig_len = 0;
+
+	if (!sdata || !sdata->key || !sdata->message.data ||
+	    !sdata->signature.data || !sdata->message.length)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	key = sdata->key;
+
+	res = get_key_size_and_algo(key->curve, sdata->algo,
+				    sdata->message.length,
+				    &key_size_bits, &ele_algo);
+	if (res) {
+		if (!IS_ENABLED(CFG_IMX_ELE_ECC_DRV_FALLBACK))
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		DMSG("ELE ECC sign fallback to software");
+		return pair_ops->sign(sdata->algo, sdata->key,
+				      sdata->message.data,
+				      sdata->message.length,
+				      sdata->signature.data,
+				      &sdata->signature.length);
+	}
+
+	key_size = ROUNDUP_DIV(key_size_bits, 8);
+	sig_len = key_size * 2;
+
+	if (sdata->signature.length < sig_len) {
+		sdata->signature.length = sig_len;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	priv_buf = calloc(1, key_size);
+	if (!priv_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/*
+	 * The bignum representation may be shorter than the key size when
+	 * leading zeros are stripped; right-align the scalar in the buffer.
+	 */
+	d_size = crypto_bignum_num_bytes(key->d);
+	if (!d_size || d_size > key_size) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	crypto_bignum_bn2bin(key->d, priv_buf + key_size - d_size);
+
+	res = imx_ele_signature_generate(priv_buf, key_size,
+					 sdata->message.data,
+					 sdata->message.length,
+					 sdata->signature.data,
+					 sig_len,
+					 ele_algo,
+					 ELE_SIG_GEN_MSG_TYPE_DIGEST,
+					 ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1,
+					 key_size_bits);
+	if (res) {
+		EMSG("ELE signature generation failed");
+		goto out;
+	}
+
+	sdata->signature.length = sig_len;
+
+out:
+	free_wipe(priv_buf);
+
+	return res;
+}
+
+static TEE_Result do_verify(struct drvcrypt_sign_data *sdata)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct ecc_public_key *key = NULL;
+	size_t key_size_bits = 0;
+	size_t key_size = 0;
+	uint32_t ele_algo = 0;
+	uint8_t *pub_buf = NULL;
+	size_t x_size = 0;
+	size_t y_size = 0;
+
+	if (!sdata || !sdata->key || !sdata->message.data ||
+	    !sdata->signature.data || !sdata->message.length ||
+	    !sdata->signature.length)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	key = sdata->key;
+
+	res = get_key_size_and_algo(key->curve, sdata->algo,
+				    sdata->message.length,
+				    &key_size_bits, &ele_algo);
+	if (res) {
+		if (!IS_ENABLED(CFG_IMX_ELE_ECC_DRV_FALLBACK))
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		DMSG("ELE ECC verify fallback to software");
+		return pub_ops->verify(sdata->algo, sdata->key,
+				       sdata->message.data,
+				       sdata->message.length,
+				       sdata->signature.data,
+				       sdata->signature.length);
+	}
+
+	key_size = ROUNDUP_DIV(key_size_bits, 8);
+
+	if (sdata->signature.length != key_size * 2)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	pub_buf = calloc(1, key_size * 2);
+	if (!pub_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/*
+	 * Right-align each coordinate in its half of the buffer to handle
+	 * bignums with stripped leading zeros.
+	 */
+	x_size = crypto_bignum_num_bytes(key->x);
+	if (!x_size || x_size > key_size) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+	crypto_bignum_bn2bin(key->x, pub_buf + key_size - x_size);
+
+	y_size = crypto_bignum_num_bytes(key->y);
+	if (!y_size || y_size > key_size) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	crypto_bignum_bn2bin(key->y, pub_buf + key_size + (key_size - y_size));
+
+	res = imx_ele_signature_verify(pub_buf, key_size * 2,
+				       sdata->message.data,
+				       sdata->message.length,
+				       sdata->signature.data,
+				       sdata->signature.length,
+				       key_size_bits,
+				       ELE_KEY_TYPE_ECC_PUB_KEY_SECP_R1,
+				       ele_algo,
+				       ELE_SIG_GEN_MSG_TYPE_DIGEST);
+	if (res)
+		EMSG("ELE signature verification failed: res=0x%x", res);
+
+out:
+	free(pub_buf);
+
+	return res;
+}
+
+static struct drvcrypt_ecc driver_ecc = {
+	.alloc_keypair   = do_allocate_keypair,
+	.alloc_publickey = do_allocate_publickey,
+	.free_publickey  = do_free_publickey,
+	.gen_keypair     = do_gen_keypair,
+	.sign            = do_sign,
+	.verify          = do_verify,
+};
+
+TEE_Result imx_ele_ecc_init(void)
+{
+	pub_ops = crypto_asym_get_ecc_public_ops(TEE_TYPE_ECDSA_PUBLIC_KEY);
+	if (!pub_ops)
+		return TEE_ERROR_GENERIC;
+
+	pair_ops = crypto_asym_get_ecc_keypair_ops(TEE_TYPE_ECDSA_KEYPAIR);
+	if (!pair_ops)
+		return TEE_ERROR_GENERIC;
+
+	if (drvcrypt_register_ecc(&driver_ecc))
+		return TEE_ERROR_GENERIC;
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/crypto/ele/acipher/sub.mk
+++ b/core/drivers/crypto/ele/acipher/sub.mk
@@ -1,0 +1,3 @@
+incdirs-y += ../include
+
+srcs-$(CFG_IMX_ELE_ECC_DRV) += ecc.c

--- a/core/drivers/crypto/ele/crypto.mk
+++ b/core/drivers/crypto/ele/crypto.mk
@@ -1,4 +1,12 @@
 ifeq ($(CFG_IMX_ELE),y)
+CFG_IMX_ELE_ECC_DRV ?= n
+CFG_IMX_ELE_ECC_DRV_FALLBACK ?= $(CFG_IMX_ELE_ECC_DRV)
+
+CFG_CRYPTO_DRIVER ?= $(CFG_IMX_ELE_ECC_DRV)
+
+ifeq ($(CFG_CRYPTO_DRIVER),y)
+CFG_CRYPTO_DRIVER_DEBUG ?= 0
+endif # CFG_CRYPTO_DRIVER
 
 # Issues in the ELE FW prevent OPTEE and Kernel from using
 # the RNG concurrently at runtime. To prevent any issue,
@@ -6,4 +14,5 @@ ifeq ($(CFG_IMX_ELE),y)
 # But with Kernel ELE driver disabled, Runtime ELE RNG
 # generation can be done.
 CFG_WITH_SOFTWARE_PRNG ?= y
+
 endif # CFG_IMX_ELE

--- a/core/drivers/crypto/ele/ele.c
+++ b/core/drivers/crypto/ele/ele.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2022-2023, 2025 NXP
+ * Copyright 2022-2023, 2025-2026 NXP
  */
 #include <drivers/imx_mu.h>
 #include <ele.h>
@@ -20,6 +20,7 @@
 #include <trace.h>
 #include <types_ext.h>
 #include <utee_types.h>
+#include <ecc.h>
 #include <util.h>
 
 #define ELE_BASE_ADDR MU_BASE
@@ -371,6 +372,19 @@ int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 
 	return 0;
 }
+
+static TEE_Result imx_ele_global_init(void)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = imx_ele_ecc_init();
+	if (res)
+		EMSG("ELE ECC driver registration failed");
+
+	return res;
+}
+
+driver_init(imx_ele_global_init);
 
 #if defined(CFG_MX93) || defined(CFG_MX91) || defined(CFG_MX95) || \
 	defined(CFG_MX943)

--- a/core/drivers/crypto/ele/ele.c
+++ b/core/drivers/crypto/ele/ele.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2022-2023, 2025 NXP
+ * Copyright 2022-2023, 2025-2026 NXP
  */
 #include <drivers/imx_mu.h>
 #include <ele.h>
@@ -20,6 +20,7 @@
 #include <trace.h>
 #include <types_ext.h>
 #include <utee_types.h>
+#include <ecc.h>
 #include <util.h>
 
 #define ELE_BASE_ADDR MU_BASE
@@ -371,6 +372,19 @@ int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 
 	return 0;
 }
+
+static TEE_Result imx_ele_global_init(void)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = imx_ele_ecc_init();
+	if (res)
+		EMSG("ELE ECC driver registration failed");
+
+	return res;
+}
+
+driver_init(imx_ele_global_init);
 
 #if defined(CFG_MX93) || defined(CFG_MX91) || defined(CFG_MX95) || \
 	defined(CFG_MX943) || defined(CFG_MX952)

--- a/core/drivers/crypto/ele/include/ecc.h
+++ b/core/drivers/crypto/ele/include/ecc.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2026 NXP
+ *
+ * Brief   ELE ECC driver TEE Crypto integration.
+ */
+#ifndef __ECC_H__
+#define __ECC_H__
+
+#include <tee_api_types.h>
+
+#ifdef CFG_IMX_ELE_ECC_DRV
+/*
+ * Initialize the ECC module
+ */
+TEE_Result imx_ele_ecc_init(void);
+#else
+static inline TEE_Result imx_ele_ecc_init(void)
+{
+	return TEE_SUCCESS;
+}
+#endif /* CFG_IMX_ELE_ECC_DRV */
+
+#endif /* __ECC_H__ */

--- a/core/drivers/crypto/ele/include/key_mgmt.h
+++ b/core/drivers/crypto/ele/include/key_mgmt.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2026 NXP
+ */
+#ifndef __KEY_MGMT_H__
+#define __KEY_MGMT_H__
+
+#include <tee_api_types.h>
+
+/* Plain-text key flag for key generation and signature commands */
+#define IMX_ELE_FLAG_PLAINTEXT_KEY	0x8
+
+/* ECC key types */
+#define ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1	0x7112
+#define ELE_KEY_TYPE_ECC_PUB_KEY_SECP_R1	0x4112
+
+/*
+ * Generate a plain-text asymmetric key pair via EdgeLock Enclave.
+ *
+ * For plain key generation the key management handle, key group, key
+ * lifetime, key usage, permitted algorithm, monotonic-counter-increment
+ * and sync flags are not used by ELE and must be passed as zero / false.
+ *
+ * @priv_key_buf:    caller-allocated buffer that receives the private key
+ * @priv_key_size:   size in bytes of @priv_key_buf
+ * @public_key_buf:  caller-allocated buffer that receives the public key
+ *                   (x || y coordinates, each @key_size_bits/8 bytes)
+ * @public_key_size: size in bytes of @public_key_buf
+ * @key_type:        ELE key type (e.g. ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1)
+ * @key_size_bits:   key security size in bits (224, 256, 384 or 521)
+ */
+TEE_Result imx_ele_generate_keypair(uint8_t *priv_key_buf,
+				    size_t priv_key_size,
+				    uint8_t *public_key_buf,
+				    size_t public_key_size,
+				    uint16_t key_type,
+				    size_t key_size_bits);
+
+#endif /* __KEY_MGMT_H__ */

--- a/core/drivers/crypto/ele/include/sign_verify.h
+++ b/core/drivers/crypto/ele/include/sign_verify.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2026 NXP
+ */
+#ifndef __SIGN_VERIFY_H__
+#define __SIGN_VERIFY_H__
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/* ECDSA signature schemes */
+#define ELE_ALGO_ECDSA_SHA224	0x06000608
+#define ELE_ALGO_ECDSA_SHA256	0x06000609
+#define ELE_ALGO_ECDSA_SHA384	0x0600060A
+#define ELE_ALGO_ECDSA_SHA512	0x0600060B
+
+/* Signature generation message type */
+#define ELE_SIG_GEN_MSG_TYPE_DIGEST	0x0
+#define ELE_SIG_GEN_MSG_TYPE_MESSAGE	0x1
+
+/* Signature verification status codes returned by ELE */
+#define ELE_SIG_VERIFICATION_SUCCESS	0x5A3CC3A5
+#define ELE_SIG_VERIFICATION_FAILURE	0x2B4DD4B2
+
+/*
+ * Generate an ECDSA signature using a plain-text private key.
+ *
+ * @priv_key:         private key bytes (big-endian scalar)
+ * @priv_key_size:    size in bytes of @priv_key
+ * @message:          digest or message bytes to sign
+ * @message_size:     size in bytes of @message
+ * @signature:        caller-allocated output buffer for the signature (r || s)
+ * @signature_size:   size in bytes of @signature buffer
+ * @signature_scheme: ELE algorithm identifier (e.g. ELE_ALGO_ECDSA_SHA256)
+ * @message_type:     ELE_SIG_GEN_MSG_TYPE_DIGEST or
+ *		      ELE_SIG_GEN_MSG_TYPE_MESSAGE
+ * @key_type:         ELE key type (e.g. ELE_KEY_TYPE_ECC_KEY_PAIR_SECP_R1)
+ * @key_size_bits:    key security size in bits
+ */
+TEE_Result imx_ele_signature_generate(const uint8_t *priv_key,
+				      size_t priv_key_size,
+				      const uint8_t *message,
+				      size_t message_size,
+				      uint8_t *signature,
+				      size_t signature_size,
+				      uint32_t signature_scheme,
+				      uint8_t message_type,
+				      uint32_t key_type,
+				      size_t key_size_bits);
+
+/*
+ * Verify an ECDSA signature using a plain-text public key.
+ *
+ * @public_key:       public key bytes (x || y coordinates)
+ * @public_key_size:  size in bytes of @public_key
+ * @message:          digest or message bytes that were signed
+ * @message_size:     size in bytes of @message
+ * @signature:        signature bytes (r || s) to verify
+ * @signature_size:   size in bytes of @signature
+ * @key_security_size: key security size in bits
+ * @key_type:         ELE key type (e.g. ELE_KEY_TYPE_ECC_PUB_KEY_SECP_R1)
+ * @signature_scheme: ELE algorithm identifier
+ * @message_type:     ELE_SIG_GEN_MSG_TYPE_DIGEST or
+ *		      ELE_SIG_GEN_MSG_TYPE_MESSAGE
+ */
+TEE_Result imx_ele_signature_verify(const uint8_t *public_key,
+				    size_t public_key_size,
+				    const uint8_t *message,
+				    size_t message_size,
+				    const uint8_t *signature,
+				    size_t signature_size,
+				    size_t key_security_size,
+				    uint16_t key_type,
+				    uint32_t signature_scheme,
+				    uint8_t message_type);
+
+#endif /* __SIGN_VERIFY_H__ */

--- a/core/drivers/crypto/ele/key_mgmt.c
+++ b/core/drivers/crypto/ele/key_mgmt.c
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2026 NXP
+ */
+#include <ele.h>
+#include <key_mgmt.h>
+#include <memutils.h>
+#include <string.h>
+
+#define ELE_CMD_GENERATE_KEY	0x42
+
+TEE_Result imx_ele_generate_keypair(uint8_t *priv_key_buf,
+				    size_t priv_key_size,
+				    uint8_t *public_key_buf,
+				    size_t public_key_size,
+				    uint16_t key_type,
+				    size_t key_size_bits)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct imx_ele_buf pub_key = { };
+	struct imx_ele_buf priv_key = { };
+	/*
+	 * For plain-text key generation the key_mgmt_handle, key_group,
+	 * key_lifetime, key_usage, permitted_algo and key_lifecycle fields
+	 * are reserved and must be zero.  Only the plain-key flag, the key
+	 * type, the security size and the DMA buffer addresses are relevant.
+	 */
+	struct gen_key_cmd {
+		uint32_t key_mgmt_handle;
+		uint32_t private_key_addr;
+		uint16_t public_key_size;
+		uint16_t key_group;
+		uint16_t key_type;
+		uint16_t key_size;
+		uint32_t key_lifetime;
+		uint32_t key_usage;
+		uint32_t permitted_algo;
+		uint32_t key_lifecycle;
+		uint8_t flags;
+		uint8_t reserved;
+		uint16_t private_key_size;
+		uint32_t public_key_addr;
+		uint32_t crc;
+	} __packed cmd = { };
+	struct imx_mu_msg msg = { };
+
+	if (!priv_key_buf || !public_key_buf ||
+	    !priv_key_size || !public_key_size || !key_size_bits)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = imx_ele_buf_alloc(&pub_key, NULL, public_key_size);
+	if (res) {
+		EMSG("Public key buffer allocation failed");
+		return res;
+	}
+
+	res = imx_ele_buf_alloc(&priv_key, NULL, priv_key_size);
+	if (res) {
+		EMSG("Private key buffer allocation failed");
+		goto free_pub;
+	}
+
+	cmd.private_key_addr = priv_key.paddr_lsb;
+	cmd.private_key_size = (uint16_t)priv_key.size;
+	cmd.public_key_size = (uint16_t)pub_key.size;
+	cmd.public_key_addr = pub_key.paddr_lsb;
+	cmd.key_type = key_type;
+	cmd.key_size = (uint16_t)key_size_bits;
+	cmd.flags = IMX_ELE_FLAG_PLAINTEXT_KEY;
+	cmd.crc = 0;
+
+	msg.header.version = ELE_VERSION_HSM;
+	msg.header.size = SIZE_MSG_32(cmd);
+	msg.header.tag = ELE_REQUEST_TAG;
+	msg.header.command = ELE_CMD_GENERATE_KEY;
+
+	memcpy(msg.data.u8, &cmd, sizeof(cmd));
+	update_crc(&msg);
+
+	res = imx_ele_call(&msg);
+	if (res) {
+		EMSG("Key generation failed: %#" PRIx32, res);
+		goto free_priv;
+	}
+
+	res = imx_ele_buf_copy(&pub_key, public_key_buf, public_key_size);
+	if (res) {
+		EMSG("Public key copy failed");
+		goto free_priv;
+	}
+
+	res = imx_ele_buf_copy(&priv_key, priv_key_buf, priv_key_size);
+	if (res)
+		EMSG("Private key copy failed");
+
+free_priv:
+	imx_ele_buf_free(&priv_key);
+free_pub:
+	imx_ele_buf_free(&pub_key);
+
+	return res;
+}

--- a/core/drivers/crypto/ele/key_mgmt.c
+++ b/core/drivers/crypto/ele/key_mgmt.c
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2026 NXP
+ */
+#include <ele.h>
+#include <key_mgmt.h>
+#include <memutils.h>
+
+#define ELE_CMD_GENERATE_KEY	0x42
+
+/*
+ * For plain-text key generation the key_mgmt_handle, key_group,
+ * key_lifetime, key_usage, permitted_algo and key_lifecycle fields
+ * are reserved and must be zero.  Only the plain-key flag, the key
+ * type, the security size and the DMA buffer addresses are relevant.
+ */
+struct gen_key_cmd {
+	uint32_t key_mgmt_handle;
+	uint32_t private_key_addr;
+	uint16_t public_key_size;
+	uint16_t key_group;
+	uint16_t key_type;
+	uint16_t key_size;
+	uint32_t key_lifetime;
+	uint32_t key_usage;
+	uint32_t permitted_algo;
+	uint32_t key_lifecycle;
+	uint8_t flags;
+	uint8_t reserved;
+	uint16_t private_key_size;
+	uint32_t public_key_addr;
+	uint32_t crc;
+} __packed;
+
+TEE_Result imx_ele_generate_keypair(uint8_t *priv_key_buf,
+				    size_t priv_key_size,
+				    uint8_t *public_key_buf,
+				    size_t public_key_size,
+				    uint16_t key_type,
+				    size_t key_size_bits)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct imx_ele_buf pub_key = { };
+	struct imx_ele_buf priv_key = { };
+	struct gen_key_cmd *cmd = NULL;
+	struct imx_mu_msg msg = { };
+
+	if (!priv_key_buf || !public_key_buf ||
+	    !priv_key_size || !public_key_size || !key_size_bits)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	cmd = (void *)msg.data.u8;
+
+	res = imx_ele_buf_alloc(&pub_key, NULL, public_key_size);
+	if (res) {
+		EMSG("Public key buffer allocation failed");
+		return res;
+	}
+
+	res = imx_ele_buf_alloc(&priv_key, NULL, priv_key_size);
+	if (res) {
+		EMSG("Private key buffer allocation failed");
+		goto free_pub;
+	}
+
+	cmd->private_key_addr = priv_key.paddr_lsb;
+	cmd->private_key_size = (uint16_t)priv_key.size;
+	cmd->public_key_size = (uint16_t)pub_key.size;
+	cmd->public_key_addr = pub_key.paddr_lsb;
+	cmd->key_type = key_type;
+	cmd->key_size = (uint16_t)key_size_bits;
+	cmd->flags = IMX_ELE_FLAG_PLAINTEXT_KEY;
+	cmd->crc = 0;
+
+	msg.header.version = ELE_VERSION_HSM;
+	msg.header.size = SIZE_MSG_32(*cmd);
+	msg.header.tag = ELE_REQUEST_TAG;
+	msg.header.command = ELE_CMD_GENERATE_KEY;
+
+	update_crc(&msg);
+
+	res = imx_ele_call(&msg);
+	if (res) {
+		EMSG("Key generation failed: %#" PRIx32, res);
+		goto free_priv;
+	}
+
+	res = imx_ele_buf_copy(&pub_key, public_key_buf, public_key_size);
+	if (res) {
+		EMSG("Public key copy failed");
+		goto free_priv;
+	}
+
+	res = imx_ele_buf_copy(&priv_key, priv_key_buf, priv_key_size);
+	if (res)
+		EMSG("Private key copy failed");
+
+free_priv:
+	imx_ele_buf_free(&priv_key);
+free_pub:
+	imx_ele_buf_free(&pub_key);
+
+	return res;
+}

--- a/core/drivers/crypto/ele/sign_verify.c
+++ b/core/drivers/crypto/ele/sign_verify.c
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2026 NXP
+ */
+#include <ele.h>
+#include <key_mgmt.h>
+#include <memutils.h>
+#include <sign_verify.h>
+#include <string.h>
+
+#define ELE_CMD_SIG_GENERATE		0x72
+#define ELE_CMD_SIG_VERIFICATION	0x82
+
+TEE_Result imx_ele_signature_generate(const uint8_t *priv_key,
+				      size_t priv_key_size,
+				      const uint8_t *message,
+				      size_t message_size,
+				      uint8_t *signature,
+				      size_t signature_size,
+				      uint32_t signature_scheme,
+				      uint8_t message_type,
+				      uint32_t key_type,
+				      size_t key_size_bits)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct imx_ele_buf msg_buf = { };
+	struct imx_ele_buf sig_buf = { };
+	struct imx_ele_buf priv_key_buf = { };
+	/*
+	 * For plain-text signing the sig_gen_handle and key_identifier
+	 * fields are reserved and must be zero.  The private key is passed
+	 * directly via a DMA buffer with IMX_ELE_FLAG_PLAINTEXT_KEY set.
+	 */
+	struct sig_generate_cmd {
+		uint32_t sig_gen_handle;
+		uint32_t private_key_addr;
+		uint32_t message;
+		uint32_t signature;
+		uint32_t message_size;
+		uint16_t signature_size;
+		uint8_t flags;
+		uint8_t rsvd;
+		uint32_t signature_scheme;
+		uint16_t salt_len;
+		uint16_t key_type;
+		uint16_t priv_key_size;
+		uint16_t keypair_sec_size;
+		uint32_t crc;
+	} __packed cmd = { };
+	struct imx_mu_msg mu_msg = { };
+
+	if (!priv_key || !message || !signature ||
+	    !priv_key_size || !message_size || !signature_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = imx_ele_buf_alloc(&msg_buf, message, message_size);
+	if (res) {
+		EMSG("Message buffer allocation failed");
+		return res;
+	}
+
+	res = imx_ele_buf_alloc(&sig_buf, NULL, signature_size);
+	if (res) {
+		EMSG("Signature buffer allocation failed");
+		goto free_msg;
+	}
+
+	res = imx_ele_buf_alloc(&priv_key_buf, priv_key, priv_key_size);
+	if (res) {
+		EMSG("Private key buffer allocation failed");
+		goto free_sig;
+	}
+
+	cmd.private_key_addr = priv_key_buf.paddr_lsb;
+	cmd.message = msg_buf.paddr_lsb;
+	cmd.signature = sig_buf.paddr_lsb;
+	cmd.message_size = (uint32_t)msg_buf.size;
+	cmd.signature_size = (uint16_t)sig_buf.size;
+	cmd.flags = message_type | IMX_ELE_FLAG_PLAINTEXT_KEY;
+	cmd.rsvd = 0;
+	cmd.signature_scheme = signature_scheme;
+	cmd.salt_len = 0;
+	cmd.key_type = (uint16_t)key_type;
+	cmd.priv_key_size = (uint16_t)priv_key_buf.size;
+	cmd.keypair_sec_size = (uint16_t)key_size_bits;
+	cmd.crc = 0;
+
+	mu_msg.header.version = ELE_VERSION_HSM;
+	mu_msg.header.size = SIZE_MSG_32(cmd);
+	mu_msg.header.tag = ELE_REQUEST_TAG;
+	mu_msg.header.command = ELE_CMD_SIG_GENERATE;
+
+	memcpy(mu_msg.data.u8, &cmd, sizeof(cmd));
+	update_crc(&mu_msg);
+
+	res = imx_ele_call(&mu_msg);
+	if (res) {
+		EMSG("Signature generation failed: %#" PRIx32, res);
+		goto free_priv;
+	}
+
+	res = imx_ele_buf_copy(&sig_buf, signature, signature_size);
+	if (res)
+		EMSG("Signature copy failed");
+
+free_priv:
+	imx_ele_buf_free(&priv_key_buf);
+free_sig:
+	imx_ele_buf_free(&sig_buf);
+free_msg:
+	imx_ele_buf_free(&msg_buf);
+
+	return res;
+}
+
+static TEE_Result imx_ele_sig_verify_status(uint32_t verification_status)
+{
+	switch (verification_status) {
+	case ELE_SIG_VERIFICATION_SUCCESS:
+		return TEE_SUCCESS;
+	case ELE_SIG_VERIFICATION_FAILURE:
+		return TEE_ERROR_SIGNATURE_INVALID;
+	default:
+		return TEE_ERROR_GENERIC;
+	}
+}
+
+TEE_Result imx_ele_signature_verify(const uint8_t *public_key,
+				    size_t public_key_size,
+				    const uint8_t *message,
+				    size_t message_size,
+				    const uint8_t *signature,
+				    size_t signature_size,
+				    size_t key_security_size,
+				    uint16_t key_type,
+				    uint32_t signature_scheme,
+				    uint8_t message_type)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct imx_ele_buf pub_key_buf = { };
+	struct imx_ele_buf msg_buf = { };
+	struct imx_ele_buf sig_buf = { };
+	/*
+	 * For plain-text verification the sig_verify_handle field is
+	 * reserved and must be zero.
+	 */
+	struct sig_verify_cmd {
+		uint32_t sig_verify_handle;
+		uint32_t key;
+		uint32_t message;
+		uint32_t signature;
+		uint32_t message_size;
+		uint16_t signature_size;
+		uint16_t key_size;
+		uint16_t key_security_size;
+		uint16_t key_type;
+		uint8_t flags;
+		uint8_t rsvd[3];
+		uint32_t signature_scheme;
+		uint16_t salt_len;
+		uint8_t rsvd2[2];
+		uint32_t crc;
+	} __packed cmd = { };
+	struct sig_verify_rsp {
+		uint32_t rsp_code;
+		uint32_t verification_status;
+	} rsp = { };
+	struct imx_mu_msg mu_msg = { };
+
+	if (!public_key || !message || !signature ||
+	    !public_key_size || !message_size || !signature_size ||
+	    !key_security_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = imx_ele_buf_alloc(&pub_key_buf, public_key, public_key_size);
+	if (res) {
+		EMSG("Public key buffer allocation failed");
+		return res;
+	}
+
+	res = imx_ele_buf_alloc(&msg_buf, message, message_size);
+	if (res) {
+		EMSG("Message buffer allocation failed");
+		goto free_pub;
+	}
+
+	res = imx_ele_buf_alloc(&sig_buf, signature, signature_size);
+	if (res) {
+		EMSG("Signature buffer allocation failed");
+		goto free_msg;
+	}
+
+	cmd.key = pub_key_buf.paddr_lsb;
+	cmd.message = msg_buf.paddr_lsb;
+	cmd.signature = sig_buf.paddr_lsb;
+	cmd.message_size = (uint32_t)msg_buf.size;
+	cmd.signature_size = (uint16_t)sig_buf.size;
+	cmd.key_size = (uint16_t)pub_key_buf.size;
+	cmd.key_security_size = (uint16_t)key_security_size;
+	cmd.key_type = key_type;
+	cmd.flags = message_type;
+	cmd.signature_scheme = signature_scheme;
+	cmd.salt_len = 0;
+	cmd.crc = 0;
+
+	mu_msg.header.version = ELE_VERSION_HSM;
+	mu_msg.header.size = SIZE_MSG_32(cmd);
+	mu_msg.header.tag = ELE_REQUEST_TAG;
+	mu_msg.header.command = ELE_CMD_SIG_VERIFICATION;
+
+	memcpy(mu_msg.data.u8, &cmd, sizeof(cmd));
+	update_crc(&mu_msg);
+
+	res = imx_ele_call(&mu_msg);
+	if (res) {
+		EMSG("Signature verification failed: %#" PRIx32, res);
+		goto free_sig;
+	}
+
+	memcpy(&rsp, mu_msg.data.u8, sizeof(rsp));
+	res = imx_ele_sig_verify_status(rsp.verification_status);
+
+free_sig:
+	imx_ele_buf_free(&sig_buf);
+free_msg:
+	imx_ele_buf_free(&msg_buf);
+free_pub:
+	imx_ele_buf_free(&pub_key_buf);
+
+	return res;
+}

--- a/core/drivers/crypto/ele/sign_verify.c
+++ b/core/drivers/crypto/ele/sign_verify.c
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2026 NXP
+ */
+#include <ele.h>
+#include <key_mgmt.h>
+#include <memutils.h>
+#include <sign_verify.h>
+
+#define ELE_CMD_SIG_GENERATE		0x72
+#define ELE_CMD_SIG_VERIFICATION	0x82
+
+/*
+ * For plain-text signing the sig_gen_handle and key_identifier
+ * fields are reserved and must be zero.  The private key is passed
+ * directly via a DMA buffer with IMX_ELE_FLAG_PLAINTEXT_KEY set.
+ */
+struct sig_generate_cmd {
+	uint32_t sig_gen_handle;
+	uint32_t private_key_addr;
+	uint32_t message;
+	uint32_t signature;
+	uint32_t message_size;
+	uint16_t signature_size;
+	uint8_t flags;
+	uint8_t rsvd;
+	uint32_t signature_scheme;
+	uint16_t salt_len;
+	uint16_t key_type;
+	uint16_t priv_key_size;
+	uint16_t keypair_sec_size;
+	uint32_t crc;
+} __packed;
+
+/* For plain-text verification the sig_verify_handle field is reserved. */
+struct sig_verify_cmd {
+	uint32_t sig_verify_handle;
+	uint32_t key;
+	uint32_t message;
+	uint32_t signature;
+	uint32_t message_size;
+	uint16_t signature_size;
+	uint16_t key_size;
+	uint16_t key_security_size;
+	uint16_t key_type;
+	uint8_t flags;
+	uint8_t rsvd[3];
+	uint32_t signature_scheme;
+	uint16_t salt_len;
+	uint8_t rsvd2[2];
+	uint32_t crc;
+} __packed;
+
+struct sig_verify_rsp {
+	uint32_t rsp_code;
+	uint32_t verification_status;
+};
+
+TEE_Result imx_ele_signature_generate(const uint8_t *priv_key,
+				      size_t priv_key_size,
+				      const uint8_t *message,
+				      size_t message_size,
+				      uint8_t *signature,
+				      size_t signature_size,
+				      uint32_t signature_scheme,
+				      uint8_t message_type,
+				      uint32_t key_type,
+				      size_t key_size_bits)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct imx_ele_buf msg_buf = { };
+	struct imx_ele_buf sig_buf = { };
+	struct imx_ele_buf priv_key_buf = { };
+	struct sig_generate_cmd *cmd = NULL;
+	struct imx_mu_msg mu_msg = { };
+
+	if (!priv_key || !message || !signature ||
+	    !priv_key_size || !message_size || !signature_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	cmd = (void *)mu_msg.data.u8;
+
+	res = imx_ele_buf_alloc(&msg_buf, message, message_size);
+	if (res) {
+		EMSG("Message buffer allocation failed");
+		return res;
+	}
+
+	res = imx_ele_buf_alloc(&sig_buf, NULL, signature_size);
+	if (res) {
+		EMSG("Signature buffer allocation failed");
+		goto free_msg;
+	}
+
+	res = imx_ele_buf_alloc(&priv_key_buf, priv_key, priv_key_size);
+	if (res) {
+		EMSG("Private key buffer allocation failed");
+		goto free_sig;
+	}
+
+	cmd->private_key_addr = priv_key_buf.paddr_lsb;
+	cmd->message = msg_buf.paddr_lsb;
+	cmd->signature = sig_buf.paddr_lsb;
+	cmd->message_size = (uint32_t)msg_buf.size;
+	cmd->signature_size = (uint16_t)sig_buf.size;
+	cmd->flags = message_type | IMX_ELE_FLAG_PLAINTEXT_KEY;
+	cmd->rsvd = 0;
+	cmd->signature_scheme = signature_scheme;
+	cmd->salt_len = 0;
+	cmd->key_type = (uint16_t)key_type;
+	cmd->priv_key_size = (uint16_t)priv_key_buf.size;
+	cmd->keypair_sec_size = (uint16_t)key_size_bits;
+	cmd->crc = 0;
+
+	mu_msg.header.version = ELE_VERSION_HSM;
+	mu_msg.header.size = SIZE_MSG_32(*cmd);
+	mu_msg.header.tag = ELE_REQUEST_TAG;
+	mu_msg.header.command = ELE_CMD_SIG_GENERATE;
+
+	update_crc(&mu_msg);
+
+	res = imx_ele_call(&mu_msg);
+	if (res) {
+		EMSG("Signature generation failed: %#" PRIx32, res);
+		goto free_priv;
+	}
+
+	res = imx_ele_buf_copy(&sig_buf, signature, signature_size);
+	if (res)
+		EMSG("Signature copy failed");
+
+free_priv:
+	imx_ele_buf_free(&priv_key_buf);
+free_sig:
+	imx_ele_buf_free(&sig_buf);
+free_msg:
+	imx_ele_buf_free(&msg_buf);
+
+	return res;
+}
+
+static TEE_Result imx_ele_sig_verify_status(uint32_t verification_status)
+{
+	switch (verification_status) {
+	case ELE_SIG_VERIFICATION_SUCCESS:
+		return TEE_SUCCESS;
+	case ELE_SIG_VERIFICATION_FAILURE:
+		return TEE_ERROR_SIGNATURE_INVALID;
+	default:
+		return TEE_ERROR_GENERIC;
+	}
+}
+
+TEE_Result imx_ele_signature_verify(const uint8_t *public_key,
+				    size_t public_key_size,
+				    const uint8_t *message,
+				    size_t message_size,
+				    const uint8_t *signature,
+				    size_t signature_size,
+				    size_t key_security_size,
+				    uint16_t key_type,
+				    uint32_t signature_scheme,
+				    uint8_t message_type)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct imx_ele_buf pub_key_buf = { };
+	struct imx_ele_buf msg_buf = { };
+	struct imx_ele_buf sig_buf = { };
+	struct sig_verify_cmd *cmd = NULL;
+	struct sig_verify_rsp *rsp = NULL;
+	struct imx_mu_msg mu_msg = { };
+
+	if (!public_key || !message || !signature ||
+	    !public_key_size || !message_size || !signature_size ||
+	    !key_security_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	cmd = (void *)mu_msg.data.u8;
+
+	res = imx_ele_buf_alloc(&pub_key_buf, public_key, public_key_size);
+	if (res) {
+		EMSG("Public key buffer allocation failed");
+		return res;
+	}
+
+	res = imx_ele_buf_alloc(&msg_buf, message, message_size);
+	if (res) {
+		EMSG("Message buffer allocation failed");
+		goto free_pub;
+	}
+
+	res = imx_ele_buf_alloc(&sig_buf, signature, signature_size);
+	if (res) {
+		EMSG("Signature buffer allocation failed");
+		goto free_msg;
+	}
+
+	cmd->key = pub_key_buf.paddr_lsb;
+	cmd->message = msg_buf.paddr_lsb;
+	cmd->signature = sig_buf.paddr_lsb;
+	cmd->message_size = (uint32_t)msg_buf.size;
+	cmd->signature_size = (uint16_t)sig_buf.size;
+	cmd->key_size = (uint16_t)pub_key_buf.size;
+	cmd->key_security_size = (uint16_t)key_security_size;
+	cmd->key_type = key_type;
+	cmd->flags = message_type;
+	cmd->signature_scheme = signature_scheme;
+	cmd->salt_len = 0;
+	cmd->crc = 0;
+
+	mu_msg.header.version = ELE_VERSION_HSM;
+	mu_msg.header.size = SIZE_MSG_32(*cmd);
+	mu_msg.header.tag = ELE_REQUEST_TAG;
+	mu_msg.header.command = ELE_CMD_SIG_VERIFICATION;
+
+	update_crc(&mu_msg);
+
+	res = imx_ele_call(&mu_msg);
+	if (res) {
+		EMSG("Signature verification failed: %#" PRIx32, res);
+		goto free_sig;
+	}
+
+	rsp = (void *)mu_msg.data.u8;
+	res = imx_ele_sig_verify_status(rsp->verification_status);
+
+free_sig:
+	imx_ele_buf_free(&sig_buf);
+free_msg:
+	imx_ele_buf_free(&msg_buf);
+free_pub:
+	imx_ele_buf_free(&pub_key_buf);
+
+	return res;
+}

--- a/core/drivers/crypto/ele/sub.mk
+++ b/core/drivers/crypto/ele/sub.mk
@@ -2,3 +2,6 @@ incdirs-y += include
 
 srcs-y += ele.c
 srcs-y += memutils.c
+srcs-$(CFG_IMX_ELE_ECC_DRV) += key_mgmt.c
+srcs-$(CFG_IMX_ELE_ECC_DRV) += sign_verify.c
+subdirs-$(CFG_IMX_ELE_ECC_DRV) += acipher


### PR DESCRIPTION

```
Add an ECC drvcrypt driver backed by the EdgeLock Enclave (ELE) hardware
accelerator on i.MX91 and i.MX93, supporting plain-text key generation,
ECDSA signing, and ECDSA verification for NIST P-224, P-256, P-384, and
P-521 curves.

Changes introduced:

1. drivers: crypto: ele: add plain-text asymmetric key generation
   - Introduces key_mgmt.h and key_mgmt.c implementing the
     ELE_CMD_GENERATE_KEY (0x42) MU command.
   - ELE writes the private scalar and public coordinates directly into
     caller-supplied DMA buffers (plain-text mode).

2. drivers: crypto: ele: add plain-text ECDSA sign and verify
   - Introduces sign_verify.h and sign_verify.c implementing
     ELE_CMD_SIG_GENERATE (0x72) and ELE_CMD_SIG_VERIFICATION (0x82).
   - Supports ECDSA with SHA-224/256/384/512 digest algorithms.
   - No service flow open/close required for plain-text operations.

3. drivers: crypto: ele: add ECC drvcrypt driver for i.MX91/i.MX93
   - Registers struct drvcrypt_ecc backed by ELE via drvcrypt_register_ecc.
   - Implements alloc_keypair, gen_keypair, sign, and verify.
   - SM2 and ECDH fall back to software (NOT_IMPLEMENTED).
   - Optional software fallback for unsupported curves/algorithms via
     CFG_NXP_ELE_ECC_DRV_FALLBACK.

4. plat-imx: enable ELE ECC driver for i.MX91 and i.MX93
   - Sets CFG_IMX_ELE_ECC_DRV=y in platform config for i.MX91/i.MX93.
   - Removes force(CFG_CRYPTO_DRIVER,n) on i.MX93 that was blocking
     hardware crypto driver registration.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Signed-off-by: Kshitiz Varshney <kshitiz.varshney@nxp.com>
```
