### PR TITLE
core: tee_ta_manager: hold busy while destroying a panicked session

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -468,14 +468,22 @@ static void close_session(struct tee_ta_session *sess,
 	}
 
 	ctx = ts_to_ta_ctx(ts_ctx);
-	if (ctx->panicked) {
-		destroy_session(sess, open_sessions);
-	} else {
-		tee_ta_set_busy(ctx);
-		set_invoke_timeout(sess, TEE_TIMEOUT_INFINITE);
-		ts_ctx->ops->enter_close_session(&sess->ts_sess);
+	if (tee_ta_try_set_busy(ctx)) {
+		if (!ctx->panicked) {
+			set_invoke_timeout(sess, TEE_TIMEOUT_INFINITE);
+			ts_ctx->ops->enter_close_session(&sess->ts_sess);
+		}
 		destroy_session(sess, open_sessions);
 		tee_ta_clear_busy(ctx);
+	} else {
+		/*
+		 * Deadlock avoided: ctx is already busy and we're
+		 * holding the single-instance lock, so we can't
+		 * safely enter the TA to run its close entry point,
+		 * regardless of whether it has panicked. Tear down
+		 * the session state without the busy protection.
+		 */
+		destroy_session(sess, open_sessions);
 	}
 
 	mutex_lock(&tee_ta_mutex);


### PR DESCRIPTION
close_session() called destroy_session() without tee_ta_set_busy() when the context had panicked. For a SINGLE_INSTANCE + MULTI_SESSION TA the struct tee_ta_ctx is shared and may only be accessed while it is busy/ locked by the current thread. destroy_session() can still touch that context, so running it outside the busy section can race a sibling session that holds the single-instance lock.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
