### PR TITLE
core: map external device tree as cached memory

### DIFF
--- a/core/arch/riscv/include/mm/core_mmu_arch.h
+++ b/core/arch/riscv/include/mm/core_mmu_arch.h
@@ -189,6 +189,14 @@ static inline void core_mmu_table_write_barrier(void)
 
 TEE_Result cache_op_inner(enum cache_op op, void *va, size_t len);
 
+static inline TEE_Result cache_op_outer(enum cache_op op __unused,
+					paddr_t pa __unused,
+					size_t len __unused)
+{
+	/* No outer cache to maintain */
+	return TEE_SUCCESS;
+}
+
 static inline bool core_mmu_check_max_pa(paddr_t pa)
 {
 	return pa <= (BIT64(RISCV_MMU_PA_WIDTH) - 1);

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -892,6 +892,15 @@ static TEE_Result release_external_dt(void)
 		panic();
 	}
 
+	if (IS_ENABLED(CFG_EXT_DT_CACHED)) {
+		if (cache_op_inner(DCACHE_AREA_CLEAN, external_dt.blob,
+				   CFG_DTB_MAX_SIZE))
+			panic("Failed to clean external DT from inner cache");
+
+		if (cache_op_outer(DCACHE_AREA_CLEAN, pa_dt, CFG_DTB_MAX_SIZE))
+			panic("Failed to clean external DT from outer cache");
+	}
+
 	if (core_mmu_remove_mapping(MEM_AREA_EXT_DT, external_dt.blob,
 				    CFG_DTB_MAX_SIZE))
 		panic("Failed to remove temporary Device Tree mapping");

--- a/core/kernel/transfer_list.c
+++ b/core/kernel/transfer_list.c
@@ -8,7 +8,6 @@
  * https://github.com/FirmwareHandoff/firmware_handoff
  ******************************************************************************/
 
-#include <kernel/cache_helpers.h>
 #include <kernel/panic.h>
 #include <kernel/transfer_list.h>
 #include <mm/core_memprot.h>
@@ -76,7 +75,13 @@ void transfer_list_unmap_sync(struct transfer_list_header *tl)
 	size_t sz = tl->max_size;
 
 	transfer_list_update_checksum(tl);
-	dcache_cleaninv_range(tl, sz);
+
+	if (cache_op_inner(DCACHE_AREA_CLEAN, tl, sz))
+		panic("Failed to clean transfer list from inner cache");
+
+	if (cache_op_outer(DCACHE_AREA_CLEAN, virt_to_phys(tl), sz))
+		panic("Failed to clean transfer list from outer cache");
+
 	unmap_list(tl, sz);
 }
 

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -891,15 +891,10 @@ uint32_t core_mmu_type_to_attr(enum teecore_memtypes t)
 	case MEM_AREA_TRANSFER_LIST:
 		return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW | cached;
 	case MEM_AREA_EXT_DT:
-		/*
-		 * If CFG_MAP_EXT_DT_SECURE is enabled map the external device
-		 * tree as secure non-cached memory, otherwise, fall back to
-		 * non-secure mapping.
-		 */
-		if (IS_ENABLED(CFG_MAP_EXT_DT_SECURE))
-			return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW |
-			       noncache;
-		fallthrough;
+		return attr | TEE_MATTR_PRW |
+		       (IS_ENABLED(CFG_EXT_DT_CACHED) ? cached : noncache) |
+		       (IS_ENABLED(CFG_MAP_EXT_DT_SECURE) ? TEE_MATTR_SECURE
+							  : 0);
 	case MEM_AREA_IO_NSEC:
 		return attr | TEE_MATTR_PRW | noncache;
 	case MEM_AREA_IO_SEC:

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -891,15 +891,10 @@ uint32_t core_mmu_type_to_attr(enum teecore_memtypes t)
 	case MEM_AREA_TRANSFER_LIST:
 		return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW | cached;
 	case MEM_AREA_EXT_DT:
-		/*
-		 * If CFG_MAP_EXT_DT_SECURE is enabled map the external device
-		 * tree as secure non-cached memory, otherwise, fall back to
-		 * non-secure mapping.
-		 */
-		if (IS_ENABLED(CFG_MAP_EXT_DT_SECURE))
-			return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW |
-			       noncache;
-		fallthrough;
+		return attr | TEE_MATTR_PRW |
+		       (IS_ENABLED(CFG_EXT_DT_CACHED) ? cached : noncache) |
+		       (IS_ENABLED(CFG_MAP_EXT_DT_SECURE) ?
+			TEE_MATTR_SECURE : 0);
 	case MEM_AREA_IO_NSEC:
 		return attr | TEE_MATTR_PRW | noncache;
 	case MEM_AREA_IO_SEC:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -523,6 +523,11 @@ CFG_STACK_TMP_EXTRA ?= 0
 # When CFG_MAP_EXT_DT_SECURE is enabled the external device tree is expected to
 # be in the secure memory.
 #
+# When CFG_EXT_DT_CACHED is enabled the external device tree is mapped as
+# cached memory instead of non-cached memory, which speeds up parsing of the
+# device tree considerably. Platforms can enable it once it is known that the
+# external device tree resides in memory that can be mapped cached.
+#
 # When CFG_EMBED_DTB is enabled, CFG_EMBED_DTB_SOURCE_FILE shall define the
 # relative path of a DTS file located in core/arch/$(ARCH)/dts.
 # The DTS file is compiled into a DTB file which content is embedded in a
@@ -541,6 +546,7 @@ CFG_MAP_EXT_DT_SECURE ?= n
 ifeq ($(CFG_MAP_EXT_DT_SECURE),y)
 $(call force,CFG_DT,y)
 endif
+CFG_EXT_DT_CACHED ?= n
 
 # This option enables OP-TEE to support boot arguments handover via Transfer
 # List defined in Firmware Handoff specification.


### PR DESCRIPTION
The device tree passed in from the boot loader was mapped as non-cached device memory. Reading the fdt multiple times from uncached memory which slows down OP-TEE startup considerably. Map it cached instead for faster OP-TEE startup. On an ARM i.MX8MP board this reduces the startup time from about 1.4s to 140ms.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
