### PR TITLE
core: spmc: allow S-EL0 access to physical counter

### DIFF
--- a/core/arch/arm/include/kernel/thread_arch.h
+++ b/core/arch/arm/include/kernel/thread_arch.h
@@ -56,6 +56,8 @@ struct thread_core_local {
 #endif
 	long kcode_offset;
 	short int curr_thread;
+	/* Previous PL0PCTEN state for the active counter grant on this PE */
+	bool cntpct_was_enabled;
 	uint32_t flags;
 	vaddr_t abt_stack_va_end;
 #ifdef CFG_TEE_CORE_DEBUG
@@ -358,6 +360,14 @@ unsigned long thread_system_reset_handler(unsigned long a0, unsigned long a1);
 #define THREAD_EXCP_ALL			(THREAD_EXCP_FOREIGN_INTR	\
 					| THREAD_EXCP_NATIVE_INTR	\
 					| (ARM32_CPSR_A >> ARM32_CPSR_F_SHIFT))
+
+/*
+ * Grant and revoke EL0 physical-counter access for the current user context.
+ * Calls may be nested and the grant remains requested while the thread is
+ * suspended. Foreign interrupts must be masked when calling these functions.
+ */
+void thread_user_enable_cntpct(void);
+void thread_user_disable_cntpct(void);
 
 #ifdef CFG_WITH_VFP
 /*

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1806,14 +1806,11 @@ static TEE_Result sp_enter_invoke_cmd(struct ts_session *s,
 	uint32_t rpc_target_info = 0;
 	uint32_t panicked = false;
 	uint32_t panic_code = 0;
-	uint32_t cntkctl = 0;
 
 	sp_regs = &ctx->sp_regs;
 	ts_push_current_session(s);
 
 	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
-	cntkctl = read_cntkctl();
-	write_cntkctl(cntkctl | CNTKCTL_PL0PCTEN);
 
 	/* Enable/disable foreign interrupts in CPSR/SPSR */
 	caller = ts_get_calling_session();
@@ -1828,8 +1825,11 @@ static TEE_Result sp_enter_invoke_cmd(struct ts_session *s,
 	thread_get_tsd()->rpc_target_info =
 		ffa_target_info_set(sp_s->endpoint_id, sp_s->thread_id);
 
+	thread_user_enable_cntpct();
 	__thread_enter_user_mode(sp_regs, &panicked, &panic_code);
-	write_cntkctl(cntkctl);
+	/* User-mode return may leave foreign interrupts enabled. */
+	thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+	thread_user_disable_cntpct();
 
 	sp_s->thread_id = THREAD_ID_INVALID;
 

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1806,11 +1806,14 @@ static TEE_Result sp_enter_invoke_cmd(struct ts_session *s,
 	uint32_t rpc_target_info = 0;
 	uint32_t panicked = false;
 	uint32_t panic_code = 0;
+	uint32_t cntkctl = 0;
 
 	sp_regs = &ctx->sp_regs;
 	ts_push_current_session(s);
 
 	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+	cntkctl = read_cntkctl();
+	write_cntkctl(cntkctl | CNTKCTL_PL0PCTEN);
 
 	/* Enable/disable foreign interrupts in CPSR/SPSR */
 	caller = ts_get_calling_session();
@@ -1826,6 +1829,7 @@ static TEE_Result sp_enter_invoke_cmd(struct ts_session *s,
 		ffa_target_info_set(sp_s->endpoint_id, sp_s->thread_id);
 
 	__thread_enter_user_mode(sp_regs, &panicked, &panic_code);
+	write_cntkctl(cntkctl);
 
 	sp_s->thread_id = THREAD_ID_INVALID;
 

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -123,11 +123,9 @@ static TEE_Result stmm_enter_user_mode(struct stmm_ctx *spc)
 	uint32_t exceptions = 0;
 	uint32_t panic_code = 0;
 	uint32_t panicked = 0;
-	uint64_t cntkctl = 0;
 
 	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
-	cntkctl = read_cntkctl();
-	write_cntkctl(cntkctl | CNTKCTL_PL0PCTEN);
+	thread_user_enable_cntpct();
 
 #ifdef ARM32
 	/* Handle usr_lr in place of __thread_enter_user_mode() */
@@ -140,7 +138,9 @@ static TEE_Result stmm_enter_user_mode(struct stmm_ctx *spc)
 	spc->regs.usr_lr = thread_get_usr_lr();
 #endif
 
-	write_cntkctl(cntkctl);
+	/* User-mode return may leave foreign interrupts enabled. */
+	thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+	thread_user_disable_cntpct();
 	thread_unmask_exceptions(exceptions);
 
 	thread_user_clear_vfp(&spc->uctx);

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -120,6 +120,46 @@ void __nostackcheck thread_unmask_exceptions(uint32_t state)
 	thread_set_exceptions(state & THREAD_EXCP_ALL);
 }
 
+static void enable_user_cntpct(struct thread_core_local *l)
+{
+	uint32_t cntkctl = read_cntkctl();
+
+	/*
+	 * CNTKCTL (CNTKCTL_EL1 on AArch64) controls EL0 counter access in the
+	 * EL1&0 execution regime, but not in VHE host mode. It is per PE, so
+	 * save its previous state per PE.
+	 */
+	l->cntpct_was_enabled = cntkctl & CNTKCTL_PL0PCTEN;
+	write_cntkctl(cntkctl | CNTKCTL_PL0PCTEN);
+}
+
+static void disable_user_cntpct(struct thread_core_local *l)
+{
+	if (!l->cntpct_was_enabled)
+		write_cntkctl(read_cntkctl() & ~CNTKCTL_PL0PCTEN);
+}
+
+void thread_user_enable_cntpct(void)
+{
+	struct thread_core_local *l = thread_get_core_local();
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	if (!thr->cntpct_access_depth)
+		enable_user_cntpct(l);
+	thr->cntpct_access_depth++;
+}
+
+void thread_user_disable_cntpct(void)
+{
+	struct thread_core_local *l = thread_get_core_local();
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thr->cntpct_access_depth);
+	thr->cntpct_access_depth--;
+	if (!thr->cntpct_access_depth)
+		disable_user_cntpct(l);
+}
+
 static void thread_lazy_save_ns_vfp(void)
 {
 #ifdef CFG_WITH_VFP
@@ -463,6 +503,10 @@ void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,
 	if (threads[n].have_user_map)
 		ftrace_resume();
 
+	/* Reapply a pending grant using the state of the destination PE. */
+	if (threads[n].cntpct_access_depth)
+		enable_user_cntpct(l);
+
 	l->flags &= ~THREAD_CLF_TMP;
 	thread_resume(&threads[n].regs);
 	/*NOTREACHED*/
@@ -518,6 +562,7 @@ void thread_state_free(void)
 	thread_lock_global();
 
 	assert(threads[ct].state == THREAD_STATE_ACTIVE);
+	assert(!threads[ct].cntpct_access_depth);
 	threads[ct].state = THREAD_STATE_FREE;
 	threads[ct].flags = 0;
 	l->curr_thread = THREAD_ID_INVALID;
@@ -560,6 +605,9 @@ int thread_state_suspend(uint32_t flags, uint32_t cpsr, vaddr_t pc)
 	int ct = l->curr_thread;
 
 	assert(ct != THREAD_ID_INVALID);
+	/* Do not leave a per-PE grant active while this thread is suspended. */
+	if (threads[ct].cntpct_access_depth)
+		disable_user_cntpct(l);
 
 	if (core_mmu_user_mapping_is_active())
 		ftrace_suspend();

--- a/core/include/kernel/thread_private.h
+++ b/core/include/kernel/thread_private.h
@@ -37,6 +37,10 @@ struct thread_ctx {
 	enum thread_state state;
 	vaddr_t stack_va_end;
 	uint32_t flags;
+#if defined(ARM32) || defined(ARM64)
+	/* Nested requests for EL0 physical-counter access */
+	unsigned int cntpct_access_depth;
+#endif
 	struct core_mmu_user_map user_map;
 	bool have_user_map;
 #if defined(ARM64) || defined(RV64)


### PR DESCRIPTION
Secure partitions can use the physical counter as a time source. OP-TEE currently leaves access disabled when entering generic S-EL0 partitions. Reads of CNTPCT_EL0 therefore trap unless function tracing is enabled.

Enable physical counter access while the partition runs, then restore the previous CNTKCTL_EL1 value on return. This matches the existing handling for StandaloneMM.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
