### PR TITLE
drivers: crypto: harden crypto_acipher_rsaes_{de,en}crypt()

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -244,6 +244,8 @@ TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
 		rsa_data.key.key = key;
 		rsa_data.key.isprivate = true;
 		rsa_data.key.n_size = crypto_bignum_num_bytes(key->n);
+		if (cipher_len > rsa_data.key.n_size)
+			return TEE_ERROR_BAD_PARAMETERS;
 
 		rsa_data.message.data = msg;
 		rsa_data.message.length = *msg_len;
@@ -310,7 +312,8 @@ TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 			rsa_data.rsa_id = DRVCRYPT_RSA_PKCS_V1_5;
 
 			/* Message length <= (modulus_size - 11) */
-			if (msg_len > rsa_data.key.n_size - 11)
+			if (rsa_data.key.n_size < 11 ||
+			    msg_len > rsa_data.key.n_size - 11)
 				return TEE_ERROR_BAD_PARAMETERS;
 
 		} else {
@@ -323,7 +326,8 @@ TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 			if (ret != TEE_SUCCESS)
 				return ret;
 
-			if (2 * rsa_data.digest_size >= rsa_data.key.n_size - 2)
+			if (rsa_data.key.n_size <=
+			    2 * rsa_data.digest_size + 2)
 				return TEE_ERROR_BAD_PARAMETERS;
 
 			if (msg_len >


### PR DESCRIPTION
Following the recently merged commit 7b8b494e0a32 ("drivers: crypto: harden crypto_acipher_rsanopad_{de,en}crypt()"),
I found similar validation gaps in the RSAES encrypt and decrypt paths.

RSAES decryption did not reject ciphertexts larger than the RSA modulus.
So, RSAES encryption could underflow when calculating the maximum message size
if the modulus was too small for the required padding.
