### PR TITLE
mk: make the dev kit configuration available while Android.mk is parsed

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -44,6 +44,10 @@ else
 HOST_MAKE := $(MAKE)
 endif
 
+# The configuration below is generated while the makefiles are parsed, with
+# no jobserver to talk to, so keep the -jN out of that invocation.
+HOST_MAKE_CONF := $(firstword $(HOST_MAKE))
+
 
 # OPTEE_OUT_DIR could be exported explicitly
 # if PRODUCT_OUT is not the default out directory in aosp workspace
@@ -70,6 +74,17 @@ CROSS_COMPILE32 ?= $(TOP_ROOT_ABS)/$($(combo_2nd_arch_prefix)TARGET_TOOLS_PREFIX
 CROSS_COMPILE_LINE += CROSS_COMPILE32="$(CROSS_COMPILE32)"
 endif
 
+# Command line shared by every optee_os invocation below; the TA target
+# differs between them, so callers pass it. Deferred assignment, as
+# OPTEE_EXTRA_FLAGS may reference variables set while Android.mk is parsed.
+OPTEE_MAKE_LINE = -C $(TOP_ROOT_ABS)/$(OPTEE_OS_DIR) \
+	O=$(ABS_OPTEE_OS_OUT_DIR) \
+	CFG_ARM64_core=$(OPTEE_CFG_ARM64_CORE) \
+	PLATFORM=$(OPTEE_PLATFORM) \
+	PLATFORM_FLAVOR=$(OPTEE_PLATFORM_FLAVOR) \
+	$(CROSS_COMPILE_LINE) \
+	$(OPTEE_EXTRA_FLAGS)
+
 OPTEE_BIN := $(OPTEE_OS_OUT_DIR)/core/tee.bin
 
 $(OPTEE_BIN) : $(sort $(shell find -L $(OPTEE_OS_DIR)))
@@ -77,6 +92,28 @@ $(OPTEE_BIN) : $(sort $(shell find -L $(OPTEE_OS_DIR)))
 OPTEE_TA_DEV_KIT_MK := $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
 
 $(OPTEE_TA_DEV_KIT_MK) : $(sort $(shell find -L $(OPTEE_OS_DIR)))
+
+# Android.mk files test the CFG_ flags of the dev kit to decide what to
+# build, so the configuration must exist before they are parsed. A rule
+# cannot provide it, as rules only run once parsing is over. Generate it
+# here instead, while the makefiles are parsed; building the dev kit itself
+# is left to the rule below. The MD5 ties the variable to the configuration,
+# so that a change of configuration triggers a new parse.
+ifeq ($(filter $(TA_TARGET),$(BUILD_TA_DEV_KIT_CONF_DEFINED)),)
+BUILD_TA_DEV_KIT_CONF_DEFINED := $(TA_TARGET) $(BUILD_TA_DEV_KIT_CONF_DEFINED)
+TA_DEV_KIT_CONF_$(TA_TARGET) := $(shell \
+	mkdir -p $(ABS_OPTEE_OS_OUT_DIR) && \
+	env -u MAKEFLAGS -u MAKELEVEL -u MFLAGS \
+		$(HOST_MAKE_CONF) -s $(OPTEE_MAKE_LINE) \
+		CFG_USER_TA_TARGETS=$(TA_TARGET) \
+		ta_dev_kit_conf >/dev/null && \
+	md5sum $(TA_DEV_KIT_DIR)/host_include/conf.mk || \
+	printf 'ERROR')
+ifeq ($(TA_DEV_KIT_CONF_$(TA_TARGET)),ERROR)
+$(error Failed to generate the OP-TEE TA dev kit configuration \
+	for $(TA_TARGET))
+endif
+endif
 
 ###########################################################
 ## define making rules for $(OPTEE_BIN) target, and add  ##
@@ -92,14 +129,8 @@ ifneq (true,$(BUILD_OPTEE_OS_DEFINED))
 BUILD_OPTEE_OS_DEFINED := true
 $(OPTEE_BIN):
 	@echo "Start building optee_os..."
-	+$(HOST_MAKE) -C $(TOP_ROOT_ABS)/$(OPTEE_OS_DIR) \
-		O=$(ABS_OPTEE_OS_OUT_DIR) \
-		CFG_USER_TA_TARGETS=$(OPTEE_TA_TARGETS) \
-		CFG_ARM64_core=$(OPTEE_CFG_ARM64_CORE) \
-		PLATFORM=$(OPTEE_PLATFORM) \
-		PLATFORM_FLAVOR=$(OPTEE_PLATFORM_FLAVOR) \
-		$(CROSS_COMPILE_LINE) \
-		$(OPTEE_EXTRA_FLAGS)
+	+$(HOST_MAKE) $(OPTEE_MAKE_LINE) \
+		CFG_USER_TA_TARGETS=$(OPTEE_TA_TARGETS)
 	@echo "Finished building optee_os..."
 
 endif
@@ -114,14 +145,8 @@ BUILD_TA_DEV_KIT_DEFINED := $(TA_TARGET) $(BUILD_TA_DEV_KIT_DEFINED)
 $(OPTEE_TA_DEV_KIT_MK): PRIVATE_TA_TARGET := $(TA_TARGET)
 $(OPTEE_TA_DEV_KIT_MK):
 	@echo "Start building ta_dev_kit ($(PRIVATE_TA_TARGET))..."
-	+$(HOST_MAKE) -C $(TOP_ROOT_ABS)/$(OPTEE_OS_DIR) \
-		O=$(ABS_OPTEE_OS_OUT_DIR) \
-		CFG_USER_TA_TARGETS=$(PRIVATE_TA_TARGET) \
-		CFG_ARM64_core=$(OPTEE_CFG_ARM64_CORE) \
-		PLATFORM=$(OPTEE_PLATFORM) \
-		PLATFORM_FLAVOR=$(OPTEE_PLATFORM_FLAVOR) \
-		$(CROSS_COMPILE_LINE) \
-		$(OPTEE_EXTRA_FLAGS) ta_dev_kit
+	+$(HOST_MAKE) $(OPTEE_MAKE_LINE) \
+		CFG_USER_TA_TARGETS=$(PRIVATE_TA_TARGET) ta_dev_kit
 	@echo "Finished building ta_dev_kit ($(PRIVATE_TA_TARGET))..."
 endif
 

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -191,6 +191,14 @@ $(foreach d, $(incdirs-host), \
 $(foreach f, $(incfiles-extra-host), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/host_include)))
 
+# Some dev kit consumers need the configuration before they can build
+# anything, typically to pick which sources to compile. Export the
+# configuration files alone; they are written by plain shell commands, so
+# this builds nothing.
+.PHONY: ta_dev_kit_conf
+ta_dev_kit_conf: $(foreach f, $(conf-file) $(conf-mk-file) $(conf-cmake-file), \
+	$(out-dir)/export-$(sm)/host_include/$(notdir $(f)))
+
 # Copy the src files
 ta-srcfiles = ta/user_ta_header.c ta/arch/$(ARCH)/ta.ld.S
 ifeq ($(ta-target),ta_arm32)


### PR DESCRIPTION
Adds `ta_dev_kit_conf`, a target that exports the dev kit configuration
(conf.h, conf.mk, conf.cmake): the files are written by shell commands, so
it builds no libraries and takes about a second. `mk/aosp_optee.mk` then
runs it while the makefiles are parsed, so the configuration is on disk
before any `Android.mk` is read. Building the dev kit itself is left to the
ninja graph, as before.

The md5 of the generated conf.mk is kept in a variable, so ckati re-parses
when the configuration changes, even though that configuration comes from
files ckati never reads itself. All optee_os invocations now share one
command line, so the configuration read while parsing cannot drift from the
one the dev kit is built with.

This fixes a long-standing trap for `Android.mk` files that select what to
build from the CFG_ flags of the TEE they are built against -
`-include $(TA_DEV_KIT_DIR)/host_include/conf.mk`, as optee_test does for its
GP socket tests. On a clean build that include finds nothing, because ckati
parses the makefiles to emit the ninja graph and the dev kit is built by
that very graph: the flags come out empty and the sources they select are
dropped with no diagnostic, so what ends up in the binary depends on whether
the output directory happens to be warm. It was reported as
OP-TEE/optee_test#275 in 2018 and closed without a fix; no build dependency
can close it, since the parsing is what produces the rules. The approach
here is the one @jforissier suggested in OP-TEE/optee_test#825, making the
dev kit configuration a required input.
