### PR TITLE
plat-qcom: Add BRUIN architecture with QCM2290 Agatti platform support

### DIFF
--- a/core/arch/arm/plat-qcom/bruin/agatti/target.mk
+++ b/core/arch/arm/plat-qcom/bruin/agatti/target.mk
@@ -1,0 +1,4 @@
+# SM4125 Agatti (QCM2290 / QRB2210) target. Family defaults in
+# ../qcom-arch.mk are sufficient for bring-up.
+
+CFG_QCOM_DIAG_LOG ?= $(CFG_TEE_CORE_DEBUG)

--- a/core/arch/arm/plat-qcom/bruin/agatti/target_config.h
+++ b/core/arch/arm/plat-qcom/bruin/agatti/target_config.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SM4125 Agatti (QCM2290 / QRB2210, Arduino Uno-Q) target config for OP-TEE.
+ */
+
+#ifndef TARGET_CONFIG_H
+#define TARGET_CONFIG_H
+
+/* GENI UART (QUPV3_0 SE4) - ttyMSM0 debug console. */
+#define GENI_UART_REG_BASE		UL(0x04A90000)
+#define GENI_UART_REG_SIZE		UL(0x4000)
+
+/*
+ * DDR at 0x40000000 (EBI1). DRAM0_SIZE is the non-secure window OP-TEE
+ * validates normal-world buffers against (register_ddr() in plat-qcom/main.c).
+ * The Uno-Q ships in 2 GiB and 4 GiB variants and the DT leaves the size to
+ * the bootloader, so use the 2 GiB floor: under-reporting only rejects real
+ * DDR, whereas over-reporting would accept unpopulated addresses. 4 GiB boards
+ * need runtime DT/SMEM-derived sizing for high-memory buffers.
+ */
+#define DRAM0_BASE			UL(0x40000000)
+#define DRAM0_SIZE			UL(0x80000000)
+
+/* Boot IMEM window (used by the diag-log region). */
+#define IMEM_BASE			UL(0x0C100000)
+#define IMEM_SIZE			UL(0x19000)
+
+#endif /* TARGET_CONFIG_H */

--- a/core/arch/arm/plat-qcom/bruin/arch_config.h
+++ b/core/arch/arm/plat-qcom/bruin/arch_config.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * BRUIN family (QCM2290 / QRB2210, SM4125 Agatti) arch config for OP-TEE.
+ */
+
+#ifndef ARCH_CONFIG_H
+#define ARCH_CONFIG_H
+
+/* GIC-500 (GICv3). GICC_BASE is unused with CFG_ARM_GICV3=y. */
+#define GICD_BASE			UL(0x0F200000)
+#define GICR_BASE			UL(0x0F300000)
+#define GICC_BASE			UL(0x0F200000)
+
+/* Diag-log region (only used when CFG_QCOM_DIAG_LOG=y). */
+#define IMEM_DIAG_OFFSET		UL(0x720)
+#define DIAG_SIZE			UL(0x3000)
+#define DIAG_BASE			(IMEM_BASE + IMEM_SIZE - DIAG_SIZE)
+#define DIAG_LOG_START_INFO		(IMEM_BASE + IMEM_DIAG_OFFSET)
+
+/* TCSR boot-misc (forced-dload detect). */
+#define TCSR_BOOT_MISC_DETECT		UL(0x01FD3000)
+
+#endif /* ARCH_CONFIG_H */

--- a/core/arch/arm/plat-qcom/bruin/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/bruin/qcom-arch.mk
@@ -1,0 +1,21 @@
+# BRUIN family (QCM2290 / QRB2210, SM4125 Agatti): 4x Cortex-A53, GIC-500
+# (GICv3), RPM (not RPMh).
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+CFG_NUM_THREADS ?= 4
+
+$(call force,CFG_ARM_GICV3,y)
+
+CFG_QCOM_CSRNG ?= n
+CFG_WITH_SOFTWARE_PRNG ?= y
+
+# Hard ':=' (not '?='): CFG_TZDRAM_START must equal TF-A's BL32_BASE. A
+# conditional assignment can lose to an earlier family default, linking OP-TEE
+# for an address other than the one TF-A enters BL32 at, which hangs the
+# BL31->BL32 handoff.
+CFG_TZDRAM_START := 0x40200000
+CFG_TEE_RAM_VA_SIZE ?= 0x100000
+CFG_TA_RAM_VA_SIZE ?= 0x100000
+CFG_TZDRAM_SIZE ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)

--- a/core/arch/arm/plat-qcom/bruin/sub.mk
+++ b/core/arch/arm/plat-qcom/bruin/sub.mk
@@ -1,0 +1,2 @@
+# No family-level sources: GICv3, GENI console and CSRNG come from the generic
+# qcom main.c / drivers.

--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -32,6 +32,7 @@ supported-ta-targets ?= ta_arm64
 HOYA_ARCH_CHIPSETS := kodiak lemans
 BOBCAT_ARCH_CHIPSETS := ipq96xx ipq52xx
 WILDCAT_ARCH_CHIPSETS := nord
+BRUIN_ARCH_CHIPSETS := agatti
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),$(HOYA_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := hoya
@@ -39,6 +40,8 @@ else ifneq (,$(filter $(PLATFORM_FLAVOR),$(BOBCAT_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := bobcat
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(WILDCAT_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := wildcat
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(BRUIN_ARCH_CHIPSETS)))
+QCOM_ARCH_FAMILY := bruin
 else
 $(error Unsupported PLATFORM_FLAVOR: $(PLATFORM_FLAVOR))
 endif


### PR DESCRIPTION
Add the BRUIN chipset family for the Qualcomm Agatti (QCM2290 / QRB2210 / SM4125) [1], following the existing HOYA / BOBCAT / WILDCAT pattern. This MPU is used on Arduino Uno Q boards [2].

Configuration verified against the QRB2210 data sheet available on [1] and the internal IP catalog register map:
- 4x Cortex-A53 with 512 KB shared L2
- ARM GIC-500 (GICv3): GICD 0x0F200000, GICR 0x0F300000
- GENI UART (QUPV3_0 SE4) console at 0x04A90000
- Always-on subsystem uses RPM
- DDR based at 0x40000000 (EBI1)
- TZDRAM at 0x40200000 (2 MiB)

CFG_TZDRAM_START uses a hard ':=' assignment rather than '?=' because it must equal TF-A's BL32_BASE: a conditional assignment can lose to an earlier family default, which links OP-TEE for an address other than the one TF-A enters BL32 at and hangs the BL31->BL32 handoff.

This is a minimal bring-up: OP-TEE comes up with the software PRNG and without PAS or HWKM support, which are follow-ups.

DRAM0_SIZE is the 2 GiB floor because register_ddr() uses it statically as the non-secure window and the Uno-Q ships in 2 GiB and 4 GiB variants with the size left to the bootloader in DT; under-reporting only rejects real memory, whereas over-reporting would accept unpopulated addresses.

[1] https://www.qualcomm.com/internet-of-things/products/q2-series/qrb2210
[2] https://www.arduino.cc/product-uno-q/

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
