### PR TITLE
libutee: fix digest final short-buffer handling after extraction

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -950,8 +950,13 @@ TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, const void *chunk,
 		 * This is not an Extendable-Output Function and we have
 		 * already started extracting
 		 */
-		len = MIN(operation->block_size - operation->buffer_offs,
-			  *hashLen);
+		len = operation->block_size - operation->buffer_offs;
+		if (*hashLen < len) {
+			*hashLen = len;
+			res = TEE_ERROR_SHORT_BUFFER;
+			goto out;
+		}
+
 		memcpy(hash, operation->buffer + operation->buffer_offs, len);
 		*hashLen = len;
 	} else {


### PR DESCRIPTION
For a non-XOF operation in extracting state, TEE_DigestDoFinal() currently truncates the remaining digest to the output buffer size and returns success. This finalizes the operation even though the caller cannot retrieve the complete digest.

GP TEE Internal Core API v1.3.1 §6.3.2 requires non-XOF operations to return TEE_ERROR_SHORT_BUFFER without finalizing in this case.

Return TEE_ERROR_SHORT_BUFFER with the required remaining length before copying, leaving the operation in extracting state for a retry.