### PR TITLE
ta: pkcs11: invalidate handles before freeing token objects

### DIFF
--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -159,9 +159,9 @@ void destroy_object(struct pkcs11_session *session, struct pkcs11_object *obj,
 
 		handle_put(get_object_handle_db(session),
 			   pkcs11_object2handle(obj, session));
-		cleanup_persistent_object(obj, session->token);
-
 		token_invalidate_object_handles(obj);
+
+		cleanup_persistent_object(obj, session->token);
 	} else {
 		handle_put(get_object_handle_db(session),
 			   pkcs11_object2handle(obj, session));


### PR DESCRIPTION
Move token_invalidate_object_handles() before cleanup_persistent_object() so that handles are invalidated while obj is still valid.

cleanup_persistent_object() frees obj through cleanup_volatile_obj_ref(). Calling token_invalidate_object_handles() afterwards therefore passes a pointer to an object whose lifetime has ended.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
