### PR TITLE
core: spmc: fix missing addr_dst increment in retrieve response

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -612,6 +612,7 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 		dst_region->address_range_count++;
 
 		dst_region->total_page_count += addr_dst->page_count;
+		addr_dst++;
 	}
 }
 


### PR DESCRIPTION
create_retrieve_response() in core/arch/arm/kernel/spmc_sp_handler.c sets addr_dst to the start of dst_region->address_range_array before the SLIST_FOREACH loop, but never advances the pointer inside the loop body. As a result, every iteration overwrites slot [0] with the current region's address and page_count, while address_range_count is correctly incremented to N.

For single-region shares (e.g. all NW-originated shares, which always produce exactly one region via spmc_sp_add_nw_region()) the bug is invisible. For multi-region SP-to-SP shares produced by spmc_sp_add_sp_region() the receiving SP gets a descriptor that declares N regions but only carries valid data in slot [0]; slots [1..N-1] remain zero-initialised.

total_page_count is unaffected because it sums addr_dst->page_count, which always reflects the current iteration.

Fix: advance addr_dst at the end of the loop body, mirroring the per-region descriptor write pattern used elsewhere in the SPMC.

Reviewed-by: @jenswikl
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
