### PR TITLE
drivers: qcom: add OP-TEE-owned XPU protection for TZDRAM and DIAG log

### DIFF
--- a/core/arch/arm/plat-qcom/bobcat/ipq52xx/xpu_target.h
+++ b/core/arch/arm/plat-qcom/bobcat/ipq52xx/xpu_target.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef XPU_TARGET_H
+#define XPU_TARGET_H
+
+#include <drivers/qcom/xpuv4.h>
+
+/* TZDRAM is secure-APPS only, for both read and write */
+#define TZDRAM_XPU_READ_QAD		QAD_APPS_SEC
+#define TZDRAM_XPU_WRITE_QAD		QAD_APPS_SEC
+
+/* Only secure APPS may write the DIAG log */
+#define DIAG_XPU_WRITE_QAD		QAD_APPS_SEC
+
+/* MEMNOC_SCH_MPU: resource groups 10..15 are free for runtime allocation */
+#define DDR_MPU_BASE			UL(0xAC0000)
+#define DDR_MPU_ADDR_OFFSET		UL(0x80000000)
+#define DDR_XPU_RG_START		UL(10)
+#define DDR_XPU_RG_COUNT		UL(6)
+
+/*
+ * OCIMEM_MPU register window. The base is well below CORE_MMU_PGDIR_SIZE,
+ * so a pgdir-granularity mapping would round it down to address 0 and a
+ * small explicit range is mapped instead. Resource groups 9..10 are free
+ * for runtime allocation.
+ */
+#define IMEM_MPU_BASE			UL(0x54000)
+#define IMEM_MPU_MAP_SIZE		(2 * SMALL_PAGE_SIZE)
+#define IMEM_XPU_RG_START		UL(9)
+#define IMEM_XPU_RG_COUNT		UL(2)
+
+/* AP (secure + non-secure), TME ROM, and debug may read the DIAG log */
+#define DIAG_XPU_READ_QAD \
+	(QAD_ENV_APPS | QAD_TME_ROM | QAD_DEBUG)
+
+#endif /* XPU_TARGET_H */

--- a/core/arch/arm/plat-qcom/bobcat/ipq96xx/xpu_target.h
+++ b/core/arch/arm/plat-qcom/bobcat/ipq96xx/xpu_target.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef XPU_TARGET_H
+#define XPU_TARGET_H
+
+#include <drivers/qcom/xpuv4.h>
+
+/* TZDRAM is secure-APPS only, for both read and write */
+#define TZDRAM_XPU_READ_QAD		QAD_APPS_SEC
+#define TZDRAM_XPU_WRITE_QAD		QAD_APPS_SEC
+
+/* Only secure APPS may write the DIAG log */
+#define DIAG_XPU_WRITE_QAD		QAD_APPS_SEC
+
+/* MACHX_LLCC_MPU: resource groups 30..39 are free for runtime allocation */
+#define DDR_MPU_BASE			UL(0x4060000)
+#define DDR_MPU_ADDR_OFFSET		UL(0x0)
+#define DDR_XPU_RG_START		UL(30)
+#define DDR_XPU_RG_COUNT		UL(10)
+
+/*
+ * OCIMEM_MPU register window. The base is well below CORE_MMU_PGDIR_SIZE,
+ * so a pgdir-granularity mapping would round it down to address 0 and a
+ * small explicit range is mapped instead. Resource groups 6..9 are free
+ * for runtime allocation.
+ */
+#define IMEM_MPU_BASE			UL(0x54000)
+#define IMEM_MPU_MAP_SIZE		(2 * SMALL_PAGE_SIZE)
+#define IMEM_XPU_RG_START		UL(6)
+#define IMEM_XPU_RG_COUNT		UL(4)
+
+/*
+ * AP (secure + non-secure), TME ROM, debug, AP boot loader, modem, and
+ * PRIME may read the DIAG log.
+ */
+#define DIAG_XPU_READ_QAD \
+	(QAD_ENV_APPS | QAD_TME_ROM | QAD_DEBUG | QAD_AP_QC_BL | QAD_MSA | \
+	 QAD_PRIME)
+
+#endif /* XPU_TARGET_H */

--- a/core/arch/arm/plat-qcom/bobcat/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/bobcat/qcom-arch.mk
@@ -2,3 +2,9 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 CFG_QCOM_SEC_WDOG ?= y
+
+# XPU protection for TZDRAM and the OP-TEE DIAG log buffer
+CFG_QCOM_XPU_PROTECT ?= y
+ifeq ($(CFG_QCOM_XPU_PROTECT),y)
+$(call force,CFG_QCOM_XPUV4,y)
+endif

--- a/core/arch/arm/plat-qcom/sub.mk
+++ b/core/arch/arm/plat-qcom/sub.mk
@@ -3,6 +3,7 @@ global-incdirs-y += $(QCOM_ARCH_FAMILY)
 global-incdirs-y += $(QCOM_ARCH_FAMILY)/$(PLATFORM_FLAVOR)
 srcs-y += main.c
 srcs-$(CFG_QCOM_DIAG_LOG) += diag_log.c
+srcs-$(CFG_QCOM_XPU_PROTECT) += xpu_policy.c
 
 subdirs-$(CFG_QCOM_QFPROM_FUSEPROV) += provision
 subdirs-y += $(QCOM_ARCH_FAMILY)

--- a/core/arch/arm/plat-qcom/xpu_policy.c
+++ b/core/arch/arm/plat-qcom/xpu_policy.c
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <assert.h>
+#include <config.h>
+#include <drivers/qcom/xpu.h>
+#include <drivers/qcom/xpuv4.h>
+#include <initcall.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <tee_api_types.h>
+#include <trace.h>
+#include <util.h>
+#include <xpu_target.h>
+
+/* This SoC's XPU4 instances, handed to the driver at protection time */
+static const struct xpu4_instance xpu4_instances[] = {
+	{
+		.base = DDR_MPU_BASE,
+		.map_size = CORE_MMU_PGDIR_SIZE,
+		.addr_off = DDR_MPU_ADDR_OFFSET,
+		.guard_start = DRAM0_BASE,
+		.guard_size = DRAM0_SIZE,
+		.rg_start = DDR_XPU_RG_START,
+		.rg_count = DDR_XPU_RG_COUNT,
+	},
+	{
+		.base = IMEM_MPU_BASE,
+		.map_size = IMEM_MPU_MAP_SIZE,
+		.addr_off = IMEM_BASE,
+		.guard_start = IMEM_BASE,
+		.guard_size = IMEM_SIZE,
+		.rg_start = IMEM_XPU_RG_START,
+		.rg_count = IMEM_XPU_RG_COUNT,
+	},
+};
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, DDR_MPU_BASE, CORE_MMU_PGDIR_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, IMEM_MPU_BASE, IMEM_MPU_MAP_SIZE);
+
+/* A memory region to protect and the QAD read/write policy to apply */
+struct xpu_region {
+	const char *name;
+	paddr_t base;
+	size_t size;
+	uint32_t read_qad;
+	uint32_t write_qad;
+	bool enabled;
+};
+
+static const struct xpu_region xpu_regions[] = {
+	{
+		.name = "TZDRAM",
+		.base = CFG_TZDRAM_START,
+		.size = CFG_TZDRAM_SIZE,
+		.read_qad = TZDRAM_XPU_READ_QAD,
+		.write_qad = TZDRAM_XPU_WRITE_QAD,
+		.enabled = true,
+	},
+	{
+		/*
+		 * The DIAG log buffer only holds data when the log itself
+		 * is built in, so protecting it otherwise would lock a
+		 * resource group for a region nothing uses.
+		 */
+		.name = "DIAG log",
+		.base = DIAG_BASE,
+		.size = DIAG_SIZE,
+		.read_qad = DIAG_XPU_READ_QAD,
+		.write_qad = DIAG_XPU_WRITE_QAD,
+		.enabled = IS_ENABLED(CFG_QCOM_DIAG_LOG),
+	},
+};
+
+static TEE_Result plat_xpu_protect(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+	size_t i = 0;
+
+	static_assert(IS_ALIGNED(CFG_TZDRAM_START, SIZE_4K));
+	static_assert(IS_ALIGNED(CFG_TZDRAM_SIZE, SIZE_4K));
+
+	xpu4_register_instances(xpu4_instances, ARRAY_SIZE(xpu4_instances));
+
+	/* Protect what is left even if one region could not be programmed */
+	for (i = 0; i < ARRAY_SIZE(xpu_regions); i++) {
+		const struct xpu_region *r = &xpu_regions[i];
+		TEE_Result rc = TEE_SUCCESS;
+
+		if (!r->enabled)
+			continue;
+
+		rc = xpu_protect_region(r->base, r->size, r->read_qad,
+					r->write_qad);
+		if (rc) {
+			EMSG("XPU: %s protection failed: %#" PRIx32,
+			     r->name, rc);
+			if (!res)
+				res = rc;
+		}
+	}
+
+	return res;
+}
+service_init(plat_xpu_protect);

--- a/core/drivers/qcom/sub.mk
+++ b/core/drivers/qcom/sub.mk
@@ -11,3 +11,4 @@ srcs-$(CFG_QCOM_SEC_WDOG) += wdt/qcom-wdt.c
 subdirs-$(CFG_QCOM_CMD_DB) += cmd_db
 subdirs-$(CFG_QCOM_RPMH_CLIENT) += rpmh
 subdirs-$(CFG_QCOM_QFPROM) += qfprom
+subdirs-$(CFG_QCOM_XPUV4) += xpu

--- a/core/drivers/qcom/xpu/sub.mk
+++ b/core/drivers/qcom/xpu/sub.mk
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+
+srcs-$(CFG_QCOM_XPUV4) += xpuv4.c

--- a/core/drivers/qcom/xpu/xpuv4.c
+++ b/core/drivers/qcom/xpu/xpuv4.c
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <drivers/qcom/xpuv4.h>
+#include <io.h>
+#include <kernel/tee_misc.h>
+#include <mm/core_memprot.h>
+#include <tee_api_types.h>
+#include <trace.h>
+#include <types_ext.h>
+#include <util.h>
+
+/*
+ * XPU4 register offsets.
+ * IDR0 reports the highest resource group (RG) index in NRG. Each RG
+ * occupies 0x40 bytes starting at base + 0x1000.
+ *   IDR0     +0x0000  NRG = bits 25:16
+ *   RGCR1n   +0x1004  bit 0 = RGE (enable)
+ *   RGCSAR1n +0x1008  start address [63:32]
+ *   RGCSAR0n +0x100C  start address [31:0]
+ *   RGCEAR1n +0x1010  end   address [63:32]
+ *   RGCEAR0n +0x1014  end   address [31:0]
+ *   RGRDRn   +0x1018  read  QAD vector
+ *   RGWRRn   +0x101C  write QAD vector
+ *   QADRGLn  +0x1030  QAD lock vector (bit 31 = secure lock RGL_S)
+ */
+#define XPU4_IDR0(b)        ((b) + 0x0u)
+#define XPU4_RGCR1n(b, n)   ((b) + 0x1004u + 0x40u * (n))
+#define XPU4_RGCSAR1n(b, n) ((b) + 0x1008u + 0x40u * (n))
+#define XPU4_RGCSAR0n(b, n) ((b) + 0x100Cu + 0x40u * (n))
+#define XPU4_RGCEAR1n(b, n) ((b) + 0x1010u + 0x40u * (n))
+#define XPU4_RGCEAR0n(b, n) ((b) + 0x1014u + 0x40u * (n))
+#define XPU4_RGRDRn(b, n)   ((b) + 0x1018u + 0x40u * (n))
+#define XPU4_RGWRRn(b, n)   ((b) + 0x101Cu + 0x40u * (n))
+#define XPU4_QADRGLn(b, n)  ((b) + 0x1030u + 0x40u * (n))
+
+#define XPU4_IDR0_NRG_MASK	SHIFT_U32(0x3FF, 16)
+#define XPU4_IDR0_NRG_SHIFT	16
+
+#define XPU4_RGCR1n_RGE		BIT32(0)
+
+/* Instances the platform registered, describing this SoC's XPU layout */
+static const struct xpu4_instance *xpu4_instances;
+static size_t xpu4_instance_count;
+
+void xpu4_register_instances(const struct xpu4_instance *instances,
+			     size_t count)
+{
+	xpu4_instances = instances;
+	xpu4_instance_count = count;
+}
+
+static const struct xpu4_instance *xpu4_find_instance(paddr_t start,
+						      size_t size)
+{
+	const struct xpu4_instance *inst = NULL;
+	size_t i = 0;
+
+	for (i = 0; i < xpu4_instance_count; i++) {
+		inst = &xpu4_instances[i];
+
+		if (core_is_buffer_inside(start, size, inst->guard_start,
+					  inst->guard_size))
+			return inst;
+	}
+
+	return NULL;
+}
+
+static TEE_Result xpu4_find_free_rg(vaddr_t base,
+				    const struct xpu4_instance *inst,
+				    unsigned int *rg)
+{
+	unsigned int rg_end = inst->rg_start + inst->rg_count;
+	unsigned int nrg = 0;
+	unsigned int i = 0;
+
+	/* IDR0 reports the highest RG index, so the count is one more */
+	nrg = ((io_read32(XPU4_IDR0(base)) & XPU4_IDR0_NRG_MASK) >>
+	       XPU4_IDR0_NRG_SHIFT) + 1;
+	if (rg_end > nrg) {
+		EMSG("XPU: RG window %u..%u exceeds %u RGs implemented",
+		     inst->rg_start, rg_end - 1, nrg);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	for (i = inst->rg_start; i < rg_end; i++) {
+		if (io_read32(XPU4_RGCR1n(base, i)) & XPU4_RGCR1n_RGE)
+			continue;
+
+		*rg = i;
+		return TEE_SUCCESS;
+	}
+
+	EMSG("XPU: no free RG in window %u..%u", inst->rg_start, rg_end - 1);
+	return TEE_ERROR_OUT_OF_MEMORY;
+}
+
+static void xpu4_program_rg(vaddr_t base, unsigned int rg, paddr_t start,
+			    paddr_t end, uint32_t read_qad, uint32_t write_qad,
+			    uint32_t lock_qad)
+{
+	io_write32(XPU4_RGCSAR1n(base, rg), (uint32_t)(start >> 32));
+	io_write32(XPU4_RGCSAR0n(base, rg), (uint32_t)start);
+	io_write32(XPU4_RGCEAR1n(base, rg), (uint32_t)(end >> 32));
+	io_write32(XPU4_RGCEAR0n(base, rg), (uint32_t)end);
+	io_write32(XPU4_RGRDRn(base, rg), read_qad);
+	io_write32(XPU4_RGWRRn(base, rg), write_qad);
+	io_write32(XPU4_RGCR1n(base, rg), XPU4_RGCR1n_RGE);
+	io_write32(XPU4_QADRGLn(base, rg), lock_qad);
+}
+
+TEE_Result xpu_protect_region(paddr_t start, size_t size,
+			      uint32_t read_perm, uint32_t write_perm)
+{
+	const struct xpu4_instance *inst = NULL;
+	uint32_t lock_perm = 0;
+	unsigned int rg = 0;
+	paddr_t xpu_start = 0;
+	paddr_t xpu_end = 0;
+	vaddr_t base = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	/* XPU4 requires 4KB-aligned, non-zero start and end addresses */
+	if (!size || !IS_ALIGNED(start, SIZE_4K) ||
+	    !IS_ALIGNED(size, SIZE_4K)) {
+		EMSG("XPU: region %#" PRIxPA "+%#zx not 4KB aligned",
+		     start, size);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	inst = xpu4_find_instance(start, size);
+	if (!inst) {
+		EMSG("XPU: no instance guards region %#" PRIxPA "+%#zx",
+		     start, size);
+		return TEE_ERROR_ITEM_NOT_FOUND;
+	}
+
+	/* Addresses are relative to the region base; the end is exclusive */
+	if (SUB_OVERFLOW(start, inst->addr_off, &xpu_start) ||
+	    ADD_OVERFLOW(xpu_start, size, &xpu_end)) {
+		EMSG("XPU: region %#" PRIxPA "+%#zx invalid for offset %#"
+		     PRIxPA, start, size, inst->addr_off);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	lock_perm = (read_perm | write_perm) & QAD_ENV_APPS;
+	if (!lock_perm) {
+		EMSG("XPU: no AP domain in region perms, refusing to program");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	base = io_pa_or_va_secure(&(struct io_pa_va){ .pa = inst->base },
+				  inst->map_size);
+
+	res = xpu4_find_free_rg(base, inst, &rg);
+	if (res)
+		return res;
+
+	xpu4_program_rg(base, rg, xpu_start, xpu_end,
+			read_perm, write_perm, lock_perm);
+
+	return TEE_SUCCESS;
+}

--- a/core/include/drivers/qcom/xpu.h
+++ b/core/include/drivers/qcom/xpu.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef DRIVERS_QCOM_XPU_H
+#define DRIVERS_QCOM_XPU_H
+
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+/*
+ * Restrict [start, start + size) to the given read/write QAD permission
+ * vectors and lock it. start and size must be 4KB aligned, size non-zero.
+ */
+TEE_Result xpu_protect_region(paddr_t start, size_t size,
+			      uint32_t read_perm, uint32_t write_perm);
+
+#endif /* DRIVERS_QCOM_XPU_H */

--- a/core/include/drivers/qcom/xpuv4.h
+++ b/core/include/drivers/qcom/xpuv4.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef XPUV4_H
+#define XPUV4_H
+
+#include <drivers/qcom/xpu.h>
+#include <types_ext.h>
+#include <util.h>
+
+/* XPU4 static QAD permission encodings */
+
+/*
+ * QAD vector for the secure APPS domain: bit 0 = QAD_APPS identifier,
+ * bit 31 = secure qualifier.
+ */
+#define QAD_APPS_SEC		(BIT32(0) | BIT32(31))
+
+/*
+ * AP execution-environment QAD vector (secure + non-secure APPS).
+ */
+#define QAD_ENV_APPS		(BIT32(0) | BIT32(31) | BIT32(30))
+
+/*
+ * Per-master QAD identifiers, so read/write policy vectors in target
+ * config spell out which masters have access instead of an opaque hex
+ * literal. Identifiers and their meaning come from the XPU4 static QAD
+ * assignment; not every identifier is wired to a real master on every SoC.
+ */
+#define QAD_TME_ROM		BIT32(1)
+#define QAD_DEBUG		BIT32(3)
+#define QAD_AP_QC_BL		BIT32(4)
+#define QAD_MSA			BIT32(5)
+#define QAD_PRIME		BIT32(6)
+
+/*
+ * An XPU4 instance and the memory range it guards. Resource groups outside
+ * [rg_start, rg_start + rg_count) belong to other owners such as earlier
+ * boot stages and are never allocated here. The platform provides these.
+ */
+struct xpu4_instance {
+	paddr_t base;
+	size_t map_size;
+	paddr_t addr_off;
+	paddr_t guard_start;
+	size_t guard_size;
+	unsigned int rg_start;
+	unsigned int rg_count;
+};
+
+/* Register the platform's XPU instances before any region is protected */
+void xpu4_register_instances(const struct xpu4_instance *instances,
+			     size_t count);
+
+#endif /* XPUV4_H */


### PR DESCRIPTION
## Summary

Move XPU protection of TZDRAM and the OP-TEE DIAG log from TF-A's static
policy into OP-TEE, which already owns the values being protected. Callers
only describe the region and access policy; the driver resolves the
guarding XPU instance and a free resource group on its own.

## Testing

Verified by inspecting the XPU resource-group registers programmed by
OP-TEE (addresses, permissions, enable/lock bits) and by triggering XPU
violations from non-secure accesses to both regions. 

Tested-on: Hermosa (IPQ52xx)
Tested-on: Juhu (IPQ96xx)
