### PR TITLE
core storage: clear enum state after failed start

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -606,17 +606,20 @@ TEE_Result syscall_storage_start_enum(unsigned long obj_enum,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	if (e->dir) {
+	if (e->dir)
 		e->fops->closedir(e->dir);
-		e->dir = NULL;
-	}
+
+	e->dir = NULL;
+	e->fops = NULL;
 
 	if (!fops)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	e->fops = fops;
+	res = fops->opendir(&sess->ctx->uuid, &e->dir);
+	if (!res)
+		e->fops = fops;
 
-	return fops->opendir(&sess->ctx->uuid, &e->dir);
+	return res;
 }
 
 TEE_Result syscall_storage_next_enum(unsigned long obj_enum,


### PR DESCRIPTION
Do not retain file operations for an enumerator whose directory could not be opened. 
This makes a subsequent GetNext return ITEM_NOT_FOUND instead of dereferencing a NULL directory handle.

`TEE_StartPersistentObjectEnumerator()` can return
`TEE_ERROR_ITEM_NOT_FOUND` with its file operations retained and its
directory handle set to NULL.

A subsequent `TEE_GetNextPersistentObject()` then treats the enumerator
as started, dereferences the NULL directory handle, and aborts the
Secure Core.

Only assign file operations after `opendir()` succeeds, leaving the
enumerator unstarted on failure. A subsequent GetNext then returns
`TEE_ERROR_ITEM_NOT_FOUND`.

Tested with:

    make -j2 CHECK_TESTS=xtest XTEST_ARGS=6010 check
