### PR TITLE
crypto: rsa: reject RSA NOPAD input longer than the modulus

### DIFF
--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -353,6 +353,13 @@ static TEE_Result decrypt_nopad(struct rsa_keypair *key, const uint8_t *src,
 	}
 
 	rsa_len = crypto_bignum_num_bytes(key->n);
+
+	/* Input cannot be larger than the modulus */
+	if (src_len > rsa_len) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
 	memcpy(buf + rsa_len - src_len, src, src_len);
 
 	st = sss_se05x_asymmetric_decrypt(&ctx, buf, rsa_len, buf, &blen);
@@ -415,6 +422,13 @@ static TEE_Result encrypt_nopad(struct rsa_public_key *key, const uint8_t *src,
 	}
 
 	rsa_len = crypto_bignum_num_bytes(key->n);
+
+	/* Input cannot be larger than the modulus */
+	if (src_len > rsa_len) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
 	memcpy(buf + rsa_len - src_len, src, src_len);
 
 	st = sss_se05x_asymmetric_encrypt(&ctx, buf, rsa_len, buf, &blen);

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -354,6 +354,12 @@ TEE_Result sw_crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
 
 	rsa.len = crypto_bignum_num_bytes((void *)&rsa.N);
 
+	/* Input cannot be larger than the modulus */
+	if (src_len > rsa.len) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
 	blen = CFG_CORE_BIGNUM_MAX_BITS / 8;
 	buf = malloc(blen);
 	if (!buf) {
@@ -414,6 +420,12 @@ TEE_Result sw_crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
 	res = rsa_init_and_complete_from_key_pair(&rsa, key);
 	if (res)
 		return res;
+
+	/* Input cannot be larger than the modulus */
+	if (src_len > rsa.len) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
 
 	blen = CFG_CORE_BIGNUM_MAX_BITS / 8;
 	buf = malloc(blen);


### PR DESCRIPTION
The RSA NOPAD encrypt and decrypt operations copy the caller's input into
a modulus-sized buffer, left-aligned:

	memcpy(buf + rsa_len - src_len, src, src_len);

The input length src_len and the modulus size rsa_len are both size_t, and
nothing checks that src_len fits within rsa_len. A Trusted Application can
reach this through a TEE_ALG_RSA_NOPAD operation with an input longer than
the modulus; the input is only checked for read access, never bounded
against the key. The offset rsa_len - src_len then underflows to a huge
value and the memcpy writes before the buffer, a heap underwrite of
attacker-controlled data.

Two backends are missing the bound: the mbedtls software backend and the
SE050 driver. libtomcrypt already rejects an oversize input, and the
hisilicon and asu drivers already perform the same check.

Patch 1 adds the bound to the mbedtls RSA NOPAD encrypt and decrypt.
Patch 2 adds it to the SE050 driver's encrypt_nopad and decrypt_nopad.

Based on master (991587c). A reproducer is available on request.
