### PR TITLE
core: spmc: reject too small mem_access_size

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -344,6 +344,11 @@ int spmc_sp_add_share(struct ffa_mem_transaction_x *mem_trans,
 		goto cleanup;
 	}
 
+	if (mem_acc_size < sizeof(struct ffa_mem_access_common)) {
+		res = FFA_INVALID_PARAMETERS;
+		goto cleanup;
+	}
+
 	/* Store the ffa_mem_transaction */
 	smem->sender_id = sender_id;
 	smem->mem_reg_attr = mem_trans->mem_reg_attr;
@@ -671,6 +676,12 @@ static void ffa_mem_retrieve(struct thread_smc_1_2_regs *args,
 					tot_len, frag_len, &mem_trans);
 	if (ret)
 		goto err_set;
+
+	if (mem_trans.mem_access_size < sizeof(struct ffa_mem_access_common) ||
+	    mem_trans.mem_access_count < 1) {
+		ret = FFA_INVALID_PARAMETERS;
+		goto err_set;
+	}
 
 	smem = sp_mem_lookup_and_read_lock(mem_trans.global_handle);
 	if (!smem) {

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1078,6 +1078,9 @@ static int get_acc_perms(vaddr_t mem_acc_base, unsigned int mem_access_size,
 	struct ffa_mem_access_perm *descr = NULL;
 	unsigned int n = 0;
 
+	if (mem_access_size < sizeof(struct ffa_mem_access_common))
+		return FFA_INVALID_PARAMETERS;
+
 	for (n = 0; n < mem_access_count; n++) {
 		mem_acc = (void *)(mem_acc_base + mem_access_size * n);
 		descr = &mem_acc->access_perm;
@@ -1205,6 +1208,9 @@ static bool is_sp_op(struct ffa_mem_transaction_x *mem_trans, void *buf)
 		return false;
 
 	if (mem_trans->mem_access_count < 1)
+		return false;
+
+	if (mem_trans->mem_access_size < sizeof(struct ffa_mem_access_common))
 		return false;
 
 	mem_acc = (void *)((vaddr_t)buf + mem_trans->mem_access_offs);
@@ -2866,6 +2872,10 @@ struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie,
 	 */
 	if (!IS_ALIGNED_WITH_TYPE(frag_len, struct ffa_address_range) ||
 	    !IS_ALIGNED_WITH_TYPE(tot_len, struct ffa_address_range))
+		goto out;
+	if (retrieve_desc.mem_access_size <
+	    sizeof(struct ffa_mem_access_common) ||
+	    retrieve_desc.mem_access_count < 1)
 		goto out;
 	mem_acc = (void *)((vaddr_t)buf + retrieve_desc.mem_access_offs);
 	/*


### PR DESCRIPTION
spmc_read_mem_transaction() reads mem_access_size, mem_access_count and mem_access_offs from a normal-world memory transaction descriptor and checks that the endpoint memory access descriptor array fits within the fragment (mem_access_offs + mem_access_size * mem_access_count <= frag_len). mem_access_size is bounded from above but not from below.

The array elements are dereferenced as struct ffa_mem_access_common, in get_acc_perms() and, on the S-EL0 secure partition path, in spmc_sp_add_share(). With mem_access_size smaller than that structure the array-fit check no longer keeps each element read in range; with mem_access_size 0 and mem_access_offs equal to frag_len the read lands past the mapped buffer. The descriptor comes from the normal world, so this is an out-of-bounds read in the SPMC.

Reject a mem_access_size smaller than struct ffa_mem_access_common. Both dereference sites take mem_access_size from this function, so the single check covers both.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
