### PR TITLE
plat: rpi4: add basic Raspberry Pi 4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
               _make PLATFORM=rzg CFG_ARM64_core=y
               _make PLATFORM=rpi3
               _make PLATFORM=rpi3 CFG_ARM64_core=y
+              _make PLATFORM=rpi4
               _make PLATFORM=rpi5
               _make PLATFORM=zynq7k-zc702
               _make PLATFORM=marvell-cnf20ka

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -306,6 +306,12 @@ R:	Joakim Bech <joakim.bech@gmail.com> [@jockebech]
 S:	Maintained
 F:	core/arch/arm/plat-rpi3/
 
+Raspberry Pi4
+R:	Sahil Kaushal <sahil.kaushal@arm.com> [@sah01Kaushal]
+R:	Arteom Katkov <arteom.katkov@arm.com> [@artkat-arm]
+S:	Maintained
+F:	core/arch/arm/plat-rpi4/
+
 Renesas RCAR
 R:	Volodymyr Babchuk <vlad.babchuk@gmail.com> [@lorc]
 S:	Maintained

--- a/core/arch/arm/plat-rpi4/conf.mk
+++ b/core/arch/arm/plat-rpi4/conf.mk
@@ -1,0 +1,21 @@
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_WITH_LPAE,y)
+$(call force,CFG_AUTO_MAX_PA_BITS,y)
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,40)
+
+CFG_SHMEM_START     ?= 0x08000000
+CFG_SHMEM_SIZE      ?= 0x00400000
+CFG_TZDRAM_START    ?= 0x10100000
+CFG_TZDRAM_SIZE     ?= 0x00F00000
+CFG_TEE_RAM_VA_SIZE ?= 0x00700000
+CFG_DT              ?= y
+CFG_DTB_MAX_SIZE    ?= 0x20000
+
+$(call force,CFG_PL011,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+
+CFG_NUM_THREADS ?= 4

--- a/core/arch/arm/plat-rpi4/main.c
+++ b/core/arch/arm/plat-rpi4/main.c
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, EPAM Systems.
+ * Copyright (c) 2026, Arm Limited and Contributors. All rights reserved.
+ */
+
+#include <console.h>
+#include <drivers/pl011.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
+			PL011_REG_SIZE);
+
+static struct pl011_data console_data __nex_bss;
+
+void plat_console_init(void)
+{
+	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
+		   CONSOLE_BAUDRATE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-rpi4/platform_config.h
+++ b/core/arch/arm/plat-rpi4/platform_config.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2016, Sequitur Labs Inc.
+ * Copyright (c) 2024, EPAM Systems.
+ * Copyright (c) 2026, Arm Limited and Contributors. All rights reserved.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+/* BCM2711 PL011 UART0 */
+#define CONSOLE_UART_BASE	0xfe201000
+#define CONSOLE_BAUDRATE	115200
+#define CONSOLE_UART_CLK_IN_HZ	48000000
+
+#define DRAM0_BASE		0x00000000
+#define DRAM0_SIZE		0x200000000
+
+#endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-rpi4/sub.mk
+++ b/core/arch/arm/plat-rpi4/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
RPi4 is based on the BCM2711 SoC, which includes four Cortex-A72 cores.

BCM2711 does not provide hardware-protected secure memory. Reuse the RPi3 OP-TEE and shared-memory layout, placing OP-TEE at 0x10100000. These regions lie below the first GiB, so the same layout works across RPi4 memory variants.

Follow the existing RPi5 platform structure and use PL011 UART0 for the console. Enable LPAE and 40-bit physical addresses so dynamic shared memory can use BCM2711 RAM above 4 GiB.

Testing:
- Built RPi4 configurations in debug and release modes.
- Boot-tested on Raspberry Pi 4 Model B and Raspberry Pi 400.
- Both configurations reached Linux using TF-A staged boot with SPMD.

The TF-A staged-boot support used for validation will be submitted
separately.

OPTEE_ALLOW_SMC_LOAD may provide an alternative loading path
(similar to how it is expected for RPi5), but it has not been tested with this port.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
