### PR TITLE
plat-tegra: introduce NVIDIA Tegra platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,10 @@ jobs:
               _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y CFG_DRIVERS_REGULATOR_PRINT_TREE=y
               _make PLATFORM=stm32mp1-135F_DK COMPILER=clang
               _make PLATFORM=stm32mp1 CFG_STM32MP1_OPTEE_IN_SYSRAM=y CFG_STM32MP_REMOTEPROC=y
+          - name: arm tegra
+            make_commands: |
+              _make PLATFORM=tegra-t234
+              _make PLATFORM=tegra-t264
           - name: arm ti
             make_commands: |
               _make PLATFORM=ti-dra7xx out/core/tee{,-pager,-pageable}.bin

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -225,6 +225,13 @@ R:	GM Lin <guan-gm.lin@mediatek.com> [@p870613]
 S:	Maintained
 F:	core/arch/arm/plat-mediatek/
 
+NVIDIA Tegra
+R:	Sungbae Yoo <sungbaey@nvidia.com> [@ysbnim]
+S:	Maintained
+F:	core/arch/arm/plat-tegra/
+F:	core/drivers/tegra_*.c
+F:	core/include/drivers/tegra_*.h
+
 NXP (Freescale) i.MX family
 R:	Peng Fan <peng.fan@nxp.com> [@MrVan]
 R:	Silvano Di Ninno <silvano.dininno@nxp.com> [@sdininno]

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -157,9 +157,9 @@ endif
 ifeq ($(CFG_CORE_PHYS_RELOCATABLE)-$(CFG_WITH_PAGER),y-y)
 $(error CFG_CORE_PHYS_RELOCATABLE and CFG_WITH_PAGER are not compatible)
 endif
-ifeq ($(CFG_CORE_PHYS_RELOCATABLE),y)
+ifeq ($(CFG_CORE_PHYS_RELOCATABLE)-$(CFG_CORE_FFA),y-y)
 ifneq ($(CFG_CORE_SEL2_SPMC),y)
-$(error CFG_CORE_PHYS_RELOCATABLE depends on CFG_CORE_SEL2_SPMC)
+$(error CFG_CORE_PHYS_RELOCATABLE with CFG_CORE_FFA depends on CFG_CORE_SEL2_SPMC)
 endif
 endif
 

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1469,6 +1469,12 @@ void __weak boot_save_args(unsigned long a0, unsigned long a1,
 			boot_arg_nsec_entry = a4;
 #endif
 		}
+
+#if defined(CFG_TZDRAM_SIZE)
+		if (IS_ENABLED(CFG_CORE_PHYS_RELOCATABLE))
+			core_mmu_set_secure_memory(core_mmu_tee_load_pa,
+						   CFG_TZDRAM_SIZE);
+#endif
 	}
 }
 

--- a/core/arch/arm/plat-tegra/conf.mk
+++ b/core/arch/arm/plat-tegra/conf.mk
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2020-2026, NVIDIA CORPORATION
+#
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+tegra-platform-flavors := t234 t264
+
+ifeq (,$(filter $(PLATFORM_FLAVOR),$(tegra-platform-flavors)))
+$(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)" \
+    (supported: $(tegra-platform-flavors)))
+endif
+
+# TZDRAM and SHMEM addresses and sizes
+CFG_TZDRAM_START ?= 0x80000000
+
+# Use dynamic shared memory and disable static shared memory because
+# the NS shared memory address and size are calculated dynamically
+$(call force,CFG_CORE_DYN_SHM,y)
+$(call force,CFG_CORE_RESERVED_SHM,n)
+
+# The NS memory range will be calculated automatically.
+$(call force,CFG_AUTO_MAX_PA_BITS,y)
+
+# Enable ARM64 core
+$(call force,CFG_ARM64_core,y)
+
+# Default number of threads is the number of CPU cores
+CFG_NUM_THREADS ?= $(CFG_TEE_CORE_NB_CORE)
+
+# Default heap size for Core, 128 kB
+CFG_CORE_HEAP_SIZE ?= 131072
+
+# Default size for reserved virtual memory space, 32 MB
+CFG_RESERVED_VASPACE_SIZE ?= (1024 * 1024 * 32)
+
+# Increase the mmap region to accommodate more
+# device mappings in the global static map
+CFG_MMAP_REGIONS ?= 24
+
+# Makes sure everything built is 64-bit, even TA targets.
+supported-ta-targets = ta_arm64
+
+# Enables large physical address extension, necessary if ARM64 core is initialized.
+$(call force,CFG_WITH_LPAE,y)
+
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,38)
+$(call force,CFG_WITH_PAGER,n)
+
+# Lets platform interact with ATF
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+
+# Initialize kernel time source
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+
+CFG_DTB_MAX_SIZE ?= 0x10000
+$(call force,CFG_DT,y)
+
+# CFG_RPMB_FS / CFG_RPMB_KEY_HAS_PROVISIONED are opted into per-platform conf
+# not forced here so a platform can enable them (default is n).
+$(call force,CFG_RPMB_WRITE_KEY,n)
+$(call force,CFG_RPMB_TESTKEY,n)
+
+# Enable PKCS11 tests in xtest
+$(call force,CFG_PKCS11_TA,y)
+
+# Set the default log level to INFO
+$(call force,CFG_TEE_CORE_LOG_LEVEL,2)
+
+# Trusted OS implementation version
+# Overriding TEE_IMPL_VERSION for consistency in version reporting
+TEE_IMPL_VERSION = $(CFG_OPTEE_REVISION_MAJOR).$(CFG_OPTEE_REVISION_MINOR)
+
+$(call force,CFG_CORE_PHYS_RELOCATABLE,y)
+
+CFG_TEE_RAM_VA_SIZE ?= 0x400000
+
+ifeq ($(PLATFORM_FLAVOR),t234)
+CFG_TZDRAM_SIZE  ?= 0x03f80000
+
+# T234 has 3 clusters and 4 cores per cluster
+$(call force,CFG_CORE_CLUSTER_SHIFT,2)
+# Secondary CPU cores. t234 platform contains 12 CPU cores
+$(call force,CFG_TEE_CORE_NB_CORE,12)
+
+$(call force,CFG_MAP_EXT_DT_SECURE,y)
+
+# Enable Early TA support
+$(call force,CFG_EARLY_TA,y)
+$(call force,CFG_EMBEDDED_TS,y)
+
+# Enable Pointer Authentication for core (S-EL1)
+$(call force,CFG_CORE_PAUTH,y)
+
+# Disable Pointer Authentication for TA (S-EL0)
+$(call force,CFG_TA_PAUTH,n)
+
+# Leverage relocatable optee feature while not enable EL2 SPMC
+$(call force,CFG_CORE_SEL2_SPMC,n)
+
+# Enable tegra combined UART driver
+$(call force,CFG_TEGRA_TCU,y)
+
+$(call force,CFG_CORE_ASLR,y)
+endif
+
+ifeq ($(PLATFORM_FLAVOR),t264)
+CFG_TZDRAM_SIZE  ?= 0x02000000
+
+# Secondary CPU cores. t264 platform contains 14 CPU cores
+$(call force,CFG_TEE_CORE_NB_CORE,14)
+
+CFG_TEE_DYN_VASPACE_SIZE ?= (2 * 1024 * 1024)
+
+$(call force,CFG_MAP_EXT_DT_SECURE,y)
+
+# Enable Early TA support
+$(call force,CFG_EARLY_TA,y)
+$(call force,CFG_EMBEDDED_TS,y)
+
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_CORE_FFA,y)
+$(call force,CFG_FFA_CONSOLE,y)
+$(call force,CFG_CORE_SEL2_SPMC,y)
+$(call force,CFG_WITH_STACK_CANARIES,y)
+$(call force,CFG_TEGRA_UTC,y)
+
+$(call force,CFG_CORE_ASLR,y)
+
+CFG_STACK_TMP_EXTRA ?= 8192
+endif

--- a/core/arch/arm/plat-tegra/main.c
+++ b/core/arch/arm/plat-tegra/main.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION
+ */
+
+#include <console.h>
+#include <drivers/hfic.h>
+#include <kernel/boot.h>
+
+#ifdef CFG_TEGRA_TCU
+#include <drivers/tegra_combined_uart.h>
+#endif
+
+#ifdef CFG_TEGRA_UTC
+#include <drivers/tegra_utc.h>
+#endif
+
+#ifdef CFG_TEGRA_TCU
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, TEGRA_COMBUART_BASE,
+			TEGRA_COMBUART_SIZE);
+static struct tegra_combined_uart_data tcud;
+#endif
+
+#ifdef CFG_TEGRA_UTC
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, TEGRA_UTC_TX_BASE, TEGRA_UTC_TX_SIZE);
+static struct tegra_utc_data utcd;
+#endif
+
+void plat_console_init(void)
+{
+#ifdef CFG_TEGRA_TCU
+	struct io_pa_va base = { .pa = TEGRA_COMBUART_BASE };
+#endif
+
+#ifdef CFG_TEGRA_UTC
+	struct io_pa_va utc_base = { .pa = TEGRA_UTC_TX_BASE };
+#endif
+
+#ifdef CFG_TEGRA_TCU
+	tegra_combined_uart_init(&tcud, base, TEGRA_COMBUART_SIZE);
+	register_serial_console(&tcud.chip);
+#endif
+
+#ifdef CFG_TEGRA_UTC
+	tegra_utc_init(&utcd, utc_base, TEGRA_UTC_TX_SIZE);
+	register_serial_console(&utcd.chip);
+#endif
+}
+
+#ifdef CFG_CORE_HAFNIUM_INTC
+void boot_primary_init_intc(void)
+{
+	hfic_init();
+}
+#endif

--- a/core/arch/arm/plat-tegra/platform_config.h
+++ b/core/arch/arm/plat-tegra/platform_config.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+#define MAX_XLAT_TABLES		17
+
+#endif

--- a/core/arch/arm/plat-tegra/sub.mk
+++ b/core/arch/arm/plat-tegra/sub.mk
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2020-2026, NVIDIA CORPORATION
+#
+
+global-incdirs-y += .
+srcs-y += main.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -86,6 +86,7 @@ srcs-$(CFG_VERSAL_SHA3_384) += versal_sha3_384.c
 srcs-$(CFG_VERSAL_PUF) += versal_puf.c
 srcs-$(CFG_VERSAL_HUK) += versal_huk.c
 srcs-$(CFG_VERSAL_OCP) += versal_ocp.c
+srcs-$(CFG_TEGRA_TCU) += tegra_combined_uart.c
 srcs-$(CFG_CBMEM_CONSOLE) += cbmem_console.c
 srcs-$(CFG_RISCV_PLIC) += plic.c
 srcs-$(CFG_RISCV_APLIC) += aplic_priv.c aplic_direct.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -87,6 +87,7 @@ srcs-$(CFG_VERSAL_PUF) += versal_puf.c
 srcs-$(CFG_VERSAL_HUK) += versal_huk.c
 srcs-$(CFG_VERSAL_OCP) += versal_ocp.c
 srcs-$(CFG_TEGRA_TCU) += tegra_combined_uart.c
+srcs-$(CFG_TEGRA_UTC) += tegra_utc.c
 srcs-$(CFG_CBMEM_CONSOLE) += cbmem_console.c
 srcs-$(CFG_RISCV_PLIC) += plic.c
 srcs-$(CFG_RISCV_APLIC) += aplic_priv.c aplic_direct.c

--- a/core/drivers/tegra_combined_uart.c
+++ b/core/drivers/tegra_combined_uart.c
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION
+ */
+
+#include <drivers/tegra_combined_uart.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <util.h>
+
+#define TX_TIMEOUT_US		15000
+
+/*
+ * Triggers an interrupt. Also indicates that the remote processor
+ * is busy when set.
+ */
+#define MBOX_INTR_TRIGGER	BIT(31)
+/*
+ * Ensures that prints up to and including this packet are flushed on
+ * the physical uart before de-asserting MBOX_INTR_TRIGGER.
+ */
+#define MBOX_FLUSH		BIT(26)
+/*
+ * Indicates that we're only sending one byte at a time.
+ */
+#define MBOX_BYTE_COUNT		BIT(24)
+
+static vaddr_t chip_to_base(struct serial_chip *chip)
+{
+	struct tegra_combined_uart_data *tcud =
+		container_of(chip, struct tegra_combined_uart_data, chip);
+
+	return io_pa_or_va(&tcud->base, tcud->base_size);
+}
+
+static void send_msg(vaddr_t base, uint32_t msg)
+{
+	uint64_t timeout = timeout_init_us(TX_TIMEOUT_US);
+
+	while (io_read32(base) & MBOX_INTR_TRIGGER)
+		if (timeout_elapsed(timeout))
+			return;
+
+	io_write32(base, msg);
+}
+
+static void comb_uart_putc(struct serial_chip *chip, int c)
+{
+	uint32_t msg;
+	vaddr_t base = chip_to_base(chip);
+
+	msg = MBOX_INTR_TRIGGER | MBOX_BYTE_COUNT | (uint8_t)c;
+	send_msg(base, msg);
+}
+
+static void comb_uart_flush(struct serial_chip *chip)
+{
+	uint32_t msg = MBOX_INTR_TRIGGER | MBOX_FLUSH;
+	vaddr_t base = chip_to_base(chip);
+
+	send_msg(base, msg);
+}
+
+static int comb_uart_getc(struct serial_chip *chip __unused)
+{
+	return -1;
+}
+
+static bool comb_uart_have_rx_data(struct serial_chip *chip __unused)
+{
+	return false;
+}
+
+static const struct serial_ops comb_uart_ops = {
+	.flush = comb_uart_flush,
+	.getchar = comb_uart_getc,
+	.have_rx_data = comb_uart_have_rx_data,
+	.putc = comb_uart_putc,
+};
+DECLARE_KEEP_PAGER(comb_uart_ops);
+
+void tegra_combined_uart_init(struct tegra_combined_uart_data *tcud,
+			      struct io_pa_va base, size_t size)
+{
+	if (!tcud)
+		return;
+
+	tcud->base = base;
+	tcud->base_size = size;
+	tcud->chip.ops = &comb_uart_ops;
+}
+
+#ifdef CFG_DT
+
+static struct serial_chip *tegra_combined_uart_dev_alloc(void)
+{
+	struct tegra_combined_uart_data *tcud = nex_calloc(1, sizeof(*tcud));
+
+	if (!tcud)
+		return NULL;
+
+	return &tcud->chip;
+}
+
+static int tegra_combined_uart_dev_init(struct serial_chip *chip,
+					const void *fdt, int offs,
+					const char *params)
+{
+	struct tegra_combined_uart_data *tcud = container_of(chip,
+		struct tegra_combined_uart_data, chip);
+	struct io_pa_va base = { 0 };
+	size_t size = 0;
+
+	if (params && params[0])
+		IMSG("tegra_tcu: device parameters ignored (%s)", params);
+
+	if (dt_map_dev(fdt, offs, &base.va, &size, DT_MAP_AUTO) < 0) {
+		EMSG("tegra_tcu: failed to map memory");
+		return -1;
+	}
+
+	if (size < TEGRA_COMBUART_SIZE) {
+		EMSG("tegra_tcu: unexpected register size: %zx", size);
+		return -1;
+	}
+
+	base.pa = virt_to_phys((void *)base.va);
+	tegra_combined_uart_init(tcud, base, size);
+
+	return 0;
+}
+
+static void tegra_combined_uart_dev_free(struct serial_chip *chip)
+{
+	struct tegra_combined_uart_data *tcud = container_of(chip,
+		struct tegra_combined_uart_data, chip);
+
+	nex_free(tcud);
+}
+
+static const struct serial_driver tegra_combined_uart_driver = {
+	.dev_alloc = tegra_combined_uart_dev_alloc,
+	.dev_init = tegra_combined_uart_dev_init,
+	.dev_free = tegra_combined_uart_dev_free,
+};
+
+static const struct dt_device_match tegra_combined_uart_match_table[] = {
+	{ .compatible = "nvidia,tegra234-tcu" },
+	{ 0 }
+};
+
+DEFINE_DT_DRIVER(tegra_combined_uart_dt_driver) = {
+	.name = "tegra_combined_uart",
+	.type = DT_DRIVER_UART,
+	.match_table = tegra_combined_uart_match_table,
+	.driver = &tegra_combined_uart_driver,
+};
+
+#endif /* CFG_DT */

--- a/core/drivers/tegra_utc.c
+++ b/core/drivers/tegra_utc.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION
+ */
+
+#include <drivers/tegra_utc.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <util.h>
+
+#define TEGRA_UTC_TX_CLIENT_ENABLE(base)	((base) + 0x0000)
+#define TEGRA_UTC_TX_CLIENT_COMMAND(base)	((base) + 0x000c)
+#define TEGRA_UTC_TX_CLIENT_DATA(base)		((base) + 0x0020)
+#define TEGRA_UTC_TX_CLIENT_FIFO_STATUS(base)	((base) + 0x0100)
+
+#define COMMAND_FLUSH				BIT(4)
+
+#define TX_STATUS_FULL				BIT(1)
+#define TX_TIMEOUT_US				1000
+
+static vaddr_t chip_to_base(struct serial_chip *chip)
+{
+	struct tegra_utc_data *utcd =
+		container_of(chip, struct tegra_utc_data, chip);
+
+	return io_pa_or_va(&utcd->base, utcd->base_size);
+}
+
+static int32_t tegra_utc_wait_for_ready(struct serial_chip *chip)
+{
+	vaddr_t base = chip_to_base(chip);
+	uint64_t timeout = timeout_init_us(TX_TIMEOUT_US);
+
+	while (io_read32(TEGRA_UTC_TX_CLIENT_FIFO_STATUS(base)) &
+	       TX_STATUS_FULL)
+		if (timeout_elapsed(timeout))
+			return -1;
+
+	return 0;
+}
+
+static void tegra_utc_putc(struct serial_chip *chip, int c)
+{
+	vaddr_t base = chip_to_base(chip);
+	int32_t err = tegra_utc_wait_for_ready(chip);
+
+	if (err == 0)
+		io_write32(TEGRA_UTC_TX_CLIENT_DATA(base), c);
+}
+
+static void tegra_utc_flush(struct serial_chip *chip)
+{
+	vaddr_t base = chip_to_base(chip);
+
+	io_write32(TEGRA_UTC_TX_CLIENT_COMMAND(base), COMMAND_FLUSH);
+}
+
+static const struct serial_ops tegra_utc_ops = {
+	.flush = tegra_utc_flush,
+	.putc = tegra_utc_putc,
+};
+DECLARE_KEEP_PAGER(tegra_utc_ops);
+
+void tegra_utc_init(struct tegra_utc_data *utcd,
+		    struct io_pa_va base, size_t size)
+{
+	if (!utcd)
+		return;
+
+	utcd->base = base;
+	utcd->base_size = size;
+	utcd->chip.ops = &tegra_utc_ops;
+}
+
+#ifdef CFG_DT
+
+static struct serial_chip *tegra_utc_dev_alloc(void)
+{
+	struct tegra_utc_data *utcd = nex_calloc(1, sizeof(*utcd));
+
+	if (!utcd)
+		return NULL;
+
+	return &utcd->chip;
+}
+
+static int tegra_utc_dev_init(struct serial_chip *chip,
+			      const void *fdt, int offs,
+			      const char *params)
+{
+	struct tegra_utc_data *utcd = container_of(chip,
+		struct tegra_utc_data, chip);
+	struct io_pa_va base = { 0 };
+	size_t size;
+
+	if (params && params[0])
+		IMSG("tegra_utc: device parameters ignored (%s)", params);
+
+	if (dt_map_dev(fdt, offs, &base.va, &size, DT_MAP_AUTO) < 0) {
+		EMSG("tegra_utc: failed to map memory");
+		return -1;
+	}
+
+	if (size < TEGRA_UTC_TX_SIZE) {
+		EMSG("tegra_utc: unexpected register size: %zx", size);
+		return -1;
+	}
+
+	base.pa = virt_to_phys((void *)base.va);
+	tegra_utc_init(utcd, base, size);
+
+	return 0;
+}
+
+static void tegra_utc_dev_free(struct serial_chip *chip)
+{
+	struct tegra_utc_data *utcd = container_of(chip,
+		struct tegra_utc_data, chip);
+
+	nex_free(utcd);
+}
+
+static const struct serial_driver tegra_utc_driver = {
+	.dev_alloc = tegra_utc_dev_alloc,
+	.dev_init = tegra_utc_dev_init,
+	.dev_free = tegra_utc_dev_free,
+};
+
+static const struct dt_device_match tegra_utc_match_table[] = {
+	{ .compatible = "nvidia,tegra264-utc" },
+	{ 0 }
+};
+
+DEFINE_DT_DRIVER(tegra_utc_dt_driver) = {
+	.name = "tegra-utc",
+	.type = DT_DRIVER_UART,
+	.match_table = tegra_utc_match_table,
+	.driver = &tegra_utc_driver,
+};
+
+#endif /* CFG_DT */

--- a/core/include/drivers/tegra_combined_uart.h
+++ b/core/include/drivers/tegra_combined_uart.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION
+ */
+
+#ifndef TEGRA_COMBINED_UART_H
+#define TEGRA_COMBINED_UART_H
+
+#include <drivers/serial.h>
+#include <types_ext.h>
+
+#ifdef CFG_TEGRA_TCU_APE_HSP2
+#define TEGRA_COMBUART_BASE	0x0A9F8000
+#else
+#define TEGRA_COMBUART_BASE	0x0C198000
+#endif
+#define TEGRA_COMBUART_SIZE	0x1000
+
+struct tegra_combined_uart_data {
+	struct io_pa_va base;
+	size_t base_size;
+	struct serial_chip chip;
+};
+
+void tegra_combined_uart_init(struct tegra_combined_uart_data *tcud,
+			      struct io_pa_va base, size_t size);
+
+#endif

--- a/core/include/drivers/tegra_utc.h
+++ b/core/include/drivers/tegra_utc.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION
+ */
+
+#ifndef TEGRA_UTC_H
+#define TEGRA_UTC_H
+
+#include <drivers/serial.h>
+#include <types_ext.h>
+
+#ifndef TEGRA_UTC_BASE
+#define TEGRA_UTC_BASE			0x0C4E0000
+#endif
+
+#define TEGRA_UTC_TX_BASE		(TEGRA_UTC_BASE + 0x30000)
+#define TEGRA_UTC_TX_SIZE		0x1000
+
+struct tegra_utc_data {
+	struct io_pa_va base;
+	size_t base_size;
+	struct serial_chip chip;
+};
+
+void tegra_utc_init(struct tegra_utc_data *utcd,
+		    struct io_pa_va base, size_t size);
+
+#endif


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
This PR adds NVIDIA Tegra T234 and T264 platform support.

On T234, OP-TEE runs as an S-EL1 payload without FF-A or an S-EL2 SPMC.
Unlike platforms with a fixed BL32 load address, the T234 bootloader may  load the OP-TEE binary at a different physical address on each boot.
Physical relocation is therefore required to run OP-TEE from its actual load address. Since T234 has no FF-A manifest, the secure memory range is initialized using `core_mmu_tee_load_pa` and `CFG_TZDRAM_SIZE`.

On T264, OP-TEE runs with FF-A and an S-EL2 SPMC. It also uses physical relocation, but obtains the secure memory range from the FF-A manifest through the existing S-EL2 boot path.

This PR also adds the TCU console driver for T234, the UTC console driver and Hafnium interrupt controller initialization for T264, and CI build coverage for both platforms.