### PR TITLE
ci: upgrade cache and checkout actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     container: jforissier/optee_os_ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # full history so checkpatch can check commit IDs in commit messages
       - name: Update Git config
@@ -349,7 +349,7 @@ jobs:
               _make PLATFORM=cva6
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Update Git config
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Generate cache key
@@ -358,7 +358,7 @@ jobs:
           echo "CACHE_KEY=builds-cache-${HASH}-${GITHUB_SHA}" >> ${GITHUB_ENV}
           echo "CACHE_RESTORE_KEY=builds-cache-${HASH}" >> ${GITHUB_ENV}
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /github/home/.cache/ccache
           key: ${{ env.CACHE_KEY }}
@@ -428,7 +428,7 @@ jobs:
               make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_TA_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n CFG_DYN_CONFIG=n XTEST_ARGS="n_1001 n_1003 n_1004 n_1042"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Update Git config
         run: git config --global --add safe.directory /home/runner/work/optee_os/optee_os
       - name: Host cleanup
@@ -447,7 +447,7 @@ jobs:
           echo "CACHE_KEY=qemuv7_check-cache-${HASH}-${GITHUB_SHA}" >> $GITHUB_ENV
           echo "CACHE_RESTORE_KEY=qemuv7_check-cache-${HASH}" >> ${GITHUB_ENV}
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /home/runner/work/ccache
           key: ${{ env.CACHE_KEY }}
@@ -572,7 +572,7 @@ jobs:
               make -j$(nproc) check XEN_BOOT=y SPMC_AT_EL=1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Update Git config
         run: git config --global --add safe.directory /home/runner/work/optee_os/optee_os
       - name: Host cleanup
@@ -591,7 +591,7 @@ jobs:
           echo "CACHE_KEY=qemuv8_check-cache-${HASH}-${GITHUB_SHA}" >> $GITHUB_ENV
           echo "CACHE_RESTORE_KEY=qemuv8_check-cache-${HASH}" >> ${GITHUB_ENV}
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /home/runner/work/ccache
           key: ${{ env.CACHE_KEY }}
@@ -663,7 +663,7 @@ jobs:
               make -j$(nproc) check CFG_CORE_UNSAFE_MODEXP=y
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Update Git config
         run: git config --global --add safe.directory /home/runner/work/optee_os/optee_os
       - name: Host setup
@@ -682,7 +682,7 @@ jobs:
           echo "CACHE_KEY=qemuv8_arm64_check-cache-${HASH}-${GITHUB_SHA}" >> ${GITHUB_ENV}
           echo "CACHE_RESTORE_KEY=qemuv8_arm64_check-cache-${HASH}" >> ${GITHUB_ENV}
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /home/runner/work/ccache
           key: ${{ env.CACHE_KEY }}


### PR DESCRIPTION
The CI logs show the following warnings:

 Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Update cache@v4 to cache@v6 (latest version) and checkout@v4 to checkout@v5 (latest compatible version) which both use Node.js 24 instead of 20.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
