### PR TITLE
Add Allwinner SID Efuse Register read support

### DIFF
--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -52,6 +52,8 @@ CFG_SHMEM_START  ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
 CFG_SHMEM_SIZE   ?= 0x00400000
 CFG_TEE_CORE_NB_CORE ?= 4
 CFG_TZC380 ?= y
+
+CFG_SUNXI_SID ?= y
 endif
 
 ifeq ($(platform-flavor-armv8),1)

--- a/core/arch/arm/plat-sunxi/platform_config.h
+++ b/core/arch/arm/plat-sunxi/platform_config.h
@@ -69,6 +69,10 @@
 #define SUNXI_DRAM_NS_SIZE	(CFG_DRAM_SIZE - \
 					(CFG_TZDRAM_SIZE + CFG_SHMEM_SIZE))
 
+/* SID Register */
+#define SUNXI_SID_BASE		0x03006000
+#define SUNXI_SID_SIZE		0x1000
+
 #endif
 
 #endif /* PLATFORM_CONFIG_H */

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -100,6 +100,7 @@ srcs-$(CFG_WIDEVINE_HUK) += widevine_huk.c
 srcs-$(CFG_SEMIHOSTING_CONSOLE) += semihosting_console.c
 srcs-$(CFG_FFA_CONSOLE) += ffa_console.c
 srcs-$(CFG_OPENEDGES_OMC) += openedges_omc.c
+srcs-$(CFG_SUNXI_SID) += sunxi_sid.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/drivers/sunxi_sid.c
+++ b/core/drivers/sunxi_sid.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026 Linumiz
+ */
+
+#include <drivers/sunxi_sid.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/mutex.h>
+#include <kernel/tee_common_otp.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <string_ext.h>
+#include <util.h>
+
+#define SID_PRCTL		0x40
+#define SID_RDKEY		0x60
+#define SID_PRCTL_OP_LOCK	0xAC
+#define SID_PRCTL_READ		BIT(1)
+#define SID_MAX_READ_LEN	8
+
+#define SID_POLL_PERIOD_US	100
+#define SID_POLL_TIMEOUT_US	250000
+
+static vaddr_t sunxi_sid_base;
+static struct mutex lock = MUTEX_INITIALIZER;
+
+TEE_Result sunxi_sid_read_otp(uint8_t *buf, size_t len, uint32_t offset)
+{
+	uint32_t val[SID_MAX_READ_LEN] = {0};
+	TEE_Result ret = TEE_SUCCESS;
+	uint32_t reg_val = 0;
+
+	if (!sunxi_sid_base)
+		return TEE_ERROR_BAD_STATE;
+
+	if (!buf || !len || (len % sizeof(uint32_t)))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if ((len / sizeof(uint32_t)) > SID_MAX_READ_LEN)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mutex_lock(&lock);
+	for (uint8_t i = 0; i < (len / sizeof(uint32_t)); i++) {
+		reg_val = (((offset & 0x1FF) << 16) | (SID_PRCTL_OP_LOCK << 8) |
+			   SID_PRCTL_READ);
+
+		io_write32(sunxi_sid_base + SID_PRCTL, reg_val);
+		if (IO_READ32_POLL_TIMEOUT(sunxi_sid_base + SID_PRCTL, reg_val,
+					   !(reg_val & SID_PRCTL_READ),
+					   SID_POLL_PERIOD_US,
+					   SID_POLL_TIMEOUT_US)) {
+			ret = TEE_ERROR_TIMEOUT;
+			goto err_out;
+		}
+
+		val[i] = io_read32(sunxi_sid_base + SID_RDKEY);
+		io_write32(sunxi_sid_base + SID_PRCTL, 0);
+		offset += sizeof(uint32_t);
+	}
+
+	memcpy(buf, val, len);
+
+err_out:
+	memzero_explicit(val, sizeof(val));
+	mutex_unlock(&lock);
+
+	return ret;
+}
+
+int tee_otp_get_die_id(uint8_t *buffer, size_t len)
+{
+	if (!buffer || !len)
+		return -1;
+
+	if (sunxi_sid_read_otp(buffer, len, SUNXI_SID_CHIP_ID_REG))
+		return -1;
+
+	return 0;
+}
+
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+{
+	return sunxi_sid_read_otp(&hwkey->data[0], HW_UNIQUE_KEY_LENGTH,
+				  SUNXI_SID_HUK_REG);
+}
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SUNXI_SID_BASE, SUNXI_SID_SIZE);
+
+static TEE_Result sunxi_sid_init(void)
+{
+	sunxi_sid_base = (vaddr_t)core_mmu_get_va(SUNXI_SID_BASE,
+						  MEM_AREA_IO_SEC,
+						  SUNXI_SID_SIZE);
+	if (!sunxi_sid_base)
+		return TEE_ERROR_GENERIC;
+
+	DMSG("sunxi sid init done");
+	return TEE_SUCCESS;
+}
+service_init(sunxi_sid_init);

--- a/core/include/drivers/sunxi_sid.h
+++ b/core/include/drivers/sunxi_sid.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2026 Linumiz
+ */
+
+#ifndef __DRIVERS_SUNXI_SID_H
+#define __DRIVERS_SUNXI_SID_H
+
+#include <stdint.h>
+#include <tee_api_types.h>
+
+#define SUNXI_SID_CHIP_ID_REG		0x00
+#define SUNXI_SID_HUK_REG		0x50
+
+/**
+ * Reads from sunxi sid efuse register.
+ * @buf: pointer to store value
+ * @len: length of data to be read
+ * @offset: offset of the efuse register
+ * @return TEE_Result value
+ */
+TEE_Result sunxi_sid_read_otp(uint8_t *buf, size_t len, uint32_t offset);
+
+#endif


### PR DESCRIPTION
This PR adds a driver for the Allwinner Security ID (SID) efuse block read support.
The driver implements tee_otp_get_die_id() and  tee_otp_get_hw_unique_key().  Driver is on Tested on A133 platforms whuch have SID register layout follows the linux-sunxi SID register guide [1].

[1]. https://linux-sunxi.org/SID_Register_Guide