### PR TITLE
plat-vexpress: fix default offset for SHMEM

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -153,7 +153,7 @@ CFG_TZDRAM_START ?= 0x0e100000
 CFG_TZDRAM_SIZE  ?= 0x00f00000
 # SHM chosen arbitrary, in a way that it does not interfere
 # with initial location of linux kernel, dtb and initrd.
-CFG_SHMEM_START ?= 0x42000000
+CFG_SHMEM_START ?= 0x43000000
 CFG_SHMEM_SIZE  ?= 0x00200000
 # When Secure Data Path is enable, last MByte of TZDRAM is SDP test memory.
 CFG_TEE_SDP_MEM_SIZE ?= 0x00400000


### PR DESCRIPTION
By default, when using opteed as SPD, we choose to place SHMEM at 0x42000000.

By default, QEMU virt ram starts at 0x40000000, and kernel is loaded at 0x40400000. When building a kernel with default arm64 config, size is around 40MB. That's enough to overlap with SHMEM, and as a result, kernel image is overwritten. This causes u-boot to refuse to boot because zImage signature is wrong.

By moving SHMEM start to 0x43000000, this fixes the problem.