### PR TITLE
Bound the REE FS reset to an empty, anchored state

### DIFF
--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -36,6 +36,7 @@
  */
 
 #include <assert.h>
+#include <config.h>
 #include <crypto/crypto.h>
 #include <fault_mitigation.h>
 #include <initcall.h>
@@ -83,6 +84,20 @@ static const char ta_ver_db[] = "ta_ver.db";
 static const char subkey_ver_db[] = "subkey_ver.db";
 static struct mutex ver_db_mutex = MUTEX_INITIALIZER;
 
+/*
+ * The version floor these databases hold is only meaningful while it
+ * cannot be lowered.
+ * CFG_TA_VERSION_DB_RPMB keeps them in RPMB, out of reach of a normal world
+ * which can otherwise delete the REE FS and drop the floor to zero.
+ */
+static uint32_t ver_db_storage_id(void)
+{
+	if (IS_ENABLED(CFG_TA_VERSION_DB_RPMB))
+		return TEE_STORAGE_PRIVATE_RPMB;
+
+	return TEE_STORAGE_PRIVATE;
+}
+
 static TEE_Result check_update_version(const char *db_name,
 				       const uint8_t uuid[sizeof(TEE_UUID)],
 				       uint32_t version)
@@ -100,7 +115,7 @@ static TEE_Result check_update_version(const char *db_name,
 		.obj_id_len = strlen(db_name) + 1,
 	};
 
-	ops = tee_svc_storage_file_ops(TEE_STORAGE_PRIVATE);
+	ops = tee_svc_storage_file_ops(ver_db_storage_id());
 	if (!ops)
 		return TEE_SUCCESS; /* Compiled with no secure storage */
 

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -472,7 +472,7 @@ out:
 		*fh = (struct tee_file_handle *)fdp;
 	} else {
 		if (res == TEE_ERROR_SECURITY)
-			DMSG("Secure storage corruption detected");
+			EMSG("Secure storage corruption detected");
 		if (fdp->fd != -1)
 			tee_fs_rpc_close(OPTEE_RPC_CMD_FS, fdp->fd);
 		/*
@@ -570,27 +570,50 @@ static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 	if (res)
 		return res;
 
-	res = tee_fs_dirfile_open(false, hashp, 0, &ree_dirf_ops, dirh);
+	if (hashp) {
+		res = tee_fs_dirfile_open(false, hashp, 0, &ree_dirf_ops, dirh);
+		if (res != TEE_ERROR_ITEM_NOT_FOUND)
+			goto out;
 
-	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
-		if (hashp) {
-			if (IS_ENABLED(CFG_REE_FS_ALLOW_RESET)) {
-				DMSG("dirf.db not found, clear hash in RPMB");
-				res = rpmb_fs_ops.truncate(ree_fs_rpmb_fh, 0);
-				if (res) {
-					DMSG("Can't clear hash: %#"PRIx32, res);
-					res = TEE_ERROR_SECURITY;
-					goto out;
-				}
-			} else {
-				DMSG("dirf.db file not found");
-				res = TEE_ERROR_SECURITY;
-				goto out;
-			}
+		if (!IS_ENABLED(CFG_REE_FS_ALLOW_RESET)) {
+			EMSG("dirf.db file not found");
+			res = TEE_ERROR_SECURITY;
+			goto out;
 		}
 
-		DMSG("Create dirf.db");
-		res = tee_fs_dirfile_open(true, NULL, 0, &ree_dirf_ops, dirh);
+		/*
+		 * Drop the anchor before creating the new dirf.db.
+		 * An interruption from here on leaves the anchor empty, which
+		 * is handled as uninitialized below and comes back to this
+		 * path on the next boot.
+		 */
+		IMSG("dirf.db not found, resetting secure storage");
+		res = rpmb_fs_ops.truncate(ree_fs_rpmb_fh, 0);
+		if (res) {
+			EMSG("Can't clear hash: %#"PRIx32, res);
+			res = TEE_ERROR_SECURITY;
+			goto out;
+		}
+	}
+
+	/*
+	 * Without an anchor no dirf.db can be authenticated, so secure
+	 * storage is uninitialized.
+	 * Create an empty dirf.db, overwriting anything left behind, and
+	 * anchor it before use so that this is the only state which can
+	 * be opened later.
+	 */
+	IMSG("Create dirf.db");
+	res = tee_fs_dirfile_open(true, hash, 0, &ree_dirf_ops, dirh);
+	if (res)
+		goto out;
+
+	res = rpmb_fs_ops.write(ree_fs_rpmb_fh, 0, hash, NULL, sizeof(hash));
+	if (res) {
+		EMSG("Can't anchor dirf.db: %#"PRIx32, res);
+		tee_fs_dirfile_close(*dirh);
+		*dirh = NULL;
+		res = TEE_ERROR_SECURITY;
 	}
 
 out:
@@ -643,7 +666,7 @@ static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
 		if (min_counter) {
 			if (!IS_ENABLED(CFG_REE_FS_ALLOW_RESET)) {
-				DMSG("dirf.db file not found");
+				EMSG("dirf.db file not found");
 				return TEE_ERROR_SECURITY;
 			}
 			DMSG("dirf.db not found, initializing with a non-zero monotonic counter");

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -394,9 +394,8 @@ $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 # anti-rollback errors. That is, rm /data/tee/dirf.db or rm -rf /data/tee (or
 # whatever path is configured in tee-supplicant as CFG_TEE_FS_PARENT_PATH)
 # can be used to reset the secure storage to a clean, empty state.
-# Intended to be used for testing only since it weakens storage security.
-# Warning: If enabled for release build then it will break rollback protection
-# of TAs and the entire REE FS secure storage.
+# Warning: the TA and subkey version floor kept in the REE FS is lost on
+# such a reset.
 CFG_REE_FS_ALLOW_RESET ?= n
 
 # Support for loading user TAs from a special section in the TEE binary.

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -389,13 +389,19 @@ CFG_REE_FS_TA ?= y
 CFG_REE_FS_TA_BUFFERED ?= n
 $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 
+# Keep ta_ver.db and subkey_ver.db, holding the TA and subkey anti-rollback
+# version floor, in RPMB rather than in the REE FS where the normal world
+# can delete them and drop the floor to zero.
+CFG_TA_VERSION_DB_RPMB ?= n
+$(eval $(call cfg-depends-all,CFG_TA_VERSION_DB_RPMB,CFG_RPMB_FS))
+
 # When CFG_REE_FS=y:
 # Allow secure storage in the REE FS to be entirely deleted without causing
 # anti-rollback errors. That is, rm /data/tee/dirf.db or rm -rf /data/tee (or
 # whatever path is configured in tee-supplicant as CFG_TEE_FS_PARENT_PATH)
 # can be used to reset the secure storage to a clean, empty state.
 # Warning: the TA and subkey version floor kept in the REE FS is lost on
-# such a reset.
+# such a reset, unless CFG_TA_VERSION_DB_RPMB is enabled.
 CFG_REE_FS_ALLOW_RESET ?= n
 
 # Support for loading user TAs from a special section in the TEE binary.


### PR DESCRIPTION
`CFG_REE_FS_ALLOW_RESET` exists for platforms where the REE FS can be wiped while RPMB is kept, such as a user triggered factory reset that formats the partition holding `dirf.db` but not its hash anchor (#7904). It promises a reset "to a clean, empty state", but `open_dirh()` opened `dirf.db` without checking it against the anchor whenever that anchor was absent or zero length, and a reset left the anchor zero length until the first commit. Deleting the REE FS directory, booting once to empty the anchor and then restoring an older snapshot therefore restored the old state, a rollback rather than a reset.

An empty anchor is now treated as uninitialized secure storage: an existing `dirf.db` is never opened in that case, an empty one is created and anchored before use. A `dirf.db` which does not match the anchor stays rejected either way, so a wiped secure storage remains distinguishable from a tampered one. The option therefore no longer weakens rollback protection and is not testing only, it is safe on any platform whose policy allows REE secure storage to be destroyed.

| anchor | dirf.db | `CFG_REE_FS_ALLOW_RESET=n` | `CFG_REE_FS_ALLOW_RESET=y` |
|---|---|---|---|
| absent | any | create and anchor | create and anchor |
| present | absent | `TEE_ERROR_SECURITY` | create and anchor |
| present | mismatch | corrupt object | corrupt object |
| present | match | open | open |

The reset still drops the TA and subkey version floor held in `ta_ver.db` and `subkey_ver.db`, so this also adds `CFG_TA_VERSION_DB_RPMB`, disabled by default, to keep those in RPMB.

Closes #7904 

_This PR is assisted by AI tools.(Claude and Codex)_ 
