### PR TITLE
ta: pkcs11: ensure token is initialized when checking SO PIN

### DIFF
--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -1135,7 +1135,8 @@ static enum pkcs11_rc check_so_pin(struct pkcs11_session *session,
 	struct token_persistent_main *db = token->db_main;
 	enum pkcs11_rc rc = PKCS11_CKR_OK;
 
-	assert(db->flags & PKCS11_CKFT_TOKEN_INITIALIZED);
+	if (!(db->flags & PKCS11_CKFT_TOKEN_INITIALIZED))
+		return PKCS11_CKR_GENERAL_ERROR;
 
 	if (IS_ENABLED(CFG_PKCS11_TA_AUTH_TEE_IDENTITY) &&
 	    db->flags & PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH)
@@ -1293,10 +1294,6 @@ enum pkcs11_rc entry_ck_set_pin(struct pkcs11_client *client,
 		return PKCS11_CKR_SESSION_READ_ONLY;
 
 	if (pkcs11_session_is_so(session)) {
-		if (!(session->token->db_main->flags &
-		      PKCS11_CKFT_TOKEN_INITIALIZED))
-			return PKCS11_CKR_GENERAL_ERROR;
-
 		rc = check_so_pin(session, old_pin, old_pin_size);
 		if (rc)
 			return rc;


### PR DESCRIPTION
Replace the assertion in token being initialized with an always embedded test in check_so_pin() to prevent Cryptoki C_Login() (TA command PKCS11_CMD_LOGIN) to proceed on a uninitialized token.

Remove the test on that flags in entry_ck_set_pin() when setting SO PIN since it's now done in check_so_pin().

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
