### PR TITLE
core: pta: widevine: reject a NULL calling session in open_session

### DIFF
--- a/core/pta/widevine.c
+++ b/core/pta/widevine.c
@@ -117,7 +117,7 @@ static TEE_Result open_session(uint32_t param_types __unused,
 	struct ts_session *session = ts_get_calling_session();
 
 	/* Make sure we are called from a TA */
-	if (!is_user_ta_ctx(session->ctx))
+	if (!session || !is_user_ta_ctx(session->ctx))
 		return TEE_ERROR_ACCESS_DENIED;
 
 	/* Make sure we are called from an allowed TA */


### PR DESCRIPTION
open_session() restricts access to a set of allowed TA UUIDs, but dereferences the calling session without checking it for NULL:

	struct ts_session *session = ts_get_calling_session();

	if (!is_user_ta_ctx(session->ctx))
		return TEE_ERROR_ACCESS_DENIED;

When the Normal World opens a session on this PTA directly (OPTEE_MSG_CMD_OPEN_SESSION), no calling TA session is on the stack and ts_get_calling_session() returns NULL. The is_user_ta_ctx(session->ctx) dereference then faults at S-EL1 and panics the TEE: a denial of service reachable from the Normal World when CFG_WIDEVINE_PTA is enabled.

Reject a NULL calling session, as the other PTAs already do.

Fixes: ad194957b670 ("core: pta: widevine: Add the init implementation")
Based on master (991587c721a603e831cad228626078289adad159). A reproducer is available on request.