### PR TITLE
crypto: caam: rsa: harden do_oaep_decoding() against undersized modulus

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -816,6 +816,12 @@ static TEE_Result do_oaep_decoding(struct drvcrypt_rsa_ed *rsa_data)
 	 *  hLen is the Hash digest length
 	 *  mLen is the input RSA message length
 	 */
+	/* Ensure the modulus is large enough to hold the OAEP overhead */
+	if (rsa_data->key.n_size <= rsa_data->digest_size + 1) {
+		ret = TEE_ERROR_BAD_PARAMETERS;
+		goto exit_oaep_decrypt;
+	}
+
 	/* Calculate the DB size */
 	db_size = rsa_data->key.n_size - rsa_data->digest_size - 1;
 	RSA_TRACE("DB is %zu bytes", db_size);


### PR DESCRIPTION
Fixes #7932

do_oaep_decoding() computed db_size by subtracting the digest size from the RSA modulus size without first checking that the modulus is large enough. If the modulus is smaller than digest_size + 1, this subtraction underflows (unsigned arithmetic), producing a huge value passed to caam_calloc_align_buf(). This currently fails cleanly with TEE_ERROR_OUT_OF_MEMORY due to the resulting allocation size being unreasonably large, but the correct response to an undersized key is TEE_ERROR_BAD_PARAMETERS.

This mirrors the check already present in the generic RSAES encryption path (crypto_acipher_rsaes_encrypt(), rsa.c) and the PSS signature verification path (emsa_pss_verify() callers, rsassa.c), both of which validate the modulus size before performing similar arithmetic.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
---
Note: This vulnerability was identified through AI-assisted code review 
(Claude), cross-referencing the pattern from the already-fixed RSAES 
encryption path (commit 7417a3ae) against sibling crypto driver code. 
The fix and its correctness were manually verified before submission.