### PR TITLE
drivers: qcom: rpmh: fix TCS stall during rpmh_send_command()

### DIFF
--- a/core/drivers/qcom/rpmh/rpmh_hal.c
+++ b/core/drivers/qcom/rpmh/rpmh_hal.c
@@ -230,9 +230,9 @@ enum hal_status hal_rpmh_write_cmd(enum rsc_drv_id drv_id,
 	cmd_base = tcs_base + TCS_CMD_BASE_OFFSET + (cmd_idx * TCS_CMD_STRIDE);
 
 	msgid = 0;
-	msgid |= SHIFT_U32(0, MSGID_READ_OR_WRITE_SHIFT);
+	msgid |= SHIFT_U32(MSGID_WRITE, MSGID_READ_OR_WRITE_SHIFT);
 	msgid |= SHIFT_U32((completion ? 1 : 0), MSGID_RES_REQ_SHIFT);
-	msgid |= SHIFT_U32(1, MSGID_MSG_LENGTH_SHIFT);
+	msgid |= SHIFT_U32(MSGID_MSG_LENGTH_VALUE, MSGID_MSG_LENGTH_SHIFT);
 
 	slave_id = (addr >> 16) & 0x7;
 	offset = addr & 0xFFFF;

--- a/core/drivers/qcom/rpmh/rpmh_hal.h
+++ b/core/drivers/qcom/rpmh/rpmh_hal.h
@@ -53,6 +53,12 @@ enum hal_status {
 #define MSGID_RES_REQ_SHIFT		0x8
 #define MSGID_MSG_LENGTH_SHIFT		0x0
 
+#define MSGID_READ			0x0
+#define MSGID_WRITE			0x1
+
+/* Each RPMh command transfers a single 32-bit word (encoded as 8 bytes). */
+#define MSGID_MSG_LENGTH_VALUE		0x8
+
 #define ADDR_SLV_ID_SHIFT		0x10
 #define ADDR_OFFSET_SHIFT		0x0
 


### PR DESCRIPTION
## Background
hal_rpmh_write_cmd() [with the immediate call hierarchy being rpmh_send_command() -> issue_cmd_set_internal() -> hal_rpmh_write_cmd()] builds the MSGID for every command issued to
RPMh, encoding two fields incorrectly:

- Direction bit encoded as READ, although this function is only
  ever used to issue writes. RPMh commands are inherently either a
  read (fetch current value, no payload) or a write (apply a
  payload) - the direction bit must match which one is actually
  happening, and here it did not.
- Length field encoded as 1 byte, although every command issued by
  this driver carries a single 32-bit data word, i.e. 8 bytes. The
  length tells AOP how much payload to expect for the command; 1
  does not match the 8-byte word actually written into the TCS's
  data register.


AOP uses MSGID's direction and length fields to parse each command.
When they don't match (what's actually in the command), AOP's behavior is
undefined. In practice this can mean the command is never acknowledged at all, 
so the RSC leaves the addressed TCS stuck in a busy/triggered state
indefinitely, waiting on a response that never arrives.

The caller sees only a generic timeout well. One of the side effects: 
clk_set_rate() fails with TEE_ERROR_BUSY, with no direct indication 
that the root cause is a malformed RPMh command.

## Fix
Encode the direction bit as WRITE and the length field as 8 bytes,
matching what hal_rpmh_write_cmd() actually issues.

## Testing
Verified on Lemans EVK hardware: clk_set_rate()
calls that previously failed with TEE_ERROR_BUSY (RPMh command
never acknowledged, TCS left stuck busy) now complete successfully.

Unit testing done on Nord device, which involved testing 
ARC (MX, CX) and BCM (MC0, SH0) voting which are Succeeding,
and deliberate wrong address testing which is failing.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
