### PR TITLE
github: PR template: ask contributors to disclose AI use

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,17 @@
     If you are new to submitting pull requests to OP-TEE, then please have a
     look at the list below and tick them off before submitting the pull request.
 
-    1. Read our contribution guidelines:
+    1. Read our contribution guidelines, and pay extra attention to the
+       "Developer Certificate of Origin" section:
          https://optee.readthedocs.io/en/latest/general/contribute.html
 
-    2. Read the contribution section in Notice.md and pay extra attention to the
-       "Developer Certificate of Origin" in the contribution guidelines.
+    2. You should run checkpatch preferably before submitting the pull request.
 
-    3. You should run checkpatch preferably before submitting the pull request.
+    3. As a courtesy to the reviewers, please mention in this pull request
+       description if AI was used to help write or generate any part of the
+       code (this is separate from any commit-level AI attribution tags you
+       may also choose to use). If nothing is mentioned here, it will be
+       assumed that no AI was used.
 
     4. When everything has been reviewed, you will need to squash, rebase and
        add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details


### PR DESCRIPTION
Add a checklist item asking contributors to mention AI use in the PR description; assume none if unmentioned. Also fix the stale Notice.md reference in item 1.

I had help from Claude to write parts of this. :-)