### PR TITLE
Fixes for early boot hang and stack canaries false-positive check when building with clang + lld

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -66,7 +66,7 @@ static void update_external_dt(void)
 #endif /*!CFG_DT*/
 
 #ifdef CFG_RISCV_S_MODE
-static void start_secondary_cores(void)
+void boot_start_secondary_cores(void)
 {
 	uint32_t curr_hartid = thread_get_core_local()->hart_id;
 	enum sbi_hsm_hart_state status = 0;
@@ -253,10 +253,6 @@ void __weak boot_init_primary_final(void)
 	call_finalcalls();
 	IMSG("Primary CPU0 (hart%"PRIu32") initialized",
 	     thread_get_hartid());
-
-#ifdef CFG_RISCV_S_MODE
-	start_secondary_cores();
-#endif
 }
 
 static void init_secondary_helper(void)

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -367,6 +367,10 @@ UNWIND(	.cantunwind)
 	addi	sp, sp, STACK_ALIGNMENT
 #endif
 
+#ifdef CFG_RISCV_S_MODE
+	jal	boot_start_secondary_cores
+#endif
+
 	cpu_is_ready
 	flush_cpu_semaphores
 	wait_secondary

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -39,7 +39,7 @@
 	addi	t0, t0, 1
 	lw	t1, stack_tmp_stride
 	mul	t1, t0, t1
-	la	t2, stack_tmp_rel
+	lla	t2, stack_tmp_rel
 	lw	t0, 0(t2)
 	add	t0, t0, t2
 	add	sp, t1, t0
@@ -48,7 +48,7 @@
 .macro cpu_is_ready
 #ifdef CFG_BOOT_SYNC_CPU
 	csrr	t0, CSR_XSCRATCH
-	la	t1, sem_cpu_sync
+	lla	t1, sem_cpu_sync
 	slli	t0, t0, 2
 	add	t1, t1, t0
 	li	t2, SEM_CPU_READY
@@ -61,7 +61,7 @@
 	csrr	t0, CSR_XSCRATCH /* t0: hart_index */
 	li	t1, THREAD_CORE_LOCAL_SIZE
 	mul	t2, t1, t0
-	la	tp, thread_core_local
+	lla	tp, thread_core_local
 	LDR	tp, 0(tp)
 	add	tp, tp, t2
 	/* Save hart_id and hart_index into thread_core_local */
@@ -71,7 +71,7 @@
 
 .macro wait_primary
 #ifdef CFG_BOOT_SYNC_CPU
-	la	t0, sem_cpu_sync
+	lla	t0, sem_cpu_sync
 	li	t2, SEM_CPU_READY
 1:
 	fence	w, w
@@ -82,7 +82,7 @@
 
 .macro wait_secondary
 #ifdef CFG_BOOT_SYNC_CPU
-	la	t0, sem_cpu_sync
+	lla	t0, sem_cpu_sync
 	li	t1, CFG_TEE_CORE_NB_CORE
 	li	t2, SEM_CPU_READY
 1:
@@ -100,8 +100,8 @@
 
 #ifdef CFG_BOOT_SYNC_CPU
 #define flush_cpu_semaphores \
-		la	t0, sem_cpu_sync_start
-		la	t1, sem_cpu_sync_end
+		lla	t0, sem_cpu_sync_start
+		lla	t1, sem_cpu_sync_end
 		fence
 #else
 #define flush_cpu_semaphores
@@ -118,7 +118,7 @@ FUNC _start , :
 	 */
 .option push
 .option norelax
-	la	gp, __global_pointer$
+	lla	gp, __global_pointer$
 .option pop
 #ifdef CFG_RISCV_M_MODE
 	csrr	a0, CSR_MHARTID
@@ -131,7 +131,7 @@ FUNC _start , :
 	mv	s1, a1		/* Save device tree address into s1 */
 #endif
 	/* Only first hart who wins lottery runs the primary boot sequence. */
-	la	a3, hart_lottery
+	lla	a3, hart_lottery
 	li	a2, 1
 	amoadd.w a3, a2, (a3)
 	/* a3 read from hart_lottery also represents the hart_index */
@@ -174,7 +174,7 @@ UNWIND(	.cantunwind)
 	 * Point tp to a temporary struct thread_core_local before the temporary
 	 * stack.
 	 */
-	la	t0, __vcore_free_end
+	lla	t0, __vcore_free_end
 	li	t1, THREAD_BOOT_INIT_TMP_ALLOC
 	sub	t1, t0, t1
 
@@ -204,9 +204,9 @@ UNWIND(	.cantunwind)
 	 * Record a single core, to be changed later before secure world
 	 * boot is done.
 	 */
-	la	t2, thread_core_local
+	lla	t2, thread_core_local
 	STR	tp, 0(t2)
-	la	t2, thread_core_count
+	lla	t2, thread_core_count
 	li	t0, 1
 	STR	t0, 0(t2)
 #else
@@ -227,13 +227,13 @@ UNWIND(	.cantunwind)
 	jal	plat_primary_init_early
 	jal	console_init
 
-	la	a0, __vcore_free_start
-	la	a1, __vcore_free_end
+	lla	a0, __vcore_free_start
+	lla	a1, __vcore_free_end
 #ifdef CFG_DYN_CONFIG
 	li	a2, THREAD_BOOT_INIT_TMP_ALLOC
 	sub	a1, a1, a2
 #endif
-	la	a2, __vcore_free_end
+	lla	a2, __vcore_free_end
 	jal	boot_mem_init
 
 #ifdef CFG_CORE_ASLR
@@ -245,11 +245,11 @@ UNWIND(	.cantunwind)
 #else
 	mv	a0, x0
 #endif
-	la	a1, boot_mmu_config
+	lla	a1, boot_mmu_config
 	jal	core_init_mmu_map
 
 #ifdef CFG_CORE_ASLR
-	la	a0, boot_mmu_config
+	lla	a0, boot_mmu_config
 	LDR	a0, CORE_MMU_CONFIG_MAP_OFFSET(a0)
 	beqz	a0, 1f		/* no offset, skip dynamic relocation */
 	jal	relocate
@@ -264,7 +264,7 @@ UNWIND(	.cantunwind)
 	 * thread_core_local holds only one core and thread_core_count is 1
 	 * so tp points to the updated pointer for thread_core_local.
 	 */
-	la	t0, thread_core_local
+	lla	t0, thread_core_local
 	STR	tp, 0(t0)
 #endif
 
@@ -273,7 +273,7 @@ UNWIND(	.cantunwind)
 	 * code to make sure that the stack pointer matches what we have in
 	 * thread_core_local[].
 	 */
-	la	a0, boot_mmu_config
+	lla	a0, boot_mmu_config
 	LDR	a0, CORE_MMU_CONFIG_MAP_OFFSET(a0)
 	LDR	a1, THREAD_CORE_LOCAL_TMP_STACK_VA_END(tp)
 	add	a1, a1, a0
@@ -307,10 +307,10 @@ UNWIND(	.cantunwind)
 	 * keep the pointer to the new thread_core_local in a1.
 	 */
 	LDR	a1, __thread_core_count_new
-	la	a2, thread_core_count
+	lla	a2, thread_core_count
 	STR	a1, 0(a2)
 	LDR	a1, __thread_core_local_new
-	la	a2, thread_core_local
+	lla	a2, thread_core_local
 	STR	a1, 0(a2)
 
 	/*
@@ -331,7 +331,7 @@ UNWIND(	.cantunwind)
 	 *    current hart's thread_core_local structure.
 	 */
 	mv	s2, sp
-	la	a0, threads
+	lla	a0, threads
 	LDR	a0, 0(a0)
 	LDR	a0, THREAD_CTX_STACK_VA_END(a0)
 	mv	sp, a0
@@ -362,7 +362,7 @@ UNWIND(	.cantunwind)
 #endif
 	jal	plat_get_random_stack_canaries
 	LDR	s0, 0(sp)
-	la	s1, __stack_chk_guard
+	lla	s1, __stack_chk_guard
 	STR	s0, 0(s1)
 	addi	sp, sp, STACK_ALIGNMENT
 #endif
@@ -374,7 +374,7 @@ UNWIND(	.cantunwind)
 	jal	thread_clr_boot_thread
 
 	li	a0, TEEABI_OPTEED_RETURN_ENTRY_DONE
-	la	a1, thread_vector_table
+	lla	a1, thread_vector_table
 	li	a2, 0
 	li	a3, 0
 	li	a4, 0
@@ -436,8 +436,8 @@ LOCAL_FUNC relocate , :
 	/*
 	 * a0 holds relocate offset
 	 */
-	la	t0, __rel_dyn_start
-	la	t1, __rel_dyn_end
+	lla	t0, __rel_dyn_start
+	lla	t1, __rel_dyn_end
 	beq	t0, t1, 5f
 2:
 	LDR	t5, RISCV_XLEN_BYTES(t0)        /* t5: relocation info:type */
@@ -450,7 +450,7 @@ LOCAL_FUNC relocate , :
 	j	4f
 
 3:
-	la	t4, __dyn_sym_start
+	lla	t4, __dyn_sym_start
 	srli	t6, t5, SYM_INDEX             /* t6: sym table index */
 	andi	t5, t5, 0xFF                  /* t5: relocation type */
 	li	t3, RELOC_TYPE
@@ -491,7 +491,7 @@ END_FUNC relocate
 LOCAL_FUNC enable_mmu , : , .identity_map
 	/* Set SATP from boot_mmu_config.satp[hartidx] */
 	csrr	a0, CSR_XSCRATCH
-	la	a1, boot_mmu_config
+	lla	a1, boot_mmu_config
 	LDR	a3, CORE_MMU_CONFIG_MAP_OFFSET(a1)
 	addi	a1, a1, CORE_MMU_CONFIG_SATP
 	li	a2, CORE_MMU_CONFIG_SATP_SIZE

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -49,6 +49,7 @@ void boot_init_primary_early(void);
 void boot_init_primary_late(unsigned long fdt, unsigned long manifest);
 void boot_init_primary_runtime(void);
 void boot_init_primary_final(void);
+void boot_start_secondary_cores(void);
 void boot_init_memtag(void);
 void boot_clear_memtag(void);
 void boot_save_args(unsigned long a0, unsigned long a1, unsigned long a2,


### PR DESCRIPTION
These patches fix early boot hang and stack canaries false-positive check when building with clang + lld (observed with LLVM 22.1.8).
Please see the commit message of each fix for more details.