### PR TITLE
core: mm: don't walk translation tables for every mapped page

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -2064,11 +2064,27 @@ void core_mmu_map_region(struct mmu_partition *prtn, struct tee_mmap_region *mm)
 	}
 }
 
+/*
+ * The leaf translation table covering a virtual address only changes every
+ * CORE_MMU_PGDIR_SIZE. A loop mapping one small page at a time can therefore
+ * reuse the table found for the previous page instead of walking the
+ * translation tables from the base table again for every page.
+ *
+ * Returns true if @ti still describes the table covering @va. Note that @va
+ * below @ti->va_base wraps the unsigned subtraction into a large value and
+ * thus correctly reports the table as not covering @va.
+ */
+static bool tbl_info_covers_va(struct core_mmu_table_info *ti, vaddr_t va)
+{
+	return ti->table &&
+	       va - ti->va_base < BIT64(ti->shift) * ti->num_entries;
+}
+
 TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 			      enum teecore_memtypes memtype)
 {
 	TEE_Result ret;
-	struct core_mmu_table_info tbl_info;
+	struct core_mmu_table_info tbl_info = { };
 	struct tee_mmap_region *mm;
 	unsigned int idx;
 	uint32_t old_attr;
@@ -2099,21 +2115,25 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 			goto err;
 		}
 
-		while (true) {
+		while (!tbl_info_covers_va(&tbl_info, vaddr)) {
 			if (!core_mmu_find_table(NULL, vaddr, UINT_MAX,
 						 &tbl_info))
 				panic("Can't find pagetable for vaddr ");
 
-			idx = core_mmu_va2idx(&tbl_info, vaddr);
 			if (tbl_info.shift == SMALL_PAGE_SHIFT)
 				break;
 
 			/* This is supertable. Need to divide it. */
+			idx = core_mmu_va2idx(&tbl_info, vaddr);
 			if (!core_mmu_entry_to_finer_grained(&tbl_info, idx,
 							     secure))
 				panic("Failed to spread pgdir on small tables");
+
+			/* Force a new walk to reach the divided table */
+			tbl_info.table = NULL;
 		}
 
+		idx = core_mmu_va2idx(&tbl_info, vaddr);
 		core_mmu_get_entry(&tbl_info, idx, NULL, &old_attr);
 		if (old_attr)
 			panic("Page is already mapped");
@@ -2172,21 +2192,25 @@ TEE_Result core_mmu_map_contiguous_pages(vaddr_t vstart, paddr_t pstart,
 		panic("Trying to map into static region");
 
 	for (i = 0; i < num_pages; i++) {
-		while (true) {
+		while (!tbl_info_covers_va(&tbl_info, vaddr)) {
 			if (!core_mmu_find_table(NULL, vaddr, UINT_MAX,
 						 &tbl_info))
 				panic("Can't find pagetable for vaddr ");
 
-			idx = core_mmu_va2idx(&tbl_info, vaddr);
 			if (tbl_info.shift == SMALL_PAGE_SHIFT)
 				break;
 
 			/* This is supertable. Need to divide it. */
+			idx = core_mmu_va2idx(&tbl_info, vaddr);
 			if (!core_mmu_entry_to_finer_grained(&tbl_info, idx,
 							     secure))
 				panic("Failed to spread pgdir on small tables");
+
+			/* Force a new walk to reach the divided table */
+			tbl_info.table = NULL;
 		}
 
+		idx = core_mmu_va2idx(&tbl_info, vaddr);
 		core_mmu_get_entry(&tbl_info, idx, NULL, &old_attr);
 		if (old_attr)
 			panic("Page is already mapped");
@@ -2274,7 +2298,7 @@ static void maybe_remove_from_mem_map(vaddr_t vstart, size_t num_pages)
 
 void core_mmu_unmap_pages(vaddr_t vstart, size_t num_pages)
 {
-	struct core_mmu_table_info tbl_info;
+	struct core_mmu_table_info tbl_info = { };
 	size_t i;
 	unsigned int idx;
 	uint32_t exceptions;
@@ -2284,11 +2308,14 @@ void core_mmu_unmap_pages(vaddr_t vstart, size_t num_pages)
 	maybe_remove_from_mem_map(vstart, num_pages);
 
 	for (i = 0; i < num_pages; i++, vstart += SMALL_PAGE_SIZE) {
-		if (!core_mmu_find_table(NULL, vstart, UINT_MAX, &tbl_info))
-			panic("Can't find pagetable");
+		if (!tbl_info_covers_va(&tbl_info, vstart)) {
+			if (!core_mmu_find_table(NULL, vstart, UINT_MAX,
+						 &tbl_info))
+				panic("Can't find pagetable");
 
-		if (tbl_info.shift != SMALL_PAGE_SHIFT)
-			panic("Invalid pagetable level");
+			if (tbl_info.shift != SMALL_PAGE_SHIFT)
+				panic("Invalid pagetable level");
+		}
 
 		idx = core_mmu_va2idx(&tbl_info, vstart);
 		core_mmu_set_entry(&tbl_info, idx, 0, 0);


### PR DESCRIPTION
core_mmu_map_pages(), core_mmu_map_contiguous_pages() and core_mmu_unmap_pages() called core_mmu_find_table() once per small page, even though the leaf translation table only changes every CORE_MMU_PGDIR_SIZE. For a 2MB pgdir that means 511 out of 512 walks returned the same table, each one masking exceptions, reading mpidr_el1 and doing a phys_to_virt() per level descended, all with mmu_spinlock held. The user mapping path in set_um_region() and set_pg_region() already switches leaf table only once per CORE_MMU_PGDIR_SIZE.

Add tbl_info_covers_va() and only walk the tables when the virtual address has left the table found for the previous page. Registering an 8MB non-secure shared buffer now walks 4 times instead of 2048 (8 the first time, when each pgdir entry still has to be split), and the same again on unmap. No functional change.

Link: #7946

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
