### PR TITLE
ta: avb: do not silently truncate persistent values

### DIFF
--- a/ta/avb/entry.c
+++ b/ta/avb/entry.c
@@ -299,7 +299,8 @@ out:
 }
 
 static TEE_Result read_persist_value(uint32_t pt,
-				      TEE_Param params[TEE_NUM_PARAMS])
+				     TEE_Param params[TEE_NUM_PARAMS],
+				     bool truncate)
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 						TEE_PARAM_TYPE_MEMREF_INOUT,
@@ -309,6 +310,7 @@ static TEE_Result read_persist_value(uint32_t pt,
 			 TEE_DATA_FLAG_ACCESS_WRITE;
 	TEE_Result res = TEE_SUCCESS;
 	TEE_ObjectHandle h = TEE_HANDLE_NULL;
+	TEE_ObjectInfo info = { };
 	char name_full[TEE_OBJECT_ID_MAX_LEN];
 	uint32_t name_full_sz = 0;
 	uint32_t name_buf_sz = 0;
@@ -337,6 +339,27 @@ static TEE_Result read_persist_value(uint32_t pt,
 	if (res) {
 		EMSG("Can't open named object value, res = 0x%x", res);
 		goto out_free;
+	}
+
+	if (!truncate) {
+		/*
+		 * For TA_AVB_CMD_READ_PERSIST_VALUE2, do not silently
+		 * return a truncated result. Instead, inform the
+		 * caller of the true size of the value and return
+		 * TEE_ERROR_SHORT_BUFFER so that the caller can
+		 * allocate a large enough buffer and retry.
+		 */
+		res = TEE_GetObjectInfo1(h, &info);
+		if (res) {
+			EMSG("Can't get object info, res = 0x%"PRIx32, res);
+			goto out;
+		}
+
+		if (info.dataSize > value_sz) {
+			params[1].memref.size = info.dataSize;
+			res = TEE_ERROR_SHORT_BUFFER;
+			goto out;
+		}
 	}
 
 	res =  TEE_ReadObjectData(h, value, value_sz, &count);
@@ -389,7 +412,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd,
 	case TA_AVB_CMD_WRITE_LOCK_STATE:
 		return write_lock_state(pt, params);
 	case TA_AVB_CMD_READ_PERSIST_VALUE:
-		return read_persist_value(pt, params);
+		return read_persist_value(pt, params, true /* truncate */);
+	case TA_AVB_CMD_READ_PERSIST_VALUE2:
+		return read_persist_value(pt, params, false /* !truncate */);
 	case TA_AVB_CMD_WRITE_PERSIST_VALUE:
 		return write_persist_value(pt, params);
 	default:

--- a/ta/avb/include/ta_avb.h
+++ b/ta/avb/include/ta_avb.h
@@ -47,6 +47,7 @@
 
 /*
  * Reads a persistent value corresponding to the given name.
+ * Only reads as much of the value as will fit in the provided buffer.
  *
  * in	params[0].memref:	persistent value name
  * out	params[1].memref:	read persistent value buffer
@@ -60,5 +61,16 @@
  * in	params[1].memref:	persistent value buffer to write
  */
 #define TA_AVB_CMD_WRITE_PERSIST_VALUE	5
+
+/*
+ * Reads a persistent value corresponding to the given name.
+ * If the provided buffer is smaller than the value, returns
+ * TEE_ERROR_SHORT_BUFFER and sets the output buffer size to the true
+ * size of the value.
+ *
+ * in	params[0].memref:	persistent value name
+ * out	params[1].memref:	read persistent value buffer
+ */
+#define TA_AVB_CMD_READ_PERSIST_VALUE2	6
 
 #endif /*__TA_AVB_H*/


### PR DESCRIPTION
According to
https://android.googlesource.com/platform/external/avb/+/master/libavb/avb_ops.h#270, callers of the "read persistent value" API are supposed to be able to discover whether they have supplied a too small buffer, and try again with a correctly sized buffer.

However, the necessary logic was never implemented on the tee side, and since the code has been like this for over 6 years, there may be callers relying on the current "get a truncated read if buffer is too small".

Without a new API to discover the true size of a persistent value, callers can never be written in a way that they know they didn't get a truncated value. So this introduces such an API.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
