### PR TITLE
MAINTAINERS: add Qualcomm Peripheral Image Authentication files

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -288,6 +288,8 @@ F:	core/arch/arm/plat-qcom/
 F:	core/drivers/qcom/
 F:	core/drivers/qcom_geni_uart.c
 F:	core/include/drivers/qcom/
+F:	core/pta/qcom/
+F:	ta/qcom_pas/
 
 Qualcomm Bobcat Arch
 R:	Selvam Sathappan Periakaruppan <speriaka@qti.qualcomm.com> [@zelvam95]


### PR DESCRIPTION
Add the Peripheral Authentication Service (PAS) TA and PTA paths under the Qualcomm architecture section.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
