### PR TITLE
core: derive key: fix out-of-bounds write in SM2-KEP derivation

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3962,6 +3962,11 @@ ecdh_out:
 		};
 		struct tee_obj *ko2 = NULL;
 
+		if (kep_parms.out_len > sk->alloc_size) {
+			res = TEE_ERROR_BAD_PARAMETERS;
+			goto out;
+		}
+
 		res = tee_obj_get(utc, cs->key2, &ko2);
 		if (res != TEE_SUCCESS)
 			goto out;


### PR DESCRIPTION
## What

In `syscall_cryp_derive_key()` the `TEE_ALG_SM2_KEP` branch passes `so->info.maxObjectSize` as the number of bytes `sm2_kdf()` writes into the derived key's secret buffer, but never bounds it against `sk->alloc_size`.

For a `TEE_TYPE_GENERIC_SECRET` object `sk->alloc_size` is fixed at `4096 / 8 = 512` bytes, while `maxObjectSize` may be requested up to `4096`.  

A caller that allocates the output object with a size in `(512, 4096]` and runs an SM2-KEP `TEE_DeriveKey()` makes `sm2_kdf()` write past the allocation up to a ~3.5 KiB heap overflow.  

The sibling key-derivation branches (HKDF, Concat KDF, PBKDF2) already reject a derived length larger than `sk->alloc_size`; the SM2-KEP branch was missed.  

## Fix

Add the `out_len > sk->alloc_size` check to the SM2-KEP branch, matching the other derivation branches. `out_len` (= `maxd, so the GENERIC_SECRET known-answer test (regression_4014, 16-byte output) is unaffected.

## Testing
- Builds for QEMUv8 (`CFG_CRYPTO_SM2_KEP=y`)
- `xtest regression_4014` (SM2-KEP KAT) passes (16-byte output, < 512).