### PR TITLE
core: don't return releasing mobjs from mobj_reg_shm_get_by_cookie()

### DIFF
--- a/core/mm/mobj_dyn_shm.c
+++ b/core/mm/mobj_dyn_shm.c
@@ -439,11 +439,12 @@ struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie)
 	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
 	rs = reg_shm_find_unlocked(cookie);
 	if (rs) {
-		m = mobj_get(&rs->mobj);
+		if (!rs->releasing)
+			m = mobj_get(&rs->mobj);
 		goto out;
 	}
 	rm = protmem_find_unlocked(cookie);
-	if (rm)
+	if (rm && !rm->releasing)
 		m = mobj_get(&rm->mobj);
 
 out:


### PR DESCRIPTION
mobj_reg_shm_get_by_cookie() looks up an object on reg_shm_list and takes a reference with mobj_get() without checking whether the object is being released.

mobj_reg_shm_release_by_cookie() sets releasing under reg_shm_slist_lock and then drops the registration reference. mobj_reg_shm_free() leaves a releasing object on reg_shm_list until the releasing thread frees it, so the object can stay on the list after its reference count has reached zero. A lookup in that window calls mobj_get() on a zero reference count; refcount_inc() returns false for a zero value and mobj_get() calls panic().

Skip objects flagged releasing in mobj_reg_shm_get_by_cookie(), as mobj_protmem_get_by_pa() already does, so the lookup returns NULL for an object pending release instead of taking a reference on it.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
