### PR TITLE
ldelf: improve ELF validation and relocation handling

### DIFF
--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -1269,6 +1269,9 @@ void ta_elf_load_main(const TEE_UUID *uuid, uint32_t *is_32bit, uint64_t *sp,
 {
 	struct ta_elf *elf = queue_elf(uuid);
 	vaddr_t va = 0;
+	size_t stack_size = 0;
+	size_t stack_alignment = 0;
+	size_t rounded_stack_size = 0;
 	TEE_Result res = TEE_SUCCESS;
 
 	assert(elf);
@@ -1277,7 +1280,18 @@ void ta_elf_load_main(const TEE_UUID *uuid, uint32_t *is_32bit, uint64_t *sp,
 	load_main(elf);
 
 	*is_32bit = elf->is_32bit;
-	res = sys_map_zi(elf->head->stack_size, 0, &va, 0, 0);
+	stack_size = elf->head->stack_size;
+
+	/*
+	 * AArch32 is the only supported 32-bit format and requires 8-byte
+	 * stack alignment. AArch64 and RV64 require 16 bytes.
+	 */
+	stack_alignment = elf->is_32bit ? 8 : 16;
+	if (!stack_size || !IS_ALIGNED(stack_size, stack_alignment) ||
+	    ROUNDUP_OVERFLOW(stack_size, SMALL_PAGE_SIZE, &rounded_stack_size))
+		err(TEE_ERROR_BAD_FORMAT, "Invalid stack size");
+
+	res = sys_map_zi(stack_size, 0, &va, 0, 0);
 	if (res)
 		err(res, "sys_map_zi stack");
 
@@ -1286,14 +1300,14 @@ void ta_elf_load_main(const TEE_UUID *uuid, uint32_t *is_32bit, uint64_t *sp,
 		    elf->head->flags & ~TA_FLAGS_MASK);
 
 	*ta_flags = elf->head->flags;
-	*sp = va + elf->head->stack_size;
+	*sp = va + stack_size;
 	ta_stack = va;
-	ta_stack_size = elf->head->stack_size;
+	ta_stack_size = stack_size;
 
 	if (IS_ENABLED(CFG_TA_SANITIZE_KADDRESS)) {
 		res = asan_user_map_shadow((void *)ta_stack,
 					   (void *)(ta_stack +
-					   roundup(ta_stack_size)),
+						    rounded_stack_size),
 					   ASAN_REG_STACK);
 		if (res) {
 			EMSG("Failed to map shadow stack for ELF (%pUl)",

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -1002,6 +1002,9 @@ static void map_segments(struct ta_elf *elf)
 	TEE_Result res = TEE_SUCCESS;
 
 	parse_load_segments(elf);
+	if (TAILQ_EMPTY(&elf->segs))
+		err(TEE_ERROR_BAD_FORMAT, "No loadable segments");
+
 	adjust_segments(elf);
 	if (TAILQ_FIRST(&elf->segs)->offset < SMALL_PAGE_SIZE) {
 		vaddr_t va = 0;

--- a/ldelf/ta_elf_rel.c
+++ b/ldelf/ta_elf_rel.c
@@ -529,7 +529,7 @@ static void e64_process_tls_tprel_rela(const Elf64_Sym *sym_tab,
 				       size_t str_tab_size, Elf64_Rela *rela,
 				       Elf64_Addr *where, struct ta_elf *elf)
 {
-	struct ta_elf *mod = NULL;
+	struct ta_elf *mod = elf;
 	bool weak_undef = false;
 	const char *name = NULL;
 	size_t sym_idx = 0;
@@ -540,8 +540,6 @@ static void e64_process_tls_tprel_rela(const Elf64_Sym *sym_tab,
 		e64_get_sym_name(sym_tab, num_syms, str_tab, str_tab_size, rela,
 				 &name, &weak_undef);
 		resolve_sym(name, &symval, &mod, !weak_undef);
-	} else {
-		mod = elf;
 	}
 	*where = symval + mod->tls_tcb_offs + rela->r_addend;
 }


### PR DESCRIPTION
Improve ldelf validation and relocation handling for malformed or unusual ELF inputs.

These commits:
- rejects ELF files that do not contain a `PT_LOAD` segment before accessing the segment list
- validates the TA stack size before rounding and mapping it
- ~~validates symbol and string tables used by 64-bit relocations~~
- handles unresolved weak symbols safely

These changes prevent NULL dereferences, invalid zero-sized mappings, and unsafe arithmetic when processing ELF metadata.
