### PR TITLE
Add i.MX952 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
               _make PLATFORM=imx-mx93evk
               _make PLATFORM=imx-mx95evk
               _make PLATFORM=imx-mx943evk
+              _make PLATFORM=imx-mx952evk
           - name: arm k3
             make_commands: |
               _make PLATFORM=k3-j721e

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -109,6 +109,9 @@ mx91-flavorlist = \
 mx943-flavorlist = \
 	mx943evk \
 
+mx952-flavorlist = \
+	mx952evk \
+
 ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6ul-flavorlist)))
 $(call force,CFG_MX6,y)
 $(call force,CFG_MX6UL,y)
@@ -299,6 +302,16 @@ $(call force,CFG_TZC380,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
 CFG_IMX_ELE ?= y
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx952-flavorlist)))
+$(call force,CFG_MX952,y)
+$(call force,CFG_ARM64_core,y)
+CFG_IMX_LPUART ?= y
+CFG_DRAM_BASE ?= 0x80000000
+CFG_TEE_CORE_NB_CORE ?= 6
+$(call force,CFG_NXP_SNVS,n)
+$(call force,CFG_IMX_OCOTP,n)
+$(call force,CFG_TZC380,n)
+$(call force,CFG_NXP_CAAM,n)
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif
@@ -520,7 +533,7 @@ CFG_DDR_SIZE ?= 0x80000000
 CFG_UART_BASE ?= UART1_BASE
 endif
 
-ifneq (,$(filter $(PLATFORM_FLAVOR),mx95evk mx943evk))
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx95evk mx943evk mx952evk))
 CFG_DDR_SIZE ?= 0x80000000
 CFG_UART_BASE ?= UART1_BASE
 CFG_NSEC_DDR_1_BASE ?= 0x100000000UL

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -312,6 +312,8 @@ $(call force,CFG_NXP_SNVS,n)
 $(call force,CFG_IMX_OCOTP,n)
 $(call force,CFG_TZC380,n)
 $(call force,CFG_NXP_CAAM,n)
+CFG_IMX_MU ?= y
+CFG_IMX_ELE ?= y
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif

--- a/core/arch/arm/plat-imx/imx-common.c
+++ b/core/arch/arm/plat-imx/imx-common.c
@@ -74,6 +74,8 @@ uint32_t imx_get_digprog(void)
 		imx_digprog = SOC_MX95 << 16;
 	else if (IS_ENABLED(CFG_MX943))
 		imx_digprog = SOC_MX943 << 16;
+	else if (IS_ENABLED(CFG_MX952))
+		imx_digprog = SOC_MX952 << 16;
 
 	return imx_digprog;
 }

--- a/core/arch/arm/plat-imx/imx-regs.h
+++ b/core/arch/arm/plat-imx/imx-regs.h
@@ -49,6 +49,8 @@
 #include <registers/imx95.h>
 #elif defined(CFG_MX943)
 #include <registers/imx943.h>
+#elif defined(CFG_MX952)
+#include <registers/imx952.h>
 #else
 #error "CFG_MX* not defined"
 #endif

--- a/core/arch/arm/plat-imx/imx.h
+++ b/core/arch/arm/plat-imx/imx.h
@@ -29,6 +29,7 @@
 #define SOC_MX95        0x1C1
 #define SOC_MX91        0xCB
 #define SOC_MX943       0xC2
+#define SOC_MX952       0xC4
 
 #ifndef __ASSEMBLER__
 bool soc_is_imx6(void);

--- a/core/arch/arm/plat-imx/registers/imx952.h
+++ b/core/arch/arm/plat-imx/registers/imx952.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2026 NXP
+ */
+#ifndef __IMX952_H__
+#define __IMX952_H__
+
+#define GICD_BASE  0x48000000
+#define GICR_BASE  0x48060000
+
+#define UART1_BASE 0x44380000
+
+#endif /* __IMX952_H__ */

--- a/core/arch/arm/plat-imx/registers/imx952.h
+++ b/core/arch/arm/plat-imx/registers/imx952.h
@@ -10,4 +10,7 @@
 
 #define UART1_BASE 0x44380000
 
+#define MU_BASE    0x47530000
+#define MU_SIZE    0x10000
+
 #endif /* __IMX952_H__ */

--- a/core/drivers/crypto/ele/ele.c
+++ b/core/drivers/crypto/ele/ele.c
@@ -373,7 +373,7 @@ int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 }
 
 #if defined(CFG_MX93) || defined(CFG_MX91) || defined(CFG_MX95) || \
-	defined(CFG_MX943)
+	defined(CFG_MX943) || defined(CFG_MX952)
 static TEE_Result imx_ele_derive_key(const uint8_t *ctx, size_t ctx_size,
 				     uint8_t *key, size_t key_size)
 {

--- a/core/drivers/crypto/ele/ele.c
+++ b/core/drivers/crypto/ele/ele.c
@@ -59,7 +59,7 @@ struct get_info_rsp {
 	uint32_t oem_srkh[16];
 	uint8_t trng_state;
 	uint8_t csal_state;
-#if defined(CFG_MX95) || defined(CFG_MX943)
+#if defined(CFG_MX95) || defined(CFG_MX943) || defined(CFG_MX952)
 	uint8_t reserved[2];
 	uint32_t oem_pqc_srkh[16];
 	uint32_t rsvd[8];

--- a/core/drivers/imx/mu/sub.mk
+++ b/core/drivers/imx/mu/sub.mk
@@ -1,5 +1,5 @@
 srcs-y += imx_mu.c
-srcs-$(call cfg-one-enabled,CFG_MX8ULP CFG_MX93 CFG_MX91 CFG_MX95 CFG_MX943) += imx_mu_8ulp_9x.c
+srcs-$(call cfg-one-enabled,CFG_MX8ULP CFG_MX93 CFG_MX91 CFG_MX95 CFG_MX943 CFG_MX952) += imx_mu_8ulp_9x.c
 ifeq ($(filter y, $(CFG_MX8QM) $(CFG_MX8QX) $(CFG_MX8DXL)),y)
 srcs-y += imx_mu_8q.c
 endif

--- a/core/include/drivers/imx_mu.h
+++ b/core/include/drivers/imx_mu.h
@@ -17,7 +17,7 @@
 #define IMX_MU_NB_CHANNEL 4
 
 #if defined(CFG_MX8ULP) || defined(CFG_MX93) || defined(CFG_MX91) || \
-	defined(CFG_MX95) || defined(CFG_MX943)
+	defined(CFG_MX95) || defined(CFG_MX943) || defined(CFG_MX952)
 struct imx_mu_msg_header {
 	uint8_t version;
 	uint8_t size;


### PR DESCRIPTION
This pull request adds support for i.MX943-EVK platform with ELE support enabled.

Also used AI for creating this patch set from downstream NXP code.