### PR TITLE
crypto: asu: Enable HWRNG PTA for Linux integration

### DIFF
--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -80,6 +80,12 @@ CFG_AMD_ASU_ECC ?= y
 CFG_AMD_ASU_TRNG ?= y
 CFG_WITH_SOFTWARE_PRNG ?= n
 
+# HWRNG PTA configuration for Linux kernel integration
+ifeq ($(CFG_AMD_ASU_TRNG),y)
+CFG_HWRNG_PTA ?= y
+CFG_HWRNG_QUALITY ?= 1024
+endif
+
 ifeq ($(CFG_RPMB_FS),y)
 $(call force,CFG_AMD_ASU_HUK,y)
 endif


### PR DESCRIPTION
Enable HWRNG PTA and set RNG quality in conf.mk for Linux
integration with the OP-TEE ASU TRNG driver.

---
Branch: `amd_ci_asu_hwrng`