### PR TITLE
core: spmc: fix tx buffer overrun in the retrieve response

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -492,6 +492,7 @@ check_retrieve_request(struct sp_mem_receiver *receiver, uint32_t ffa_vers,
 	uint32_t retr_flags = mem_trans->flags;
 	uint64_t retr_tag = mem_trans->tag;
 	struct sp_mem_map_region *reg = NULL;
+	size_t mem_acc_size = 0;
 
 	/*
 	 * The request came from the endpoint. It should only have one
@@ -528,14 +529,17 @@ check_retrieve_request(struct sp_mem_receiver *receiver, uint32_t ffa_vers,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	/*
-	 * Check if there is enough space in the tx buffer to send the respons.
-	 */
+	/* Check that the response fits in the tx buffer. */
+	if (ffa_vers <= FFA_VERSION_1_1)
+		mem_acc_size = sizeof(struct ffa_mem_access_1_0);
+	else
+		mem_acc_size = sizeof(struct ffa_mem_access_1_2);
+
 	if (ffa_vers <= FFA_VERSION_1_0)
 		tx_len -= sizeof(struct ffa_mem_transaction_1_0);
 	else
 		tx_len -= sizeof(struct ffa_mem_transaction_1_1);
-	tx_len -= mem_trans->mem_access_size + sizeof(struct ffa_mem_region);
+	tx_len -= mem_acc_size + sizeof(struct ffa_mem_region);
 
 	if (tx_len < 0)
 		return FFA_NO_MEMORY;


### PR DESCRIPTION
check_retrieve_request() decides whether the FFA_MEM_RETRIEVE_RESP fits in the endpoint's tx buffer by subtracting the requester-supplied mem_access_size from the buffer length. create_retrieve_response() instead writes the response using the SPMC's own access descriptor size (struct ffa_mem_access_1_0 for FF-A <= 1.1, struct ffa_mem_access_1_2 for 1.2), and its address range loop writes one struct ffa_address_range per shared region without checking the space left.

An endpoint that retrieves with a mem_access_size smaller than the size the SPMC writes makes the estimate over-count the free space, so the check passes while the response is written past the end of the tx buffer. A malicious S-EL0 SP can drive this by negotiating FF-A 1.2, using a mem_access_size of sizeof(struct ffa_mem_access_common) and controlling how many regions the memory was shared with, causing the S-EL1 SPMC to write out of bounds into the SP's tx buffer.

Reserve the space using the same access descriptor size create_retrieve_response() writes, so the estimate matches the write.

Fixes: d45fc1401c57 ("core: ffa: add missing field in memory access descriptor")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
