### PR TITLE
mk/aosp_optee.mk: run the optee_os builds one at a time

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -148,6 +148,15 @@ $(OPTEE_TA_DEV_KIT_MK):
 	+$(HOST_MAKE) $(OPTEE_MAKE_LINE) \
 		CFG_USER_TA_TARGETS=$(PRIVATE_TA_TARGET) ta_dev_kit
 	@echo "Finished building ta_dev_kit ($(PRIVATE_TA_TARGET))..."
+
+# Every rule here runs make over the same output directory, each with its own
+# CFG_USER_TA_TARGETS, so let them run one at a time: chain every dev kit onto
+# the one declared before it, and the core onto them all. The dev kits go
+# first, as the TAs are built against them and an early TA setup feeds a built
+# TA back into the core build
+$(OPTEE_TA_DEV_KIT_MK): $(BUILD_TA_DEV_KIT_PREV)
+BUILD_TA_DEV_KIT_PREV := $(OPTEE_TA_DEV_KIT_MK)
+$(OPTEE_BIN): $(OPTEE_TA_DEV_KIT_MK)
 endif
 
 ##########################################################


### PR DESCRIPTION
Chain each TA dev kit onto the one declared before it, and make tee.bin
depend on them all, so that a build enters optee_os once at a time
instead of several times at once.

Every rule here runs make over the same output directory with its own
CFG_USER_TA_TARGETS: the core rule builds the default goal, which
covers the dev kits of $(OPTEE_TA_TARGETS) as well, and one dev kit
rule is emitted per TA target in use. They all rewrite the
configuration of that output directory, and everything built there is
compiled against it, so two of them running at once write the same
files at the same time. The Android build system does run them at
once, as it turns them into independent ninja edges.

The dev kits come first because the TAs are built against them, and an
early TA setup feeds a built TA back into the core build.