### PR TITLE
core: rcar-gen5: Add Renesas R-Car Gen5 support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -340,6 +340,11 @@ R:	Volodymyr Babchuk <vlad.babchuk@gmail.com> [@lorc]
 S:	Maintained
 F:	core/arch/arm/plat-rcar/
 
+Renesas RCAR Gen5
+R:	Marek Vasut <marek.vasut+renesas@mailbox.org> [@marex]
+S:	Maintained
+F:	core/arch/arm/plat-rcar_gen5/
+
 Renesas RZ/G2
 R:	Lad Prabhakar <prabhakar.mahadev-lad.rj@bp.renesas.com> [@prabhakarlad]
 R:	Biju Das <biju.das.jz@bp.renesas.com> [@bijucdas]

--- a/core/arch/arm/plat-rcar_gen5/conf.mk
+++ b/core/arch/arm/plat-rcar_gen5/conf.mk
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2025-2026, Renesas Electronics Corporation.
+#
+
+PLATFORM_FLAVOR ?= X5H
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_SCIF,y)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+# Disable core ASLR until there is RNG driver.
+$(call force,CFG_CORE_ASLR,n)
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_WITH_LPAE,y)
+$(call force,CFG_DYN_CONFIG,n)
+
+ifeq ($(PLATFORM_FLAVOR), X5H)
+$(call force,CFG_RCAR_GEN5, y)
+endif
+
+ifneq ($(CFG_CORE_HAFNIUM_INTC),y)
+$(call force,CFG_GIC,y)
+CFG_ARM_GICV3 ?= y
+endif
+CFG_CRYPTO_WITH_CE ?= n
+CFG_TZDRAM_START ?= 0x8C400000
+CFG_TZDRAM_SIZE  ?= 0x02000000
+CFG_TEE_RAM_VA_SIZE ?= 0x100000
+supported-ta-targets = ta_arm64
+CFG_DT ?= n
+CFG_WITH_SOFTWARE_PRNG ?= y
+
+ifeq ($(CFG_RCAR_GEN5),y)
+$(call force,CFG_CORE_CLUSTER_SHIFT,2) # 4 cores per cluster
+$(call force,CFG_TEE_CORE_NB_CORE,32)
+CFG_NUM_THREADS ?= $(CFG_TEE_CORE_NB_CORE)
+CFG_MMAP_REGIONS ?= 21
+endif
+
+# For virtualization
+ifeq ($(CFG_NS_VIRTUALIZATION),y)
+CFG_VIRT_GUEST_COUNT ?= 3
+CFG_CORE_RESERVED_SHM ?= n
+endif

--- a/core/arch/arm/plat-rcar_gen5/link.mk
+++ b/core/arch/arm/plat-rcar_gen5/link.mk
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2025-2026, Renesas Electronics Corporation.
+#
+
+include core/arch/arm/kernel/link.mk
+
+SRECFLAGS ?= --srec-forceS3 --adjust-vma=$(CFG_TZDRAM_START)
+
+all: $(link-out-dir)/tee.srec

--- a/core/arch/arm/plat-rcar_gen5/main.c
+++ b/core/arch/arm/plat-rcar_gen5/main.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025-2026, Renesas Electronics Corporation.
+ */
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/hfic.h>
+#include <drivers/scif.h>
+#include <kernel/boot.h>
+#include <platform_config.h>
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(GICD_BASE, CORE_MMU_PGDIR_SIZE),
+			ROUNDUP(GIC_DIST_REG_SIZE, CORE_MMU_PGDIR_SIZE));
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(MAP_DEV_REG_RCAR_BASE, CORE_MMU_PGDIR_SIZE),
+			ROUNDUP(MAP_DEV_REG_RCAR_SIZE, CORE_MMU_PGDIR_SIZE));
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(NONCACHE_WORK_BASE, CORE_MMU_PGDIR_SIZE),
+			ROUNDUP(NONCACHE_WORK_SIZE, CORE_MMU_PGDIR_SIZE));
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(OPTEE_LOG_BASE, CORE_MMU_PGDIR_SIZE),
+			ROUNDUP(OPTEE_LOG_SIZE, CORE_MMU_PGDIR_SIZE));
+
+static struct scif_uart_data console_data __nex_bss;
+
+void boot_primary_init_intc(void)
+{
+#ifdef CFG_CORE_HAFNIUM_INTC
+	hfic_init();
+#else
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+#endif
+}
+
+#ifdef CFG_GIC
+void boot_secondary_init_intc(void)
+{
+	gic_init_per_cpu();
+}
+#endif /* CFG_GIC */
+
+void plat_console_init(void)
+{
+	scif_uart_init(&console_data, CONSOLE_UART_BASE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-rcar_gen5/platform_config.h
+++ b/core/arch/arm/plat-rcar_gen5/platform_config.h
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025-2026, Renesas Electronics Corporation.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#define RCAR_CACHE_LINE_SZ		64
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT			RCAR_CACHE_LINE_SZ
+
+#if defined(CFG_RCAR_GEN5)
+#define GICD_BASE			0x39000000
+#define GICR_BASE			0x39080000
+
+#define CONSOLE_UART_BASE		0xC0710000
+/* Config for MMU mapping */
+#define RCAR_SRAM_BASE			CFG_TZDRAM_START
+#define TZDRAM_BASE			RCAR_SRAM_BASE
+#define TZDRAM_SIZE			0x02000000U	/* 32*1024*1024 */
+
+/* TEE RAM address and size */
+#define TEE_RAM_START			RCAR_SRAM_BASE
+#define TEE_RAM_SIZE			0x00300000U
+
+#ifdef CFG_TEE_RAM_VA_SIZE
+#define TEE_RAM_PH_SIZE			TEE_RAM_SIZE
+#endif
+
+#ifndef TEE_LOAD_ADDR
+#define TEE_LOAD_ADDR			TEE_RAM_START
+#endif
+
+/* TA RAM address and size */
+#define TA_RAM_START			(TEE_RAM_START + TEE_RAM_SIZE)
+#define TA_RAM_SIZE			0x01400000U
+
+/* OP-TEE Log Area address and size */
+#define OPTEE_LOG_BASE			(TA_RAM_START + TA_RAM_SIZE)
+#define OPTEE_LOG_SIZE			0x900000U
+
+/* Non Cache Area address and size */
+#define NONCACHE_WORK_BASE		(OPTEE_LOG_BASE + OPTEE_LOG_SIZE)
+#define NONCACHE_WORK_SIZE		0x00100000U
+
+/* Shared Memory address and size */
+#define TEE_SHMEM_START			(NONCACHE_WORK_BASE + 0x1D00000U)
+#define TEE_SHMEM_SIZE			0x00100000U
+
+/* For Soc Register mapping function */
+#define MAP_DEV_REG_RCAR_BASE		0xC0400000
+#define MAP_DEV_REG_RCAR_SIZE		0x1FC00000
+
+#ifdef CFG_WITH_LPAE
+#define MAX_XLAT_TABLES	CFG_MMAP_REGIONS
+#endif
+
+#endif /* CFG_RCAR_GEN5 */
+
+#endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-rcar_gen5/sub.mk
+++ b/core/arch/arm/plat-rcar_gen5/sub.mk
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2025-2026, Renesas Electronics Corporation.
+#
+
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
Add initial support for Renesas R-Car Gen5 and X5H R8A78000 SoC. The initial support includes basic platform support, MMU table configuration, configuration for 32 cores in 8 clusters with 4 cores each, and optional HFIC support.