### PR TITLE
plat-qcom: qfprom: clean up MX rail workaround handling

### DIFF
--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -5,8 +5,8 @@ PLATFORM_FLAVOR ?= kodiak
 # The default value CFG_INSECURE ?= y is assigned in mk/config.mk.
 # But mk/config.mk is included after $(platform-dir)/conf.mk from
 # core/core.mk.
-# Since we are making decision based on CFG_INSECURE in this file
-# so we need to set it early here also.
+# Since we are making decision based on CFG_INSECURE for enabling
+# certain platform features, we need to set it early here also.
 CFG_INSECURE ?= y
 
 $(call force,CFG_GIC,y)

--- a/core/arch/arm/plat-qcom/hoya/kodiak/target.mk
+++ b/core/arch/arm/plat-qcom/hoya/kodiak/target.mk
@@ -8,11 +8,16 @@ CFG_QCOM_QFPROM_FUSEPROV ?= y
 endif
 
 ifeq ($(CFG_QCOM_QFPROM_FUSEPROV),y)
-$(call force,CFG_QCOM_CMD_DB,y)
-$(call force,CFG_QCOM_RPMH_CLIENT,y)
 $(call force,CFG_QCOM_QFPROM,y)
+endif
+
+ifeq ($(CFG_QCOM_QFPROM),y)
 # Kodiak requires MX voltage rail workaround for QFPROM fuse blowing
-$(call force,CFG_QFPROM_MX_RAIL_WA,y)
+$(call force,CFG_QCOM_RPMH_CLIENT,y)
+endif
+
+ifeq ($(CFG_QCOM_RPMH_CLIENT),y)
+$(call force,CFG_QCOM_CMD_DB,y)
 endif
 
 CFG_QCOM_PAS_PTA ?= y

--- a/core/arch/arm/plat-qcom/hoya/lemans/target.mk
+++ b/core/arch/arm/plat-qcom/hoya/lemans/target.mk
@@ -8,8 +8,6 @@ CFG_QCOM_QFPROM_FUSEPROV ?= y
 endif
 
 ifeq ($(CFG_QCOM_QFPROM_FUSEPROV),y)
-$(call force,CFG_QCOM_CMD_DB,y)
-$(call force,CFG_QCOM_RPMH_CLIENT,y)
 $(call force,CFG_QCOM_QFPROM,y)
 endif
 

--- a/core/drivers/qcom/qfprom/kodiak/qfprom_fuse_region.c
+++ b/core/drivers/qcom/qfprom/kodiak/qfprom_fuse_region.c
@@ -3,7 +3,11 @@
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
+#include <drivers/qcom/cmd_db/cmd_db.h>
+#include <drivers/qcom/rpmh/rpmh_client.h>
+#include <inttypes.h>
 #include <qfprom_target.h>
+#include <trace.h>
 
 #include "qfprom_priv.h"
 
@@ -74,8 +78,75 @@ const struct qfprom_region_info region_data[] = {
 
 const size_t region_count = ARRAY_SIZE(region_data);
 
+static struct rpmh_client *rpmh_handle;
+
+static TEE_Result qfprom_platform_init(void)
+{
+	uint32_t vrm_addr = 0;
+	uint32_t req_id = 0;
+
+	if (!rpmh_handle) {
+		rpmh_handle = rpmh_create_handle(RSC_DRV_SECURE, "qfprom");
+		if (!rpmh_handle) {
+			EMSG("RPMH client creation failed");
+			return TEE_ERROR_GENERIC;
+		}
+	}
+
+	/* Enable MX voltage rail for QFPROM operations */
+	if (cmd_db_get_addr(PM_QFPROM_VREG_A, &vrm_addr) != TEE_SUCCESS) {
+		EMSG("QFPROM voltage rail '%s' not found in CMD_DB",
+		     PM_QFPROM_VREG_A);
+		return TEE_ERROR_GENERIC;
+	}
+
+	if (rpmh_send_command(rpmh_handle, RPMH_SET_ACTIVE, true,
+			      vrm_addr, QFPROM_VOLTAGE_ON, &req_id) !=
+	    TEE_SUCCESS) {
+		EMSG("RPMH enable MX failed: addr 0x%"PRIx32" req_id %"PRIu32,
+		     vrm_addr, req_id);
+		return TEE_ERROR_GENERIC;
+	}
+
+	rpmh_barrier_single(rpmh_handle, req_id);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result qfprom_platform_deinit(void)
+{
+	uint32_t vrm_addr = 0;
+	uint32_t req_id = 0;
+
+	if (!rpmh_handle) {
+		EMSG("RPMH not initialized");
+		return TEE_ERROR_GENERIC;
+	}
+
+	/* Disable MX voltage rail after QFPROM operations */
+	if (cmd_db_get_addr(PM_QFPROM_VREG_A, &vrm_addr) != TEE_SUCCESS) {
+		EMSG("QFPROM voltage rail '%s' not found in CMD_DB",
+		     PM_QFPROM_VREG_A);
+		return TEE_ERROR_GENERIC;
+	}
+
+	if (rpmh_send_command(rpmh_handle, RPMH_SET_ACTIVE, true,
+			      vrm_addr, QFPROM_VOLTAGE_OFF, &req_id) !=
+	    TEE_SUCCESS) {
+		EMSG("RPMH disable MX failed: addr 0x%"PRIx32" req_id %"PRIu32,
+		     vrm_addr, req_id);
+		return TEE_ERROR_GENERIC;
+	}
+
+	rpmh_barrier_single(rpmh_handle, req_id);
+
+	return TEE_SUCCESS;
+}
+
 const struct qfprom_platform_config plat_config = {
 	.name = "Kodiak",
+	.init = qfprom_platform_init,
+	.deinit = qfprom_platform_deinit,
 	.qfprom_raw_base = QFPROM_RAW_BASE,
 	.qfprom_corr_base = QFPROM_CORR_BASE,
 	.qfprom_size = QFPROM_SIZE,

--- a/core/drivers/qcom/qfprom/qfprom_core.c
+++ b/core/drivers/qcom/qfprom/qfprom_core.c
@@ -387,20 +387,22 @@ TEE_Result qfprom_hw_init(void)
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = qfprom_enable_voltage();
-	if (res != TEE_SUCCESS)
-		goto err_unlock;
+	if (drv->config->init) {
+		res = drv->config->init();
+		if (res != TEE_SUCCESS)
+			goto err_unlock;
+	}
 
 	res = qfprom_write_set_clock_settings();
 	if (res != TEE_SUCCESS)
-		goto err_disable_voltage;
+		goto err_deinit;
 
 	drv->write_op_allowed = true;
 	return TEE_SUCCESS;
 
-err_disable_voltage:
-	if (qfprom_disable_voltage() != TEE_SUCCESS)
-		EMSG("Failed to disable voltage");
+err_deinit:
+	if (drv->config->deinit && drv->config->deinit() != TEE_SUCCESS)
+		EMSG("Failed to deinit platform");
 err_unlock:
 	qfprom_release_hw_mutex();
 	return res;
@@ -412,8 +414,8 @@ void qfprom_hw_deinit(void)
 
 	drv->write_op_allowed = false;
 	qfprom_write_reset_clock_settings();
-	if (qfprom_disable_voltage() != TEE_SUCCESS)
-		EMSG("Failed to disable voltage");
+	if (drv->config->deinit && drv->config->deinit() != TEE_SUCCESS)
+		EMSG("Failed to deinit platform");
 	qfprom_release_hw_mutex();
 }
 

--- a/core/drivers/qcom/qfprom/qfprom_priv.h
+++ b/core/drivers/qcom/qfprom/qfprom_priv.h
@@ -41,6 +41,8 @@ struct qfprom_region_info {
 
 struct qfprom_platform_config {
 	const char *name;
+	TEE_Result (*init)(void);
+	TEE_Result (*deinit)(void);
 	paddr_t qfprom_raw_base;
 	paddr_t qfprom_corr_base;
 	size_t qfprom_size;
@@ -70,9 +72,6 @@ struct qfprom_context *qfprom_get_context(void);
 
 TEE_Result qfprom_write_set_clock_settings(void);
 TEE_Result qfprom_write_reset_clock_settings(void);
-
-TEE_Result qfprom_enable_voltage(void);
-TEE_Result qfprom_disable_voltage(void);
 
 TEE_Result qfprom_acquire_hw_mutex(void);
 TEE_Result qfprom_release_hw_mutex(void);

--- a/core/drivers/qcom/qfprom/qfprom_target.c
+++ b/core/drivers/qcom/qfprom/qfprom_target.c
@@ -4,9 +4,6 @@
  */
 
 #include <drivers/clk_qcom.h>
-#include <drivers/qcom/cmd_db/cmd_db.h>
-#include <drivers/qcom/rpmh/rpmh_client.h>
-#include <inttypes.h>
 #include <io.h>
 #include <kernel/delay.h>
 #include <kernel/panic.h>
@@ -61,83 +58,6 @@ TEE_Result qfprom_write_reset_clock_settings(void)
 
 	return TEE_SUCCESS;
 }
-
-#ifdef CFG_QFPROM_MX_RAIL_WA
-static struct rpmh_client *rpmh_handle;
-
-TEE_Result qfprom_enable_voltage(void)
-{
-	uint32_t vrm_addr = 0;
-	uint32_t req_id = 0;
-
-	if (!rpmh_handle) {
-		rpmh_handle = rpmh_create_handle(RSC_DRV_SECURE, "qfprom");
-		if (!rpmh_handle) {
-			EMSG("RPMH client creation failed");
-			return TEE_ERROR_GENERIC;
-		}
-	}
-
-	/* Enable MX voltage rail for QFPROM operations */
-	if (cmd_db_get_addr(PM_QFPROM_VREG_A, &vrm_addr) != TEE_SUCCESS) {
-		EMSG("QFPROM voltage rail '%s' not found in CMD_DB",
-		     PM_QFPROM_VREG_A);
-		return TEE_ERROR_GENERIC;
-	}
-
-	if (rpmh_send_command(rpmh_handle, RPMH_SET_ACTIVE, true,
-			      vrm_addr, QFPROM_VOLTAGE_ON, &req_id) !=
-	    TEE_SUCCESS) {
-		EMSG("RPMH enable MX failed: addr 0x%"PRIx32" req_id %"PRIu32,
-		     vrm_addr, req_id);
-		return TEE_ERROR_GENERIC;
-	}
-
-	rpmh_barrier_single(rpmh_handle, req_id);
-
-	return TEE_SUCCESS;
-}
-
-TEE_Result qfprom_disable_voltage(void)
-{
-	uint32_t vrm_addr = 0;
-	uint32_t req_id = 0;
-
-	if (!rpmh_handle) {
-		EMSG("RPMH not initialized");
-		return TEE_ERROR_GENERIC;
-	}
-
-	/* Disable MX voltage rail after QFPROM operations */
-	if (cmd_db_get_addr(PM_QFPROM_VREG_A, &vrm_addr) != TEE_SUCCESS) {
-		EMSG("QFPROM voltage rail '%s' not found in CMD_DB",
-		     PM_QFPROM_VREG_A);
-		return TEE_ERROR_GENERIC;
-	}
-
-	if (rpmh_send_command(rpmh_handle, RPMH_SET_ACTIVE, true,
-			      vrm_addr, QFPROM_VOLTAGE_OFF, &req_id) !=
-	    TEE_SUCCESS) {
-		EMSG("RPMH disable MX failed: addr 0x%"PRIx32" req_id %"PRIu32,
-		     vrm_addr, req_id);
-		return TEE_ERROR_GENERIC;
-	}
-
-	rpmh_barrier_single(rpmh_handle, req_id);
-
-	return TEE_SUCCESS;
-}
-#else
-TEE_Result qfprom_enable_voltage(void)
-{
-	return TEE_SUCCESS;
-}
-
-TEE_Result qfprom_disable_voltage(void)
-{
-	return TEE_SUCCESS;
-}
-#endif /* CFG_QFPROM_MX_RAIL_WA */
 
 TEE_Result qfprom_acquire_hw_mutex(void)
 {


### PR DESCRIPTION
This series narrows RPMH dependencies to the MX rail workaround and
refactors the workaround implementation into a dedicated source/header
pair following existing OP-TEE patterns.

No functional change intended.