### PR TITLE
core: ldelf: reject TA_FLAG_CONCURRENT for user TAs

### DIFF
--- a/core/kernel/ldelf_loader.c
+++ b/core/kernel/ldelf_loader.c
@@ -165,6 +165,10 @@ TEE_Result ldelf_init_with_ldelf(struct ts_session *sess,
 		if (arg_bbuf->flags & ~TA_FLAGS_MASK)
 			return TEE_ERROR_BAD_FORMAT;
 
+		/* TA_FLAG_CONCURRENT is for pseudo-TAs only */
+		if (arg_bbuf->flags & TA_FLAG_CONCURRENT)
+			return TEE_ERROR_BAD_FORMAT;
+
 		to_user_ta_ctx(uctx->ts_ctx)->ta_ctx.flags = arg_bbuf->flags;
 	}
 

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -1285,6 +1285,10 @@ void ta_elf_load_main(const TEE_UUID *uuid, uint32_t *is_32bit, uint64_t *sp,
 		err(TEE_ERROR_BAD_FORMAT, "Invalid TA flags(s) %#"PRIx32,
 		    elf->head->flags & ~TA_FLAGS_MASK);
 
+	if (elf->head->flags & TA_FLAG_CONCURRENT)
+		err(TEE_ERROR_BAD_FORMAT, "Invalid TA flags(s) %#"PRIx32,
+		    elf->head->flags & TA_FLAG_CONCURRENT);
+
 	*ta_flags = elf->head->flags;
 	*sp = va + elf->head->stack_size;
 	ta_stack = va;


### PR DESCRIPTION
TA_FLAG_CONCURRENT is documented as pseudo-TA only, but the flag sits inside TA_FLAGS_MASK, so a user TA can set it in its signed header and the core accepts it (ldelf_loader.c). tee_ta_try_set_busy() then returns early without serializing, so two sessions of a single-instance, multi-session user TA run concurrently on the one shared context.

Both sessions map and unmap their memref parameters on the shared uctx->vm_info.regions list with no lock, so the concurrent inserts, removals and frees corrupt the list and free vm_region nodes still in use: a use-after-free in S-EL1.

Reject a user TA that sets TA_FLAG_CONCURRENT, so user TAs stay serialized by the busy lock as the rest of the code assumes.

Fixes: c7c4b6e31b3b ("core: allow multithreaded pseudo TAs")
Based on master (991587c721a603e831cad228626078289adad159). A reproducer is available on request.