### PR TITLE
AMD ASU FW capability

### DIFF
--- a/core/drivers/amd/asu/asu_fw_info.c
+++ b/core/drivers/amd/asu/asu_fw_info.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#include <drivers/amd/asu_fw_info.h>
+#include <io.h>
+#include <mm/core_mmu.h>
+#include <trace.h>
+
+/*
+ * Covers the RTCA offsets read through this file: the module info array
+ * (ASU_RTCA_MODULE_INFO_OFFSET onward, ASU_RTCA_MODULE_COUNT entries) and
+ * the FW version register (ASU_RTCA_FW_VERSION_OFFSET).
+ */
+#define ASU_RTCA_FW_INFO_MAP_SIZE	0x200U
+
+/*
+ * Cached mapping for the RTCA FW-info region. Created once and never
+ * unmapped - core_mmu_remove_mapping() would also tear down asu_main.c's
+ * shared channel-memory mapping in the same translation block, causing a
+ * data abort on the next ASU queue access.
+ */
+static void *asu_rtca_fw_info_base;
+
+/*
+ * asu_rtca_map() - Return the (persistent) mapping for the RTCA region
+ * used for FW info
+ *
+ * Return: Mapped base address, or NULL on failure
+ */
+static void *asu_rtca_map(void)
+{
+	if (!asu_rtca_fw_info_base) {
+		asu_rtca_fw_info_base =
+			core_mmu_add_mapping(MEM_AREA_IO_SEC,
+					     ASU_RTCA_BASEADDR,
+					     ASU_RTCA_FW_INFO_MAP_SIZE);
+		if (!asu_rtca_fw_info_base)
+			EMSG("Failed to map RTCA for FW info");
+	}
+
+	return asu_rtca_fw_info_base;
+}
+
+TEE_Result asu_rtca_get_fw_version(uint8_t *major, uint8_t *minor)
+{
+	void *rtca = NULL;
+	uint32_t val = 0;
+
+	if (!major || !minor)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	rtca = asu_rtca_map();
+	if (!rtca)
+		return TEE_ERROR_GENERIC;
+
+	val = io_read32((vaddr_t)rtca + ASU_RTCA_FW_VERSION_OFFSET);
+
+	*major = (val & ASU_FW_VERSION_MAJOR_MASK) >>
+		 ASU_FW_VERSION_MAJOR_SHIFT;
+	*minor = val & ASU_FW_VERSION_MINOR_MASK;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result asu_rtca_get_module_info(uint32_t module_id,
+				    struct asu_crypto_alg_info *info)
+{
+	void *rtca = NULL;
+	vaddr_t entry = 0;
+
+	if (!info || module_id >= ASU_RTCA_MODULE_COUNT)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	rtca = asu_rtca_map();
+	if (!rtca)
+		return TEE_ERROR_GENERIC;
+
+	entry = (vaddr_t)rtca + ASU_RTCA_MODULE_INFO_OFFSET +
+		module_id * ASU_RTCA_MODULE_INFO_STRIDE;
+
+	info->version = io_read32(entry);
+	info->nist_status = io_read8(entry + 4);
+	info->kat_status = io_read8(entry + 5);
+	info->feature_caps = io_read16(entry + 6);
+	info->reserved4 = io_read32(entry + 8);
+
+	return TEE_SUCCESS;
+}
+
+bool asu_module_version_at_least(const struct fw_module_info *mod,
+				 uint16_t min_major, uint16_t min_minor)
+{
+	uint16_t major = 0;
+	uint16_t minor = 0;
+
+	if (!mod || !mod->valid)
+		return false;
+
+	major = (mod->version & ASU_MODULE_VERSION_MAJOR_MASK) >>
+		ASU_MODULE_VERSION_MAJOR_SHIFT;
+	minor = mod->version & ASU_MODULE_VERSION_MINOR_MASK;
+
+	return major > min_major ||
+	       (major == min_major && minor >= min_minor);
+}

--- a/core/drivers/amd/asu/asu_main.c
+++ b/core/drivers/amd/asu/asu_main.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/fw_compat.h>
 #include <initcall.h>
 #include <io.h>
 #include <kernel/delay.h>
@@ -492,6 +493,8 @@ static TEE_Result asu_init(void)
 	asu->slock = SPINLOCK_UNLOCK;
 	asu->p0_last_index = ASU_MAX_BUFFERS - 1;
 	asu->p1_last_index = ASU_MAX_BUFFERS - 1;
+
+	fw_compat_check();
 
 	IMSG("ASU initialization complete");
 

--- a/core/drivers/amd/asu/sub.mk
+++ b/core/drivers/amd/asu/sub.mk
@@ -5,3 +5,4 @@
 #
 
 srcs-y += asu_main.c
+srcs-y += asu_fw_info.c

--- a/core/drivers/amd/fw_compat.c
+++ b/core/drivers/amd/fw_compat.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#include <drivers/amd/fw_compat.h>
+#include <inttypes.h>
+#include <kernel/panic.h>
+#include <trace.h>
+#include <util.h>
+
+#ifdef CFG_AMD_ASU_SUPPORT
+#include <drivers/amd/asu_fw_info.h>
+
+static struct fw_module_info asu_modules[ASU_RTCA_MODULE_COUNT];
+
+/*
+ * asu_fw_compat_probe() - Validate the ASUFW version and cache per-module
+ * version/capability info
+ *
+ * Return: TEE_SUCCESS if the ASUFW version is at least
+ *	   CFG_AMD_ASU_MINVER_MAJ/_MNR.
+ */
+static TEE_Result asu_fw_compat_probe(void)
+{
+	struct asu_crypto_alg_info info = { };
+	uint32_t min_version = 0;
+	uint32_t version = 0;
+	uint8_t major = 0;
+	uint8_t minor = 0;
+	uint32_t i = 0;
+
+	if (asu_rtca_get_fw_version(&major, &minor) != TEE_SUCCESS) {
+		EMSG("Failed to read ASUFW version from RTCA");
+		return TEE_ERROR_GENERIC;
+	}
+
+	IMSG("ASUFW version: %"PRIu8".%"PRIu8, major, minor);
+
+	/*
+	 * Compare as a single packed value rather than "major < MAJ ||
+	 * (major == MAJ && minor < MNR)" - with the default MNR of 0 that
+	 * form compares an unsigned byte against 0 with "<", which is
+	 * always false and trips -Wtype-limits.
+	 */
+	version = SHIFT_U32(major, 8) | minor;
+	min_version = SHIFT_U32(CFG_AMD_ASU_MINVER_MAJ, 8) |
+		      CFG_AMD_ASU_MINVER_MNR;
+
+	if (version < min_version) {
+		EMSG("ASUFW version %"PRIu8".%"PRIu8" older than minimum %u.%u",
+		     major, minor, CFG_AMD_ASU_MINVER_MAJ,
+		     CFG_AMD_ASU_MINVER_MNR);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	for (i = 0; i < ASU_RTCA_MODULE_COUNT; i++) {
+		if (asu_rtca_get_module_info(i, &info) != TEE_SUCCESS) {
+			EMSG("Failed to read ASU module %"PRIu32" info", i);
+			continue;
+		}
+
+		asu_modules[i].version = info.version;
+		asu_modules[i].feature_caps = info.feature_caps;
+		asu_modules[i].valid = true;
+
+		IMSG("ASU module %"PRIu32": version=%#"PRIx32" caps=%#"PRIx16,
+		     i, info.version, info.feature_caps);
+	}
+
+	return TEE_SUCCESS;
+}
+
+const struct fw_module_info *fw_compat_get_module_info(uint32_t module_id)
+{
+	if (module_id >= ASU_RTCA_MODULE_COUNT)
+		return NULL;
+
+	return &asu_modules[module_id];
+}
+#else
+static TEE_Result asu_fw_compat_probe(void)
+{
+	return TEE_SUCCESS;
+}
+
+const struct fw_module_info *
+fw_compat_get_module_info(uint32_t module_id __unused)
+{
+	return NULL;
+}
+#endif /* CFG_AMD_ASU_SUPPORT */
+
+void fw_compat_check(void)
+{
+	if (asu_fw_compat_probe() != TEE_SUCCESS)
+		panic("Incompatible ASUFW version");
+}

--- a/core/drivers/amd/sub.mk
+++ b/core/drivers/amd/sub.mk
@@ -6,4 +6,6 @@
 
 subdirs-$(CFG_AMD_ASU_SUPPORT) += asu
 
+srcs-y += fw_compat.c
+
 srcs-$(CFG_AMD_PS_GPIO) += gpio_common.c ps_gpio_driver.c

--- a/core/drivers/crypto/asu_driver/asu_authenc.c
+++ b/core/drivers/crypto/asu_driver/asu_authenc.c
@@ -8,6 +8,8 @@
 #include <crypto/crypto.h>
 #include <crypto/crypto_impl.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/fw_compat.h>
 #include <drvcrypt.h>
 #include <drvcrypt_authenc.h>
 #include <drvcrypt_mac.h>
@@ -168,6 +170,23 @@ struct asu_cmac_ctx {
 #endif /* CFG_AMD_ASU_CMAC */
 
 static struct asu_authenc_dev *asu_ae_dev;
+
+/* Validate the ASU AES module version used by the GCM/CCM driver */
+static bool asu_authenc_check_fw_compat(void)
+{
+	const struct fw_module_info *mod =
+		fw_compat_get_module_info(ASU_MODULE_AES_ID);
+
+	if (asu_module_version_at_least(mod, CFG_AMD_ASU_AUTHENC_MINVER_MAJ,
+					CFG_AMD_ASU_AUTHENC_MINVER_MNR)) {
+		IMSG("ASU authenc HW available");
+		return true;
+	}
+
+	EMSG("ASU authenc module version below min %u.%u, skip HW registration",
+	     CFG_AMD_ASU_AUTHENC_MINVER_MAJ, CFG_AMD_ASU_AUTHENC_MINVER_MNR);
+	return false;
+}
 
 /*
  * asu_authenc_get_mode() - Map TEE algorithm to ASU AES engine mode.
@@ -541,7 +560,7 @@ static TEE_Result asu_authenc_init(struct drvcrypt_authenc_init *dinit)
 	ae_ctx->use_sw_fallback = false;
 
 	/*
-	 * Software fallback for 192-bit keys (unsupported by ASUFW) or
+	 * Software fallback for 192-bit keys (unsupported by ASUFW), or for
 	 * GCM with non-16-byte-aligned AAD length.
 	 */
 
@@ -1550,6 +1569,11 @@ static TEE_Result asu_authenc_driver_init(void)
 {
 	TEE_Result ret_authenc = TEE_SUCCESS;
 	TEE_Result ret_cmac = TEE_ERROR_GENERIC;
+
+	if (!asu_authenc_check_fw_compat()) {
+		IMSG("ASU authenc driver not registered, using SW fallback");
+		return TEE_SUCCESS;
+	}
 
 	asu_ae_dev = calloc(1, sizeof(*asu_ae_dev));
 	if (!asu_ae_dev)

--- a/core/drivers/crypto/asu_driver/asu_cipher.c
+++ b/core/drivers/crypto/asu_driver/asu_cipher.c
@@ -7,6 +7,8 @@
 #include <crypto/crypto.h>
 #include <crypto/crypto_impl.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/fw_compat.h>
 #include <drvcrypt.h>
 #include <drvcrypt_cipher.h>
 #include <initcall.h>
@@ -101,6 +103,25 @@ struct asu_cipher_ctx {
 	bool use_sw_fallback;
 	struct crypto_cipher_ctx *sw_ctx;
 };
+
+/* Cached ASUFW Cipher compatibility; AES has no FeatureCaps bits to check */
+
+/* Validate the ASU Cipher module version */
+static bool asu_cipher_check_fw_compat(void)
+{
+	const struct fw_module_info *mod =
+		fw_compat_get_module_info(ASU_MODULE_AES_ID);
+
+	if (asu_module_version_at_least(mod, CFG_AMD_ASU_CIPHER_MINVER_MAJ,
+					CFG_AMD_ASU_CIPHER_MINVER_MNR)) {
+		IMSG("ASU Cipher HW available");
+		return true;
+	}
+
+	EMSG("ASU Cipher module version below min %u.%u, skip HW registration",
+	     CFG_AMD_ASU_CIPHER_MINVER_MAJ, CFG_AMD_ASU_CIPHER_MINVER_MNR);
+	return false;
+}
 
 /*
  * asu_cipher_get_cipher_mode() - Map TEE algorithm to ASU cipher mode.
@@ -885,6 +906,11 @@ static struct drvcrypt_cipher asu_cipher_op = {
 static TEE_Result asu_cipher_init(void)
 {
 	TEE_Result ret = TEE_SUCCESS;
+
+	if (!asu_cipher_check_fw_compat()) {
+		IMSG("ASU Cipher driver not registered, using SW fallback");
+		return TEE_SUCCESS;
+	}
 
 	ret = drvcrypt_register_cipher(&asu_cipher_op);
 	if (ret)

--- a/core/drivers/crypto/asu_driver/asu_ecc.c
+++ b/core/drivers/crypto/asu_driver/asu_ecc.c
@@ -7,6 +7,8 @@
 #include <crypto/crypto.h>
 #include <crypto/crypto_impl.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/fw_compat.h>
 #include <drvcrypt.h>
 #include <drvcrypt_acipher.h>
 #include <initcall.h>
@@ -144,23 +146,64 @@ struct asu_ecc_verify_cbctx {
 static const struct crypto_ecc_keypair_ops *sw_pair_ops;
 static const struct crypto_ecc_public_ops *sw_pub_ops;
 
+/* Cached ASUFW ECC compatibility, populated at driver_init() */
+static struct {
+	bool hw_available;
+	uint16_t feature_caps;
+} asu_ecc_fw_caps;
+
 /*
- * Bitmask of ECC curves enabled in OP-TEE build for ASU FW offload.
- *
- * The set of HW-offloaded curves is fixed at build time, so this is a
- * compile-time constant rather than a value computed at runtime.
+ * Validate the ASU ECC and KeyManager module versions and cache ECC's
+ * FeatureCaps. The driver needs both modules (KeyManager is used
+ * internally by asu_ecc_gen_keypair() for HW keygen), so hw_available
+ * is only set when both meet their minimum version.
  */
-#define ASU_ECC_HW_CURVES_MASK \
-	(SHIFT_U32(IS_ENABLED(CFG_AMD_ASU_ECC_CURVE_NIST_P192), \
-		   ASU_ECC_CURVE_NIST_P192) | \
-	 SHIFT_U32(IS_ENABLED(CFG_AMD_ASU_ECC_CURVE_NIST_P224), \
-		   ASU_ECC_CURVE_NIST_P224) | \
-	 SHIFT_U32(IS_ENABLED(CFG_AMD_ASU_ECC_CURVE_NIST_P256), \
-		   ASU_ECC_CURVE_NIST_P256) | \
-	 SHIFT_U32(IS_ENABLED(CFG_AMD_ASU_ECC_CURVE_NIST_P384), \
-		   ASU_ECC_CURVE_NIST_P384) | \
-	 SHIFT_U32(IS_ENABLED(CFG_AMD_ASU_ECC_CURVE_NIST_P521), \
-		   ASU_ECC_CURVE_NIST_P521))
+static void asu_ecc_check_fw_compat(void)
+{
+	const struct fw_module_info *ecc_mod = NULL;
+	const struct fw_module_info *km_mod = NULL;
+
+	ecc_mod = fw_compat_get_module_info(ASU_MODULE_ECC_ID);
+	if (!asu_module_version_at_least(ecc_mod, CFG_AMD_ASU_ECC_MINVER_MAJ,
+					 CFG_AMD_ASU_ECC_MINVER_MNR)) {
+		EMSG("ASU ECC module unavailable or below min %u.%u, using SW",
+		     CFG_AMD_ASU_ECC_MINVER_MAJ, CFG_AMD_ASU_ECC_MINVER_MNR);
+		return;
+	}
+
+	km_mod = fw_compat_get_module_info(ASU_MODULE_KEYMANAGER_ID);
+	if (!asu_module_version_at_least(km_mod,
+					 CFG_AMD_ASU_KEYMANAGER_MINVER_MAJ,
+					 CFG_AMD_ASU_KEYMANAGER_MINVER_MNR)) {
+		EMSG("ASU KeyManager unavailable or below min %u.%u, using SW",
+		     CFG_AMD_ASU_KEYMANAGER_MINVER_MAJ,
+		     CFG_AMD_ASU_KEYMANAGER_MINVER_MNR);
+		return;
+	}
+
+	asu_ecc_fw_caps.hw_available = true;
+	asu_ecc_fw_caps.feature_caps = ecc_mod->feature_caps;
+	IMSG("ASU ECC HW available, caps=%#"PRIx16, ecc_mod->feature_caps);
+}
+
+/* Map an ASU curve ID to its ASUFW FeatureCaps bit, 0 if none defined */
+static uint16_t asu_ecc_curve_cap_bit(enum asu_ecc_curve_id asu_curve_id)
+{
+	switch (asu_curve_id) {
+	case ASU_ECC_CURVE_NIST_P192:
+		return ASU_ECC_CAP_NIST_P192;
+	case ASU_ECC_CURVE_NIST_P224:
+		return ASU_ECC_CAP_NIST_P224;
+	case ASU_ECC_CURVE_NIST_P256:
+		return ASU_ECC_CAP_NIST_P256;
+	case ASU_ECC_CURVE_NIST_P384:
+		return ASU_ECC_CAP_NIST_P384;
+	case ASU_ECC_CURVE_NIST_P521:
+		return ASU_ECC_CAP_NIST_P521;
+	default:
+		return 0;
+	}
+}
 
 /*
  * asu_ecc_alloc_align_buf() - Allocate zeroed cacheline-aligned memory
@@ -181,24 +224,27 @@ static void *asu_ecc_alloc_align_buf(size_t len)
 	return buf;
 }
 
+/* Curve must be reported compatible by ASUFW's per-curve FeatureCaps bit */
+static bool asu_ecc_curve_fw_enabled(enum asu_ecc_curve_id asu_curve_id)
+{
+	if (asu_curve_id >= ASU_ECC_CURVE_MAX)
+		return false;
+
+	return asu_ecc_fw_caps.hw_available &&
+	       (asu_ecc_fw_caps.feature_caps &
+		asu_ecc_curve_cap_bit(asu_curve_id));
+}
+
 /* Return "HW" if the curve is HW-offloaded, "SW" otherwise */
 static const char *asu_ecc_curve_mode(enum asu_ecc_curve_id asu_curve_id)
 {
-	if (ASU_ECC_HW_CURVES_MASK & BIT(asu_curve_id))
+	if (asu_ecc_curve_fw_enabled(asu_curve_id))
 		return "HW";
 
 	return "SW";
 }
 
-/*
- * asu_ecc_log_curve_modes() - Log per-curve HW/SW assignment
- *
- * By default AMD ASUFW only enables the NIST P-256 curve for ECC, and the
- * driver mirrors that default through the CFG_AMD_ASU_ECC_CURVE_* build
- * flags; curves not enabled for HW offload use the software fallback. This
- * logs which curves are hardware-accelerated so the active configuration is
- * unambiguous to the user. Call once during driver init.
- */
+/* Log per-curve HW/SW assignment. Call after asu_ecc_check_fw_compat() */
 static void asu_ecc_log_curve_modes(void)
 {
 	IMSG("ASU ECC: NIST_P192=%s NIST_P224=%s NIST_P256=%s",
@@ -210,15 +256,7 @@ static void asu_ecc_log_curve_modes(void)
 	     asu_ecc_curve_mode(ASU_ECC_CURVE_NIST_P521));
 }
 
-/* Check if ECC curve is enabled for HW offload in build configuration */
-static bool asu_ecc_curve_fw_enabled(enum asu_ecc_curve_id asu_curve_id)
-{
-	if (asu_curve_id >= ASU_ECC_CURVE_MAX)
-		return false;
-	return ASU_ECC_HW_CURVES_MASK & BIT(asu_curve_id);
-}
-
-/* ECC key-pair generation SW fallback for curves disabled in build config */
+/* ECC key-pair generation SW fallback for curves ASUFW reports as disabled */
 static TEE_Result asu_ecc_sw_gen_keypair(struct ecc_keypair *key,
 					 size_t size_bits)
 {
@@ -228,7 +266,7 @@ static TEE_Result asu_ecc_sw_gen_keypair(struct ecc_keypair *key,
 	return sw_pair_ops->generate(key, size_bits);
 }
 
-/* ECDSA sign SW fallback for curves disabled in build config */
+/* ECDSA sign SW fallback for curves ASUFW reports as disabled */
 static TEE_Result asu_ecc_sw_sign(struct drvcrypt_sign_data *sdata)
 {
 	if (!sw_pair_ops || !sw_pair_ops->sign || !sdata || !sdata->key)
@@ -240,7 +278,7 @@ static TEE_Result asu_ecc_sw_sign(struct drvcrypt_sign_data *sdata)
 				 &sdata->signature.length);
 }
 
-/* ECDSA verify SW fallback for curves disabled in build config */
+/* ECDSA verify SW fallback for curves ASUFW reports as disabled */
 static TEE_Result asu_ecc_sw_verify(struct drvcrypt_sign_data *sdata)
 {
 	if (!sw_pub_ops || !sw_pub_ops->verify || !sdata || !sdata->key)
@@ -252,7 +290,7 @@ static TEE_Result asu_ecc_sw_verify(struct drvcrypt_sign_data *sdata)
 				  sdata->signature.length);
 }
 
-/* ECDH shared-secret SW fallback for curves disabled in build config */
+/* ECDH shared-secret SW fallback for curves ASUFW reports as disabled */
 static TEE_Result asu_ecc_sw_shared_secret(struct drvcrypt_secret_data *sdata)
 {
 	TEE_Result ret = TEE_SUCCESS;
@@ -576,11 +614,15 @@ static TEE_Result asu_ecc_gen_keypair(struct ecc_keypair *key,
 	}
 
 	ret = asu_ecc_get_curve_info(key->curve, &asu_curve_id, &key_len);
-	/* Use software fallback if curve is disabled in build config */
+	/* Use software fallback if ASUFW reports the curve as disabled */
 	if (ret == TEE_ERROR_NOT_IMPLEMENTED)
 		return asu_ecc_sw_gen_keypair(key, size_bits);
 	else if (ret != TEE_SUCCESS)
 		goto out;
+
+	/* ECC or KeyManager module unavailable/incompatible, use SW keygen */
+	if (!asu_ecc_fw_caps.hw_available)
+		return asu_ecc_sw_gen_keypair(key, size_bits);
 
 	keypair_obj = asu_ecc_alloc_align_buf(sizeof(*keypair_obj));
 	if (!keypair_obj) {
@@ -682,7 +724,7 @@ static TEE_Result asu_ecc_sign(struct drvcrypt_sign_data *sdata)
 
 	/* Validate curve and derive key length before acquiring any resource */
 	ret = asu_ecc_get_curve_info(key->curve, &asu_curve_id, &key_len);
-	/* Use software fallback if curve is disabled in build config */
+	/* Use software fallback if ASUFW reports the curve as disabled */
 	if (ret == TEE_ERROR_NOT_IMPLEMENTED)
 		return asu_ecc_sw_sign(sdata);
 	else if (ret != TEE_SUCCESS)
@@ -805,7 +847,7 @@ static TEE_Result asu_ecc_verify(struct drvcrypt_sign_data *sdata)
 	key = sdata->key;
 
 	ret = asu_ecc_get_curve_info(key->curve, &asu_curve_id, &key_len);
-	/* Use software fallback if curve is disabled in build config */
+	/* Use software fallback if ASUFW reports the curve as disabled */
 	if (ret == TEE_ERROR_NOT_IMPLEMENTED)
 		return asu_ecc_sw_verify(sdata);
 	else if (ret != TEE_SUCCESS)
@@ -953,7 +995,7 @@ static TEE_Result asu_ecc_shared_secret(struct drvcrypt_secret_data *sdata)
 	}
 
 	ret = asu_ecc_get_curve_info(priv_key->curve, &asu_curve_id, &key_len);
-	/* Use software fallback if curve is disabled in build config */
+	/* Use software fallback if ASUFW reports the curve as disabled */
 	if (ret == TEE_ERROR_NOT_IMPLEMENTED)
 		return asu_ecc_sw_shared_secret(sdata);
 	else if (ret != TEE_SUCCESS)
@@ -1072,6 +1114,7 @@ static TEE_Result asu_ecc_init(void)
 {
 	TEE_Result ret = TEE_SUCCESS;
 
+	asu_ecc_check_fw_compat();
 	asu_ecc_log_curve_modes();
 
 	sw_pair_ops = crypto_asym_get_ecc_keypair_ops(TEE_TYPE_ECDSA_KEYPAIR);

--- a/core/drivers/crypto/asu_driver/asu_hash.c
+++ b/core/drivers/crypto/asu_driver/asu_hash.c
@@ -6,6 +6,8 @@
 
 #include <assert.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/fw_compat.h>
 #include <drvcrypt_hash.h>
 #include <drvcrypt_mac.h>
 #include <initcall.h>
@@ -894,24 +896,68 @@ err_release_engine:
 
 #endif /* CFG_AMD_ASU_HMAC */
 
+static bool asu_module_fw_compatible(const char *name, uint32_t module_id,
+				     uint16_t min_major, uint16_t min_minor)
+{
+	const struct fw_module_info *mod = fw_compat_get_module_info(module_id);
+
+	if (!asu_module_version_at_least(mod, min_major, min_minor)) {
+		EMSG("ASU %s version below min %u.%u, skip HW registration",
+		     name, min_major, min_minor);
+		return false;
+	}
+
+	IMSG("ASU %s HW available", name);
+	return true;
+}
+
 static TEE_Result asu_hash_init(void)
 {
 	TEE_Result ret = TEE_SUCCESS;
+	bool hash_registered = false;
+	bool hmac_registered = false;
 
 	asu_shadev = calloc(1, sizeof(*asu_shadev));
+	if (!asu_shadev)
+		return TEE_ERROR_OUT_OF_MEMORY;
 	mutex_init(&asu_shadev->engine_lock);
 	asu_shadev->sha2_available = true;
 	asu_shadev->sha3_available = true;
 
-	ret = drvcrypt_register_hash(&asu_hash_ctx_allocate);
-	if (ret)
-		EMSG("ASU hash register to crypto fail ret=%#"PRIx32, ret);
+	if (!asu_module_fw_compatible("SHA2", ASU_MODULE_SHA2_ID,
+				      CFG_AMD_ASU_SHA2_MINVER_MAJ,
+				      CFG_AMD_ASU_SHA2_MINVER_MNR) ||
+	    !asu_module_fw_compatible("SHA3", ASU_MODULE_SHA3_ID,
+				      CFG_AMD_ASU_SHA3_MINVER_MAJ,
+				      CFG_AMD_ASU_SHA3_MINVER_MNR)) {
+		IMSG("ASU hash driver not registered, using SW fallback");
+	} else {
+		ret = drvcrypt_register_hash(asu_hash_ctx_allocate);
+		if (ret)
+			EMSG("ASU hash register to crypto fail ret=%#"PRIx32,
+			     ret);
+		else
+			hash_registered = true;
+	}
 
 #if defined(CFG_AMD_ASU_HMAC)
-	ret = drvcrypt_register_hmac(asu_hmac_ctx_allocate);
-	if (ret)
-		EMSG("ASU HMAC register failed ret=%#"PRIx32, ret);
+	if (!asu_module_fw_compatible("HMAC", ASU_MODULE_HMAC_ID,
+				      CFG_AMD_ASU_HMAC_MINVER_MAJ,
+				      CFG_AMD_ASU_HMAC_MINVER_MNR)) {
+		IMSG("ASU HMAC driver not registered, using SW fallback");
+	} else {
+		ret = drvcrypt_register_hmac(asu_hmac_ctx_allocate);
+		if (ret)
+			EMSG("ASU HMAC register failed ret=%#"PRIx32, ret);
+		else
+			hmac_registered = true;
+	}
 #endif
+
+	if (!hash_registered && !hmac_registered) {
+		free(asu_shadev);
+		asu_shadev = NULL;
+	}
 
 	return ret;
 }

--- a/core/drivers/crypto/asu_driver/asu_huk.c
+++ b/core/drivers/crypto/asu_driver/asu_huk.c
@@ -6,6 +6,8 @@
 
 #include <crypto/crypto.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/fw_compat.h>
 #include <io.h>
 #include <kernel/delay.h>
 #include <kernel/spinlock.h>
@@ -135,6 +137,32 @@ err:
 	return ret;
 }
 
+/*
+ * Check that ASUFW reports the HUK module at least at the configured
+ * minimum version. There is no software fallback for the HUK - a
+ * software-derived key would not be hardware-rooted - so a mismatch here
+ * is always a hard failure.
+ */
+static bool asu_huk_fw_compatible(void)
+{
+	const struct fw_module_info *mod = NULL;
+
+	mod = fw_compat_get_module_info(ASU_MODULE_ID_HUK);
+	if (!mod || !mod->valid) {
+		EMSG("ASUFW does not report HUK module info");
+		return false;
+	}
+
+	if (!asu_module_version_at_least(mod, CFG_AMD_ASU_HUK_MINVER_MAJ,
+					 CFG_AMD_ASU_HUK_MINVER_MNR)) {
+		EMSG("HUK module version below minimum %u.%u",
+		     CFG_AMD_ASU_HUK_MINVER_MAJ, CFG_AMD_ASU_HUK_MINVER_MNR);
+		return false;
+	}
+
+	return true;
+}
+
 /* Validate HUK is non-zero (all-zero indicates ASU firmware failure) */
 static bool is_huk_valid(const uint8_t *huk)
 {
@@ -188,6 +216,16 @@ static TEE_Result asu_fetch_and_cache_huk(void)
 		cached_huk.fetch_in_progress = true;
 		cpu_spin_unlock_xrestore(&cached_huk.lock, exceptions);
 		break;
+	}
+
+	/*
+	 * Check ASUFW reports the HUK module as present and compatible
+	 * before sending an IPI request for it - avoids a multi-second IPI
+	 * timeout against firmware that was built without this module.
+	 */
+	if (!asu_huk_fw_compatible()) {
+		ret = TEE_ERROR_NOT_SUPPORTED;
+		goto err;
 	}
 
 	/* Fetch into temporary buffer without holding lock (IPI blocks) */

--- a/core/drivers/crypto/asu_driver/asu_rsa.c
+++ b/core/drivers/crypto/asu_driver/asu_rsa.c
@@ -7,6 +7,9 @@
 #include <crypto/crypto.h>
 #include <crypto/crypto_impl.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/asu_sharedmem.h>
+#include <drivers/amd/fw_compat.h>
 #include <drvcrypt.h>
 #include <drvcrypt_acipher.h>
 #include <initcall.h>
@@ -168,6 +171,71 @@ struct asu_rsa_km_params {
 	uint32_t wrapped_input_len;
 	uint8_t reserved[4];
 };
+
+/*
+ * Cached ASUFW RSA module compatibility, populated once by
+ * asu_rsa_check_fw_compat() at driver_init() from the fw_compat_check()
+ * snapshot. @hw_available is false when the RSA module version is below
+ * CFG_AMD_ASU_RSA_MINVER_MAJ/_MNR, in which case every
+ * operation below falls back to software regardless of @feature_caps.
+ */
+static struct {
+	bool hw_available;
+	uint16_t feature_caps;
+} asu_rsa_fw_caps;
+
+/*
+ * asu_rsa_check_fw_compat() - Validate the ASU RSA module version and
+ * cache its FeatureCaps for use by the HW/SW fallback checks below
+ */
+static void asu_rsa_check_fw_compat(void)
+{
+	const struct fw_module_info *mod = NULL;
+
+	mod = fw_compat_get_module_info(ASU_MODULE_RSA_ID);
+	if (!asu_module_version_at_least(mod, CFG_AMD_ASU_RSA_MINVER_MAJ,
+					 CFG_AMD_ASU_RSA_MINVER_MNR)) {
+		EMSG("ASU RSA module unavailable or below min %u.%u, using SW",
+		     CFG_AMD_ASU_RSA_MINVER_MAJ, CFG_AMD_ASU_RSA_MINVER_MNR);
+		return;
+	}
+
+	asu_rsa_fw_caps.hw_available = true;
+	asu_rsa_fw_caps.feature_caps = mod->feature_caps;
+
+	IMSG("ASU RSA HW available, caps=%#"PRIx16, mod->feature_caps);
+}
+
+/* Whether HW-accelerated padded RSA (OAEP/PSS) operations can be used */
+static bool asu_rsa_hw_supports_padding(void)
+{
+	return asu_rsa_fw_caps.hw_available &&
+	       (asu_rsa_fw_caps.feature_caps & ASU_RSA_CAP_PADDING);
+}
+
+/* Whether HW-accelerated raw (NOPAD) RSA operations can be used */
+static bool asu_rsa_hw_supports_nopad(void)
+{
+	return asu_rsa_fw_caps.hw_available;
+}
+
+/* Whether HW RSA key-pair generation is available for a given key size */
+static bool asu_rsa_hw_supports_keygen(size_t size_bits)
+{
+	if (!asu_rsa_fw_caps.hw_available)
+		return false;
+
+	switch (size_bits) {
+	case 2048:
+		return asu_rsa_fw_caps.feature_caps & ASU_RSA_CAP_2048_KEYGEN;
+	case 3072:
+		return asu_rsa_fw_caps.feature_caps & ASU_RSA_CAP_3072_KEYGEN;
+	case 4096:
+		return asu_rsa_fw_caps.feature_caps & ASU_RSA_CAP_4096_KEYGEN;
+	default:
+		return false;
+	}
+}
 
 /* Calculate the length of the RSA key-pair blob */
 static size_t asu_rsa_keypair_blob_len(size_t size_bytes)
@@ -1199,7 +1267,8 @@ static TEE_Result asu_rsa_encrypt(struct drvcrypt_rsa_ed *rsa_data)
 			ret = asu_rsa_sw_rsaes_encrypt(rsa_data);
 			goto out;
 		}
-		if (asu_rsa_validate_key_size(rsa_data->key.n_size)) {
+		if (asu_rsa_validate_key_size(rsa_data->key.n_size) ||
+		    !asu_rsa_hw_supports_padding()) {
 			ret = asu_rsa_sw_rsaes_encrypt(rsa_data);
 			goto out;
 		}
@@ -1211,7 +1280,8 @@ static TEE_Result asu_rsa_encrypt(struct drvcrypt_rsa_ed *rsa_data)
 			goto out;
 		}
 
-		if (asu_rsa_validate_key_size(rsa_data->key.n_size)) {
+		if (asu_rsa_validate_key_size(rsa_data->key.n_size) ||
+		    !asu_rsa_hw_supports_nopad()) {
 			ret = asu_rsa_sw_rsanopad_encrypt(rsa_data);
 			goto out;
 		}
@@ -1370,7 +1440,8 @@ static TEE_Result asu_rsa_decrypt(struct drvcrypt_rsa_ed *rsa_data)
 			ret = TEE_ERROR_BAD_PARAMETERS;
 			goto out;
 		}
-		if (asu_rsa_validate_key_size(rsa_data->key.n_size)) {
+		if (asu_rsa_validate_key_size(rsa_data->key.n_size) ||
+		    !asu_rsa_hw_supports_padding()) {
 			ret = asu_rsa_sw_rsaes_decrypt(rsa_data);
 			goto out;
 		}
@@ -1383,7 +1454,8 @@ static TEE_Result asu_rsa_decrypt(struct drvcrypt_rsa_ed *rsa_data)
 		}
 
 		if (asu_rsa_validate_key_size(rsa_data->key.n_size) ||
-		    rsa_data->cipher.length != rsa_data->key.n_size) {
+		    rsa_data->cipher.length != rsa_data->key.n_size ||
+		    !asu_rsa_hw_supports_nopad()) {
 			ret = asu_rsa_sw_rsanopad_decrypt(rsa_data);
 			goto out;
 		}
@@ -1596,7 +1668,8 @@ static TEE_Result asu_rsa_ssa_sign(struct drvcrypt_rsa_ssa *ssa_data)
 		goto out;
 	}
 
-	if (asu_rsa_validate_key_size(ssa_data->key.n_size)) {
+	if (asu_rsa_validate_key_size(ssa_data->key.n_size) ||
+	    !asu_rsa_hw_supports_padding()) {
 		ret = asu_rsa_sw_rsassa_sign(ssa_data);
 		goto out;
 	}
@@ -1725,8 +1798,14 @@ static TEE_Result asu_rsa_ssa_verify(struct drvcrypt_rsa_ssa *ssa_data)
 		goto out;
 	}
 
-	if (asu_rsa_validate_key_size(ssa_data->key.n_size)) {
-		ret = asu_rsa_sw_rsassa_verify(ssa_data);
+	if (asu_rsa_validate_key_size(ssa_data->key.n_size) ||
+	    !asu_rsa_hw_supports_padding()) {
+		/*
+		 * TODO: SW fallback here triggers an FTMN assertion under
+		 * CFG_FAULT_MITIGATION=y (nested FTMN completion corrupts
+		 * caller state). Fail closed until that shared bug is fixed.
+		 */
+		ret = TEE_ERROR_NOT_SUPPORTED;
 		goto out;
 	}
 
@@ -1819,7 +1898,8 @@ static TEE_Result asu_rsa_gen_keypair(struct rsa_keypair *key,
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	if (asu_rsa_size_bits_to_bytes(size_bits, &size_bytes) ||
-	    asu_rsa_pubexp_is_f4(key->e))
+	    asu_rsa_pubexp_is_f4(key->e) ||
+	    !asu_rsa_hw_supports_keygen(size_bits))
 		return sw_crypto_acipher_gen_rsa_key(key, size_bits);
 
 	key_obj_req_len = asu_rsa_keypair_blob_len(size_bytes);
@@ -1990,6 +2070,8 @@ static struct drvcrypt_rsa driver_rsa = {
 static TEE_Result asu_rsa_init(void)
 {
 	TEE_Result ret = TEE_SUCCESS;
+
+	asu_rsa_check_fw_compat();
 
 	ret = drvcrypt_register_rsa(&driver_rsa);
 	if (ret) {

--- a/core/drivers/crypto/asu_driver/asu_trng.c
+++ b/core/drivers/crypto/asu_driver/asu_trng.c
@@ -5,6 +5,9 @@
 
 #include <crypto/crypto.h>
 #include <drivers/amd/asu_client.h>
+#include <drivers/amd/asu_fw_info.h>
+#include <drivers/amd/asu_sharedmem.h>
+#include <drivers/amd/fw_compat.h>
 #include <kernel/panic.h>
 #include <rng_support.h>
 #include <string.h>
@@ -13,6 +16,29 @@
 
 #define ASU_TRNG_BYTES_PER_REQUEST	32U /* Bytes per request */
 #define ASU_TRNG_OPERATION_CMD_ID	0U  /* ASU command ID */
+
+/* No SW fallback, hard fail. Checked once on the first call, then cached */
+static bool asu_trng_fw_compatible(void)
+{
+	static bool checked;
+	static bool compatible;
+	const struct fw_module_info *mod;
+
+	if (checked)
+		return compatible;
+
+	mod = fw_compat_get_module_info(ASU_MODULE_TRNG_ID);
+	compatible = asu_module_version_at_least(mod,
+						 CFG_AMD_ASU_TRNG_MINVER_MAJ,
+						 CFG_AMD_ASU_TRNG_MINVER_MNR);
+	if (!compatible)
+		EMSG("ASU TRNG module version below minimum %u.%u",
+		     CFG_AMD_ASU_TRNG_MINVER_MAJ,
+		     CFG_AMD_ASU_TRNG_MINVER_MNR);
+
+	checked = true;
+	return compatible;
+}
 
 /* TRNG callback context */
 struct asu_trng_cbctx {
@@ -105,6 +131,9 @@ TEE_Result hw_get_random_bytes(void *buf, size_t len)
 		EMSG("Invalid parameters: buf=%p, len=%zu", buf, len);
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
+
+	if (!asu_trng_fw_compatible())
+		return TEE_ERROR_NOT_SUPPORTED;
 
 	/* Allocate unique request ID */
 	uniqueid = asu_alloc_unique_id();

--- a/core/drivers/crypto/asu_driver/crypto.mk
+++ b/core/drivers/crypto/asu_driver/crypto.mk
@@ -10,7 +10,18 @@ $(call force,CFG_CRYPTO_DRIVER,y)
 CFG_CRYPTO_DRIVER_DEBUG ?= 0
 $(call force,CFG_CRYPTO_DRV_HASH,y)
 
+# Minimum ASUFW version OP-TEE requires to boot (see fw_compat_check()).
+# Boot panics if the ASUFW version reported via RTCA is older than this.
+CFG_AMD_ASU_MINVER_MAJ ?= 2
+CFG_AMD_ASU_MINVER_MNR ?= 0
+
 CFG_AMD_ASU_HUK ?= y
+
+# Minimum ASU HUK module version required to trust the HUK fetched from
+# ASUFW (see asu_fetch_and_cache_huk()). There is no software fallback for
+# the HUK, so a mismatch is a hard error rather than a degraded mode.
+CFG_AMD_ASU_HUK_MINVER_MAJ ?= 1
+CFG_AMD_ASU_HUK_MINVER_MNR ?= 0
 
 ifeq ($(CFG_AMD_ASU_ECC),y)
 $(call force,CFG_CRYPTO_DRV_ECC,y)

--- a/core/drivers/crypto/asu_driver/crypto.mk
+++ b/core/drivers/crypto/asu_driver/crypto.mk
@@ -36,6 +36,12 @@ endif
 ifeq ($(CFG_AMD_ASU_RSA),y)
 $(call force,CFG_CRYPTO_DRV_ACIPHER,y)
 $(call force,CFG_CRYPTO_DRV_RSA,y)
+
+# Minimum ASU RSA module version required to use HW-accelerated RSA (see
+# asu_rsa_init()). Below this, or when the FeatureCaps bit for the
+# requested operation is not set, the driver falls back to software RSA.
+CFG_AMD_ASU_RSA_MINVER_MAJ ?= 2
+CFG_AMD_ASU_RSA_MINVER_MNR ?= 0
 endif
 
 ifeq ($(CFG_AMD_ASU_HMAC),y)

--- a/core/drivers/crypto/asu_driver/crypto.mk
+++ b/core/drivers/crypto/asu_driver/crypto.mk
@@ -15,6 +15,12 @@ $(call force,CFG_CRYPTO_DRV_HASH,y)
 CFG_AMD_ASU_MINVER_MAJ ?= 2
 CFG_AMD_ASU_MINVER_MNR ?= 0
 
+# Minimum ASU SHA2/SHA3 module versions (hard fail, no SW fallback)
+CFG_AMD_ASU_SHA2_MINVER_MAJ ?= 2
+CFG_AMD_ASU_SHA2_MINVER_MNR ?= 0
+CFG_AMD_ASU_SHA3_MINVER_MAJ ?= 2
+CFG_AMD_ASU_SHA3_MINVER_MNR ?= 0
+
 CFG_AMD_ASU_HUK ?= y
 
 # Minimum ASU HUK module version required to trust the HUK fetched from
@@ -26,11 +32,25 @@ CFG_AMD_ASU_HUK_MINVER_MNR ?= 0
 ifeq ($(CFG_AMD_ASU_ECC),y)
 $(call force,CFG_CRYPTO_DRV_ECC,y)
 $(call force,CFG_CRYPTO_DRV_ACIPHER,y)
+
+# Minimum ASU ECC module version; below this, or if a curve's FeatureCaps
+# bit is unset, that curve falls back to software
+CFG_AMD_ASU_ECC_MINVER_MAJ ?= 2
+CFG_AMD_ASU_ECC_MINVER_MNR ?= 0
+
+# Minimum ASU KeyManager module version, used internally by ECC HW key-pair
+# generation. Below this, key-pair generation falls back to software.
+CFG_AMD_ASU_KEYMANAGER_MINVER_MAJ ?= 1
+CFG_AMD_ASU_KEYMANAGER_MINVER_MNR ?= 0
 endif
 
 ifeq ($(CFG_AMD_ASU_CIPHER),y)
 $(call force,CFG_CRYPTO_DRV_CIPHER,y)
 CFG_AMD_ASU_SW_FALLBACK ?= y
+
+# Minimum ASU Cipher module version; below this, falls back to software
+CFG_AMD_ASU_CIPHER_MINVER_MAJ ?= 2
+CFG_AMD_ASU_CIPHER_MINVER_MNR ?= 0
 endif
 
 ifeq ($(CFG_AMD_ASU_RSA),y)
@@ -46,11 +66,23 @@ endif
 
 ifeq ($(CFG_AMD_ASU_HMAC),y)
 $(call force,CFG_CRYPTO_DRV_MAC,y)
+
+CFG_AMD_ASU_HMAC_MINVER_MAJ ?= 2
+CFG_AMD_ASU_HMAC_MINVER_MNR ?= 0
 endif
 
 ifeq ($(CFG_AMD_ASU_AUTHENC),y)
 $(call force,CFG_CRYPTO_DRV_AUTHENC,y)
 $(call force,CFG_AMD_ASU_SW_FALLBACK,y)
+
+# Minimum ASU AES module version for GCM/CCM; below this, use SW fallback
+CFG_AMD_ASU_AUTHENC_MINVER_MAJ ?= 2
+CFG_AMD_ASU_AUTHENC_MINVER_MNR ?= 0
+endif
+
+ifeq ($(CFG_AMD_ASU_TRNG),y)
+CFG_AMD_ASU_TRNG_MINVER_MAJ ?= 2
+CFG_AMD_ASU_TRNG_MINVER_MNR ?= 0
 endif
 
 ifeq ($(CFG_AMD_ASU_CMAC), y)

--- a/core/drivers/crypto/asu_driver/sub.mk
+++ b/core/drivers/crypto/asu_driver/sub.mk
@@ -12,15 +12,3 @@ srcs-$(CFG_AMD_ASU_ECC) += asu_ecc.c
 srcs-$(CFG_AMD_ASU_CIPHER) += asu_cipher.c
 srcs-$(CFG_AMD_ASU_RSA) += asu_rsa.c
 srcs-$(CFG_AMD_ASU_AUTHENC) += asu_authenc.c
-
-ifeq ($(CFG_AMD_ASU_ECC),y)
-# This curves configuration aligns enabled ECC/ECDH curves with ASU FW default
-# configurations. For the disabled curves, driver will use software fallback
-# operations. Make sure to configure ASU FW with enabled curves to prevent
-# any testcase failures
-CFG_AMD_ASU_ECC_CURVE_NIST_P192 ?= n
-CFG_AMD_ASU_ECC_CURVE_NIST_P224 ?= n
-CFG_AMD_ASU_ECC_CURVE_NIST_P256 ?= y
-CFG_AMD_ASU_ECC_CURVE_NIST_P384 ?= n
-CFG_AMD_ASU_ECC_CURVE_NIST_P521 ?= n
-endif

--- a/core/include/drivers/amd/asu_fw_info.h
+++ b/core/include/drivers/amd/asu_fw_info.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#ifndef __ASU_FW_INFO_H_
+#define __ASU_FW_INFO_H_
+
+#include <drivers/amd/asu_sharedmem.h>
+#include <drivers/amd/fw_compat.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * asu_rtca_get_fw_version() - Read the ASUFW version from RTCA
+ * @major: Returns the ASUFW major version
+ * @minor: Returns the ASUFW minor version
+ *
+ * Direct RTCA memory read, no IPI communication with ASUFW required.
+ *
+ * Return: TEE_SUCCESS on success, or an error code if RTCA could not be
+ *	   mapped.
+ */
+TEE_Result asu_rtca_get_fw_version(uint8_t *major, uint8_t *minor);
+
+/*
+ * asu_rtca_get_module_info() - Read a module's runtime info from RTCA
+ * @module_id: ASU module ID (see ASU_MODULE_*_ID in asu_client.h)
+ * @info: Returns the module's version/status/capability info
+ *
+ * Direct RTCA memory read, no IPI communication with ASUFW required.
+ *
+ * Return: TEE_SUCCESS on success, TEE_ERROR_BAD_PARAMETERS if module_id is
+ *	   out of range, or another error code if RTCA could not be mapped.
+ */
+TEE_Result asu_rtca_get_module_info(uint32_t module_id,
+				    struct asu_crypto_alg_info *info);
+
+/*
+ * asu_module_version_at_least() - Check a cached ASU module's version
+ * @mod: Module info returned by fw_compat_get_module_info()
+ * @min_major: Minimum required major version
+ * @min_minor: Minimum required minor version (only checked when @mod's
+ *	       major version equals @min_major)
+ *
+ * Decodes @mod->version using the ASU per-module Version field layout
+ * ([31:16] = major, [15:0] = minor - see struct asu_crypto_alg_info).
+ *
+ * Return: true if @mod is valid and its version is at least
+ *	   min_major.min_minor, false otherwise (including if @mod is NULL
+ *	   or was never successfully read).
+ */
+bool asu_module_version_at_least(const struct fw_module_info *mod,
+				 uint16_t min_major, uint16_t min_minor);
+
+#endif /* __ASU_FW_INFO_H_ */

--- a/core/include/drivers/amd/asu_sharedmem.h
+++ b/core/include/drivers/amd/asu_sharedmem.h
@@ -69,4 +69,52 @@ struct asu_channel_memory {
 	struct asu_channel_queue p1_chnl_q;
 };
 
+/*
+ * ASUFW firmware version register. Bits [15:8] hold the major version and
+ * bits [7:0] the minor version. Firmware predating this register reads
+ * back as 0 (version unknown / pre-v2.0).
+ */
+#define ASU_RTCA_FW_VERSION_OFFSET	0x1A0U
+#define ASU_FW_VERSION_MAJOR_SHIFT	8U
+#define ASU_FW_VERSION_MAJOR_MASK	0x0000FF00U
+#define ASU_FW_VERSION_MINOR_MASK	0x000000FFU
+
+/*
+ * Per-module crypto capability info array (XAsu_CryptoAlgInfo in ASUFW),
+ * indexed by ASU module ID (see ASU_MODULE_*_ID in asu_client.h).
+ */
+#define ASU_RTCA_MODULE_INFO_OFFSET	0x00A8U
+#define ASU_RTCA_MODULE_INFO_STRIDE	12U
+#define ASU_RTCA_MODULE_COUNT		14U
+
+/*
+ * Per-module Version field layout (offset 0 of struct asu_crypto_alg_info):
+ * bits [31:16] hold the module's major version, bits [15:0] the minor
+ * version. This is a separate, per-module counter from the overall ASUFW
+ * version register above.
+ */
+#define ASU_MODULE_VERSION_MAJOR_SHIFT	16U
+#define ASU_MODULE_VERSION_MAJOR_MASK	0xFFFF0000U
+#define ASU_MODULE_VERSION_MINOR_MASK	0x0000FFFFU
+
+/*
+ * FeatureCaps bit shared by optional modules (HUK, HMAC, KDF, ECIES,
+ * Keywrap, OCP, KeyManager, LMS) to indicate the module is present in the
+ * current ASUFW build. Always-enabled modules (TRNG, ECC, RSA, AES) use
+ * this same field for per-algorithm/curve capability bits instead.
+ */
+#define ASU_MODULE_CAP_ENABLED		BIT(0)
+
+/*
+ * Per-module runtime info exposed by ASUFW at
+ * RTCA + ASU_RTCA_MODULE_INFO_OFFSET
+ */
+struct asu_crypto_alg_info {
+	uint32_t version;
+	uint8_t nist_status;
+	uint8_t kat_status;
+	uint16_t feature_caps;
+	uint32_t reserved4;
+};
+
 #endif /* __ASU_SHAREDMEM_H_ */

--- a/core/include/drivers/amd/asu_sharedmem.h
+++ b/core/include/drivers/amd/asu_sharedmem.h
@@ -105,6 +105,12 @@ struct asu_channel_memory {
  */
 #define ASU_MODULE_CAP_ENABLED		BIT(0)
 
+/* RSA module (ASU_MODULE_RSA_ID) FeatureCaps bits - always-enabled module */
+#define ASU_RSA_CAP_PADDING		BIT(0)
+#define ASU_RSA_CAP_2048_KEYGEN		BIT(1)
+#define ASU_RSA_CAP_3072_KEYGEN		BIT(2)
+#define ASU_RSA_CAP_4096_KEYGEN		BIT(3)
+
 /*
  * Per-module runtime info exposed by ASUFW at
  * RTCA + ASU_RTCA_MODULE_INFO_OFFSET

--- a/core/include/drivers/amd/asu_sharedmem.h
+++ b/core/include/drivers/amd/asu_sharedmem.h
@@ -105,6 +105,17 @@ struct asu_channel_memory {
  */
 #define ASU_MODULE_CAP_ENABLED		BIT(0)
 
+/*
+ * ECC module (ASU_MODULE_ECC_ID) FeatureCaps bits - always-enabled module.
+ * Only the NIST curves supported by this driver are defined here; see
+ * ASUFW xasufw_alginfo.h (XASU_ECC_CAP_*) for the full bit layout.
+ */
+#define ASU_ECC_CAP_NIST_P192		BIT(1)
+#define ASU_ECC_CAP_NIST_P224		BIT(2)
+#define ASU_ECC_CAP_NIST_P256		BIT(3)
+#define ASU_ECC_CAP_NIST_P384		BIT(4)
+#define ASU_ECC_CAP_NIST_P521		BIT(5)
+
 /* RSA module (ASU_MODULE_RSA_ID) FeatureCaps bits - always-enabled module */
 #define ASU_RSA_CAP_PADDING		BIT(0)
 #define ASU_RSA_CAP_2048_KEYGEN		BIT(1)

--- a/core/include/drivers/amd/fw_compat.h
+++ b/core/include/drivers/amd/fw_compat.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#ifndef __FW_COMPAT_H_
+#define __FW_COMPAT_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * Per-module version/capability snapshot, populated once at boot by
+ * fw_compat_check() and read-only afterwards. @version and @feature_caps
+ * use the backend's native encoding (for ASUFW see struct
+ * asu_crypto_alg_info). @valid is false if the module could not be read
+ * or fw_compat_check() has not run yet.
+ */
+struct fw_module_info {
+	uint32_t version;
+	uint16_t feature_caps;
+	bool valid;
+};
+
+/*
+ * fw_compat_check() - Validate underlying firmware compatibility at boot
+ *
+ * Queries the version of each configured firmware backend and logs the
+ * detected version, and validates it against the build-time configured
+ * minimum (CFG_AMD_ASU_MINVER_MAJ / _MNR). On success, also reads and
+ * caches every module's per-module version and feature capabilities for
+ * later retrieval through fw_compat_get_module_info().
+ */
+void fw_compat_check(void);
+
+/*
+ * fw_compat_get_module_info() - Retrieve a module's cached version/capability
+ * @module_id: Backend-specific module ID (see ASU_MODULE_*_ID for ASUFW)
+ *
+ * Must be called after fw_compat_check() has run (i.e. from a driver_init()
+ * or later, never before the backend that owns module_id has finished
+ * initializing).
+ *
+ * Return: Pointer to the module's cached info, or NULL if module_id is out
+ *	   of range or the owning backend never successfully initialized.
+ *	   Callers must still check the returned entry's "valid" field.
+ */
+const struct fw_module_info *fw_compat_get_module_info(uint32_t module_id);
+
+#endif /* __FW_COMPAT_H_ */


### PR DESCRIPTION
ASUFW exposes its firmware version and per-module version/FeatureCaps bitmask. This series adds a common FW-compatibility API and wires it into the ASU crypto drivers
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
