### PR TITLE
core: riscv: accelerate AES with the Zvkned and Zvkb vector crypto extension

### DIFF
--- a/core/arch/riscv/crypto/riscv_aes_macros.S
+++ b/core/arch/riscv/crypto/riscv_aes_macros.S
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+/*
+ * Round key load. The schedule is a run of consecutive 16-byte round keys,
+ * as produced by crypto_accel_aes_expand_keys(), and is held one key per
+ * vector register: v1..v11 for AES-128, v1..v13 for AES-192 and v1..v15
+ * for AES-256.
+ *
+ * The .vs forms of the AES instructions take their round key from element
+ * group 0 of vs2 and broadcast it across every element group of vd, so the
+ * keys are loaded with vl = 4 and SEW = 32 whatever vl the data is later
+ * processed with.
+ *
+ * rounds selects the schedule length and must be the register holding the
+ * round count, which differs between the modes, so every caller passes it
+ * explicitly rather than relying on a fixed argument register.
+ */
+	.macro aes_load_schedule key, rounds, l128, l192
+	vsetivli	zero, 4, e32, m1, ta, ma
+	vle32.v		v1, (\key)
+	addi		t1, \key, 16
+	vle32.v		v2, (t1)
+	addi		t1, \key, 32
+	vle32.v		v3, (t1)
+	addi		t1, \key, 48
+	vle32.v		v4, (t1)
+	addi		t1, \key, 64
+	vle32.v		v5, (t1)
+	addi		t1, \key, 80
+	vle32.v		v6, (t1)
+	addi		t1, \key, 96
+	vle32.v		v7, (t1)
+	addi		t1, \key, 112
+	vle32.v		v8, (t1)
+	addi		t1, \key, 128
+	vle32.v		v9, (t1)
+	addi		t1, \key, 144
+	vle32.v		v10, (t1)
+	addi		t1, \key, 160
+	vle32.v		v11, (t1)
+	li		t0, 10
+	beq		\rounds, t0, \l128
+	addi		t1, \key, 176
+	vle32.v		v12, (t1)
+	addi		t1, \key, 192
+	vle32.v		v13, (t1)
+	li		t0, 12
+	beq		\rounds, t0, \l192
+	addi		t1, \key, 208
+	vle32.v		v14, (t1)
+	addi		t1, \key, 224
+	vle32.v		v15, (t1)
+	.endm
+
+/*
+ * Encrypt the block or blocks held in \data in place. vl and vtype select
+ * how many blocks are done at once.
+ */
+	.macro aes_encrypt data, rounds
+	vaesz.vs	\data, v1
+	vaesem.vs	\data, v2
+	vaesem.vs	\data, v3
+	vaesem.vs	\data, v4
+	vaesem.vs	\data, v5
+	vaesem.vs	\data, v6
+	vaesem.vs	\data, v7
+	vaesem.vs	\data, v8
+	vaesem.vs	\data, v9
+	vaesem.vs	\data, v10
+	.if \rounds == 10
+	vaesef.vs	\data, v11
+	.elseif \rounds == 12
+	vaesem.vs	\data, v11
+	vaesem.vs	\data, v12
+	vaesef.vs	\data, v13
+	.else
+	vaesem.vs	\data, v11
+	vaesem.vs	\data, v12
+	vaesem.vs	\data, v13
+	vaesem.vs	\data, v14
+	vaesef.vs	\data, v15
+	.endif
+	.endm
+
+/*
+ * Decrypt in place. Zvkned's decryption rounds apply InvMixColumns after
+ * AddRoundKey, so the encryption schedule is reused in reverse order and
+ * no separate inverse schedule is needed.
+ */
+	.macro aes_decrypt data, rounds
+	.if \rounds == 10
+	vaesz.vs	\data, v11
+	.elseif \rounds == 12
+	vaesz.vs	\data, v13
+	vaesdm.vs	\data, v12
+	vaesdm.vs	\data, v11
+	.else
+	vaesz.vs	\data, v15
+	vaesdm.vs	\data, v14
+	vaesdm.vs	\data, v13
+	vaesdm.vs	\data, v12
+	vaesdm.vs	\data, v11
+	.endif
+	vaesdm.vs	\data, v10
+	vaesdm.vs	\data, v9
+	vaesdm.vs	\data, v8
+	vaesdm.vs	\data, v7
+	vaesdm.vs	\data, v6
+	vaesdm.vs	\data, v5
+	vaesdm.vs	\data, v4
+	vaesdm.vs	\data, v3
+	vaesdm.vs	\data, v2
+	vaesdf.vs	\data, v1
+	.endm

--- a/core/arch/riscv/crypto/riscv_aes_zvkned.c
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned.c
@@ -53,3 +53,37 @@ void crypto_accel_aes_ecb_dec(void *out, const void *in, const void *key,
 			      round_count);
 	thread_kernel_disable_vector(state);
 }
+
+void crypto_accel_aes_cbc_enc(void *out, const void *in, const void *key,
+			      unsigned int round_count,
+			      unsigned int block_count, void *iv)
+{
+	uint32_t state = 0;
+
+	assert(iv);
+	if (!aes_accel_args_ok(out, in, key, round_count) || !block_count)
+		return;
+
+	state = thread_kernel_enable_vector();
+	riscv_aes_cbc_encrypt(key, in, out,
+			      (size_t)block_count * TEE_AES_BLOCK_SIZE, iv,
+			      round_count);
+	thread_kernel_disable_vector(state);
+}
+
+void crypto_accel_aes_cbc_dec(void *out, const void *in, const void *key,
+			      unsigned int round_count,
+			      unsigned int block_count, void *iv)
+{
+	uint32_t state = 0;
+
+	assert(iv);
+	if (!aes_accel_args_ok(out, in, key, round_count) || !block_count)
+		return;
+
+	state = thread_kernel_enable_vector();
+	riscv_aes_cbc_decrypt(key, in, out,
+			      (size_t)block_count * TEE_AES_BLOCK_SIZE, iv,
+			      round_count);
+	thread_kernel_disable_vector(state);
+}

--- a/core/arch/riscv/crypto/riscv_aes_zvkned.c
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ *
+ * AES acceleration built on the RISC-V Zvkned vector crypto extension.
+ */
+
+#include <assert.h>
+#include <crypto/crypto_accel.h>
+#include <kernel/thread.h>
+#include <utee_defines.h>
+
+#include "riscv_aes_zvkned.h"
+
+static bool aes_accel_args_ok(const void *out, const void *in,
+			      const void *key, unsigned int round_count)
+{
+	assert(out && in && key);
+	assert(round_count == 10 || round_count == 12 ||
+	       round_count == 14);
+
+	return out && in && key;
+}
+
+void crypto_accel_aes_ecb_enc(void *out, const void *in, const void *key,
+			      unsigned int round_count,
+			      unsigned int block_count)
+{
+	uint32_t state = 0;
+
+	if (!aes_accel_args_ok(out, in, key, round_count) || !block_count)
+		return;
+
+	state = thread_kernel_enable_vector();
+	riscv_aes_ecb_encrypt(key, in, out,
+			      (size_t)block_count * TEE_AES_BLOCK_SIZE,
+			      round_count);
+	thread_kernel_disable_vector(state);
+}
+
+void crypto_accel_aes_ecb_dec(void *out, const void *in, const void *key,
+			      unsigned int round_count,
+			      unsigned int block_count)
+{
+	uint32_t state = 0;
+
+	if (!aes_accel_args_ok(out, in, key, round_count) || !block_count)
+		return;
+
+	state = thread_kernel_enable_vector();
+	riscv_aes_ecb_decrypt(key, in, out,
+			      (size_t)block_count * TEE_AES_BLOCK_SIZE,
+			      round_count);
+	thread_kernel_disable_vector(state);
+}

--- a/core/arch/riscv/crypto/riscv_aes_zvkned.h
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+#ifndef __RISCV_AES_ZVKNED_H
+#define __RISCV_AES_ZVKNED_H
+
+#include <types_ext.h>
+
+/*
+ * @key points at the expanded schedule produced by
+ * crypto_accel_aes_expand_keys(), which is shared with the other modes and
+ * is not part of this file. @len is a non-zero whole number of AES
+ * blocks and @rounds is 10, 12 or 14. The caller owns the vector unit for
+ * the duration of the call.
+ */
+void riscv_aes_ecb_encrypt(const void *key, const void *src, void *dst,
+			   size_t len, unsigned int rounds);
+void riscv_aes_ecb_decrypt(const void *key, const void *src, void *dst,
+			   size_t len, unsigned int rounds);
+
+#endif /* __RISCV_AES_ZVKNED_H */

--- a/core/arch/riscv/crypto/riscv_aes_zvkned.h
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned.h
@@ -20,4 +20,10 @@ void riscv_aes_ecb_encrypt(const void *key, const void *src, void *dst,
 void riscv_aes_ecb_decrypt(const void *key, const void *src, void *dst,
 			   size_t len, unsigned int rounds);
 
+/* As above, and @iv is the chaining value, updated in place */
+void riscv_aes_cbc_encrypt(const void *key, const void *src, void *dst,
+			   size_t len, void *iv, unsigned int rounds);
+void riscv_aes_cbc_decrypt(const void *key, const void *src, void *dst,
+			   size_t len, void *iv, unsigned int rounds);
+
 #endif /* __RISCV_AES_ZVKNED_H */

--- a/core/arch/riscv/crypto/riscv_aes_zvkned_rv64.S
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned_rv64.S
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ *
+ * AES ECB using the RISC-V Zvkned vector crypto extension.
+ */
+
+#include <asm.S>
+
+	.option arch, +v, +zvkned
+
+#include "riscv_aes_macros.S"
+
+/*
+ * void riscv_aes_ecb_encrypt(const void *key, const void *src, void *dst,
+ *			      size_t len, unsigned int rounds)
+ * void riscv_aes_ecb_decrypt(const void *key, const void *src, void *dst,
+ *			      size_t len, unsigned int rounds)
+ *
+ * a0 key, a1 src, a2 dst, a3 len in bytes, a4 rounds. len is a whole
+ * number of 16-byte blocks and is not zero, both checked by the caller.
+ */
+#define KEYP	a0
+#define INP	a1
+#define OUTP	a2
+#define LEN	a3
+#define ROUNDS	a4
+
+	.macro aes_ecb_body enc, rounds
+	srli	t2, LEN, 2		# length in 32-bit elements
+1:
+	vsetvli	t3, t2, e32, m4, ta, ma
+	sub	t2, t2, t3
+	vle32.v	v16, (INP)
+	.if \enc
+	aes_encrypt v16, \rounds
+	.else
+	aes_decrypt v16, \rounds
+	.endif
+	vse32.v	v16, (OUTP)
+	slli	t3, t3, 2		# elements consumed back to bytes
+	add	INP, INP, t3
+	add	OUTP, OUTP, t3
+	bnez	t2, 1b
+	ret
+	.endm
+
+	.macro aes_ecb_crypt enc
+	aes_load_schedule KEYP, ROUNDS, 20f, 30f
+	aes_ecb_body \enc, 14
+20:
+	aes_ecb_body \enc, 10
+30:
+	aes_ecb_body \enc, 12
+	.endm
+
+FUNC riscv_aes_ecb_encrypt , :
+	aes_ecb_crypt 1
+END_FUNC riscv_aes_ecb_encrypt
+
+FUNC riscv_aes_ecb_decrypt , :
+	aes_ecb_crypt 0
+END_FUNC riscv_aes_ecb_decrypt

--- a/core/arch/riscv/crypto/riscv_aes_zvkned_rv64.S
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned_rv64.S
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2026, RISCStar Solutions Limited
  *
- * AES ECB using the RISC-V Zvkned vector crypto extension.
+ * AES ECB and CBC using the RISC-V Zvkned vector crypto extension.
  */
 
 #include <asm.S>
@@ -61,3 +61,63 @@ END_FUNC riscv_aes_ecb_encrypt
 FUNC riscv_aes_ecb_decrypt , :
 	aes_ecb_crypt 0
 END_FUNC riscv_aes_ecb_decrypt
+
+/*
+ * void riscv_aes_cbc_encrypt(const void *key, const void *src, void *dst,
+ *			      size_t len, void *iv, unsigned int rounds)
+ * void riscv_aes_cbc_decrypt(const void *key, const void *src, void *dst,
+ *			      size_t len, void *iv, unsigned int rounds)
+ *
+ * a0 key, a1 src, a2 dst, a3 len, a4 iv, a5 rounds. The iv is updated in
+ * place so that a caller can continue a chain across calls.
+ *
+ * CBC encryption is serial: block n feeds block n+1, so this runs one
+ * block at a time whatever vl the hart offers. Decryption has no such
+ * dependency and could be done several blocks at once, but is kept to one
+ * block here so that both directions share the loop and the chaining
+ * value is handled the same way.
+ */
+#define IVP	a4
+#define CBC_ROUNDS a5
+
+	.macro aes_cbc_body enc, rounds
+	vsetivli	zero, 4, e32, m1, ta, ma
+	vle32.v		v16, (IVP)		# chaining value
+	srli		t2, LEN, 4		# block count
+1:
+	vle32.v		v17, (INP)
+	.if \enc
+	vxor.vv		v16, v16, v17
+	aes_encrypt	v16, \rounds
+	vse32.v		v16, (OUTP)
+	.else
+	vmv.v.v		v18, v17		# keep the ciphertext block
+	aes_decrypt	v17, \rounds
+	vxor.vv		v17, v17, v16
+	vse32.v		v17, (OUTP)
+	vmv.v.v		v16, v18
+	.endif
+	addi		INP, INP, 16
+	addi		OUTP, OUTP, 16
+	addi		t2, t2, -1
+	bnez		t2, 1b
+	vse32.v		v16, (IVP)		# hand the chain back
+	ret
+	.endm
+
+	.macro aes_cbc_crypt enc
+	aes_load_schedule KEYP, CBC_ROUNDS, 40f, 50f
+	aes_cbc_body \enc, 14
+40:
+	aes_cbc_body \enc, 10
+50:
+	aes_cbc_body \enc, 12
+	.endm
+
+FUNC riscv_aes_cbc_encrypt , :
+	aes_cbc_crypt 1
+END_FUNC riscv_aes_cbc_encrypt
+
+FUNC riscv_aes_cbc_decrypt , :
+	aes_cbc_crypt 0
+END_FUNC riscv_aes_cbc_decrypt

--- a/core/arch/riscv/crypto/riscv_aes_zvkned_zvkb.c
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned_zvkb.c
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ *
+ * AES CTR acceleration using the RISC-V Zvkned and Zvkb
+ * extensions.
+ */
+
+#include <assert.h>
+#include <crypto/crypto_accel.h>
+#include <kernel/thread.h>
+#include <utee_defines.h>
+
+#include "riscv_aes_zvkned_zvkb.h"
+
+void crypto_accel_aes_ctr_be_enc(void *out, const void *in, const void *key,
+				 unsigned int round_count,
+				 unsigned int block_count, void *iv)
+{
+	uint32_t state = 0;
+
+	assert(out && in && key && iv);
+	assert(round_count == 10 || round_count == 12 || round_count == 14);
+
+	if (!out || !in || !key || !iv || !block_count)
+		return;
+
+	state = thread_kernel_enable_vector();
+	riscv_aes_ctr_be_encrypt(key, in, out,
+				 (size_t)block_count * TEE_AES_BLOCK_SIZE, iv,
+				 round_count);
+	thread_kernel_disable_vector(state);
+}

--- a/core/arch/riscv/crypto/riscv_aes_zvkned_zvkb.h
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned_zvkb.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+#ifndef __RISCV_AES_ZVKNED_ZVKB_H
+#define __RISCV_AES_ZVKNED_ZVKB_H
+
+#include <types_ext.h>
+
+/*
+ * @key points at the expanded schedule produced by
+ * crypto_accel_aes_expand_keys(), @len is a non-zero whole number of AES
+ * blocks and @rounds is 10, 12 or 14. @ctr is a 16-byte big-endian counter
+ * block, advanced by one per AES block over its full 128 bits and written
+ * back so the stream can be continued. The caller owns the vector unit for
+ * the duration of the call.
+ */
+void riscv_aes_ctr_be_encrypt(const void *key, const void *src, void *dst,
+			      size_t len, void *ctr, unsigned int rounds);
+
+#endif /* __RISCV_AES_ZVKNED_ZVKB_H */

--- a/core/arch/riscv/crypto/riscv_aes_zvkned_zvkb_rv64.S
+++ b/core/arch/riscv/crypto/riscv_aes_zvkned_zvkb_rv64.S
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ *
+ * AES CTR using the RISC-V Zvkned and Zvkb vector crypto extensions.
+ *
+ * Zvkb is here for vrev8.v. The counter is a 128-bit big-endian integer but
+ * vector arithmetic is little-endian per element, so counting several blocks
+ * ahead in vector registers means byte-swapping the counter, adding, and
+ * swapping back. Without vrev8.v that costs more than the parallelism wins,
+ * which is why this is a separate file from the Zvkned-only ECB and CBC.
+ */
+
+#include <asm.S>
+
+	.option arch, +v, +zvkned, +zvkb
+
+#include "riscv_aes_macros.S"
+
+#define KEYP		a0
+#define INP		a1
+#define OUTP		a2
+#define LEN		a3
+#define CTRP		a4
+#define ROUNDS		a5
+
+/*
+ * Encrypt t2 counter blocks, which the caller has already clamped so that
+ * the low 32 bits of the counter cannot overflow. Only word 3 of each block
+ * is byte-swapped and incremented, which is what makes the arithmetic a
+ * single masked vadd; the caller owns everything above it.
+ *
+ * Clobbers t0, t1, t5, t6 and v16-v27, v31. v0 holds the element mask.
+ */
+	.macro aes_ctr_batch rounds
+	slli		t5, t2, 2		# batch length in elements
+
+	vsetivli	zero, 4, e32, m1, ta, ma
+	vle32.v		v31, (CTRP)
+	vsetivli	zero, 4, e32, m1, ta, mu
+	vrev8.v		v31, v31, v0.t		# word 3 to little-endian
+4:
+	vsetvli		t0, t5, e32, m4, ta, ma
+	/*
+	 * vaesz.vs XORs its scalar element group into every element group of
+	 * the destination, so against a zeroed destination it replicates the
+	 * counter block across the whole group.
+	 */
+	vmv.v.i		v16, 0
+	vaesz.vs	v16, v31
+	viota.m		v20, v0, v0.t		# 0, 1, 2, ... per block
+	vsetvli		t0, t5, e32, m4, ta, mu
+	vadd.vv		v16, v16, v20, v0.t
+	vmv.v.v		v24, v16
+	vrev8.v		v24, v24, v0.t		# back to big-endian for AES
+
+	vsetvli		t0, t5, e32, m4, ta, ma
+	aes_encrypt	v24, \rounds
+
+	slli		t6, t0, 2		# elements consumed to bytes
+	vsetvli		zero, t6, e8, m4, ta, ma
+	vle8.v		v20, (INP)
+	vxor.vv		v20, v20, v24
+	vse8.v		v20, (OUTP)
+
+	add		INP, INP, t6
+	add		OUTP, OUTP, t6
+	sub		t5, t5, t0
+	srli		t1, t0, 2		# blocks consumed
+	vsetivli	zero, 4, e32, m1, ta, mu
+	vadd.vx		v31, v31, t1, v0.t
+	bnez		t5, 4b
+
+	vrev8.v		v31, v31, v0.t		# word 3 back to big-endian
+	vsetivli	zero, 4, e32, m1, ta, ma
+	vse32.v		v31, (CTRP)
+	.endm
+
+	.macro __aes_ctr_crypt rounds
+	/*
+	 * 0x88 per byte makes an element mask that selects element 3 of every
+	 * four, which is word 3 of every 16-byte counter block.
+	 */
+	li		t0, 0x88
+	vsetvli		t1, zero, e8, m1, ta, ma
+	vmv.v.x		v0, t0
+1:
+	srli		t2, LEN, 4		# blocks left
+	beqz		t2, 9f
+
+	/*
+	 * Read the low 32 bits of the counter and work out how many blocks
+	 * are left before they wrap. Everything above those 32 bits is
+	 * carried in scalar code below, so a batch must stop at the wrap.
+	 */
+	lbu		t3, 12(CTRP)
+	lbu		t4, 13(CTRP)
+	slli		t3, t3, 8
+	or		t3, t3, t4
+	lbu		t4, 14(CTRP)
+	slli		t3, t3, 8
+	or		t3, t3, t4
+	lbu		t4, 15(CTRP)
+	slli		t3, t3, 8
+	or		t3, t3, t4		# t3 = low 32 bits
+	li		t4, 1
+	slli		t4, t4, 32
+	sub		t4, t4, t3		# blocks until the wrap
+
+	bltu		t2, t4, 2f
+	mv		t2, t4			# clamp the batch to the wrap
+2:
+	slli		a6, t2, 4		# batch length in bytes
+	sub		LEN, LEN, a6
+	aes_ctr_batch	\rounds
+
+	/*
+	 * If the batch ended exactly on the wrap the low word is now zero
+	 * and the carry has to be propagated into the upper 96 bits, which
+	 * the masked vadd above never touches.
+	 */
+	bne		t2, t4, 1b
+	addi		t3, CTRP, 11
+3:
+	lbu		t4, 0(t3)
+	addi		t4, t4, 1
+	andi		t4, t4, 0xff
+	sb		t4, 0(t3)
+	bnez		t4, 1b
+	addi		t3, t3, -1
+	bgeu		t3, CTRP, 3b
+	j		1b
+9:
+	ret
+	.endm
+
+	.macro aes_ctr_crypt
+	aes_load_schedule KEYP, ROUNDS, 60f, 70f
+	__aes_ctr_crypt 14
+60:
+	__aes_ctr_crypt 10
+70:
+	__aes_ctr_crypt 12
+	.endm
+
+/*
+ * void riscv_aes_ctr_be_encrypt(const void *key, const void *src, void *dst,
+ *				 size_t len, void *ctr, unsigned int rounds)
+ */
+FUNC riscv_aes_ctr_be_encrypt , :
+	aes_ctr_crypt
+END_FUNC riscv_aes_ctr_be_encrypt

--- a/core/arch/riscv/crypto/sub.mk
+++ b/core/arch/riscv/crypto/sub.mk
@@ -1,0 +1,2 @@
+srcs-$(CFG_CRYPTO_AES_RISCV_ZVKNED) += riscv_aes_zvkned.c
+srcs-$(CFG_CRYPTO_AES_RISCV_ZVKNED) += riscv_aes_zvkned_rv64.S

--- a/core/arch/riscv/crypto/sub.mk
+++ b/core/arch/riscv/crypto/sub.mk
@@ -1,2 +1,4 @@
 srcs-$(CFG_CRYPTO_AES_RISCV_ZVKNED) += riscv_aes_zvkned.c
 srcs-$(CFG_CRYPTO_AES_RISCV_ZVKNED) += riscv_aes_zvkned_rv64.S
+srcs-$(CFG_CRYPTO_AES_RISCV_ZVKNED_ZVKB) += riscv_aes_zvkned_zvkb.c
+srcs-$(CFG_CRYPTO_AES_RISCV_ZVKNED_ZVKB) += riscv_aes_zvkned_zvkb_rv64.S

--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -172,6 +172,29 @@ struct thread_ctx_regs {
 
 struct user_mode_ctx;
 
+#ifdef CFG_RISCV_WITH_VECTOR
+struct thread_user_vector_state {
+	/* Allocated the first time the TA asks for the vector unit */
+	struct riscv_vector_state *state;
+	/* True when @state holds a saved copy of the TA's vector registers */
+	bool valid;
+};
+
+/* Returns false if a context could not be allocated for the TA */
+bool thread_user_enable_vector(struct thread_user_vector_state *uvect);
+void thread_user_save_vector(void);
+void thread_user_clear_vector(struct user_mode_ctx *uctx);
+#else /*CFG_RISCV_WITH_VECTOR*/
+static inline void thread_user_save_vector(void)
+{
+}
+
+static inline void thread_user_clear_vector(struct user_mode_ctx *uctx
+					    __unused)
+{
+}
+#endif /*CFG_RISCV_WITH_VECTOR*/
+
 #ifdef CFG_WITH_VFP
 uint32_t thread_kernel_enable_vfp(void);
 void thread_kernel_disable_vfp(uint32_t state);

--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -180,6 +180,16 @@ struct thread_user_vector_state {
 	bool valid;
 };
 
+/*
+ * Opens and closes a secure kernel vector section. Core code that wants to
+ * use the vector unit has to bracket it with these, the same way
+ * thread_kernel_enable_vfp() brackets floating-point use: the pair takes
+ * the registers from whoever holds them and gives them back, and keeps
+ * foreign interrupts masked in between.
+ */
+uint32_t thread_kernel_enable_vector(void);
+void thread_kernel_disable_vector(uint32_t state);
+
 /* Returns false if a context could not be allocated for the TA */
 bool thread_user_enable_vector(struct thread_user_vector_state *uvect);
 void thread_user_save_vector(void);

--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -14,6 +14,7 @@
 #include <platform_config.h>
 #include <riscv.h>
 #include <riscv_fp.h>
+#include <riscv_vector.h>
 
 /*
  * Each RISC-V platform must define their own values.

--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -13,6 +13,7 @@
 
 #include <platform_config.h>
 #include <riscv.h>
+#include <riscv_fp.h>
 
 /*
  * Each RISC-V platform must define their own values.
@@ -51,6 +52,9 @@ struct thread_core_local {
 } THREAD_CORE_LOCAL_ALIGNED;
 
 struct thread_user_vfp_state {
+	struct riscv_fp_state fp;
+	/* True when @fp holds a saved copy of the TA's FP registers */
+	bool valid;
 };
 
 struct thread_abi_args {

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -10,6 +10,7 @@
 
 #include <kernel/thread.h>
 #include <riscv_fp.h>
+#include <riscv_vector.h>
 
 #define STACK_TMP_OFFS		0
 
@@ -97,6 +98,35 @@ struct thread_vfp_state {
 	bool sec_used;
 };
 #endif /*CFG_WITH_VFP*/
+#ifdef CFG_RISCV_WITH_VECTOR
+/*
+ * Which context the vector registers of this hart currently hold.
+ *
+ * OP-TEE owns xstatus.VS while it runs, so one owner per OP-TEE thread is
+ * enough to describe the hardware: the registers hold either nothing worth
+ * preserving or the normal world context.
+ */
+enum riscv_vector_owner {
+	RISCV_VECTOR_OWNER_NONE = 0,
+	RISCV_VECTOR_OWNER_NS,
+};
+
+/*
+ * struct thread_vector_state - per OP-TEE thread vector bookkeeping
+ * @ns:		saved normal world vector context, allocated at boot
+ * @owner:	context the vector registers currently hold
+ * @ns_vs:	xstatus.VS the normal world had on entry to OP-TEE
+ * @ns_valid:	@ns holds a saved normal world context
+ * @sec_used:	secure code has written the vector registers since entry
+ */
+struct thread_vector_state {
+	struct riscv_vector_state *ns;
+	enum riscv_vector_owner owner;
+	unsigned long ns_vs;
+	bool ns_valid;
+	bool sec_used;
+};
+#endif /*CFG_RISCV_WITH_VECTOR*/
 
 extern long thread_user_kcode_offset;
 

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -65,18 +65,21 @@ struct thread_user_mode_rec {
  *
  * OP-TEE owns xstatus.FS while it runs, so one owner per OP-TEE thread is
  * enough to describe the hardware: the registers hold either nothing worth
- * preserving, the normal world context, or a secure kernel context.
+ * preserving, the normal world context, a secure kernel context, or the
+ * context of the TA the thread is running.
  */
 enum riscv_fp_owner {
 	RISCV_FP_OWNER_NONE = 0,
 	RISCV_FP_OWNER_NS,
 	RISCV_FP_OWNER_KERNEL,
+	RISCV_FP_OWNER_USER,
 };
 
 /*
  * struct thread_vfp_state - per OP-TEE thread FP bookkeeping
  * @ns:		saved normal world FP context
  * @sec:	saved secure kernel FP context
+ * @uvfp:	FP context of the TA this thread is running, if it has one
  * @owner:	context the f registers currently hold
  * @ns_fs:	xstatus.FS the normal world had on entry to OP-TEE
  * @ns_valid:	@ns holds a saved normal world context
@@ -86,6 +89,7 @@ enum riscv_fp_owner {
 struct thread_vfp_state {
 	struct riscv_fp_state ns;
 	struct riscv_fp_state sec;
+	struct thread_user_vfp_state *uvfp;
 	enum riscv_fp_owner owner;
 	unsigned long ns_fs;
 	bool ns_valid;
@@ -164,6 +168,11 @@ static inline void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS])
 }
 
 void thread_scall_handler(struct thread_scall_regs *regs);
+
+#ifdef CFG_WITH_VFP
+/* Releases the FP unit from a TA that is about to be killed */
+void vfp_disable(void);
+#endif
 
 #endif /*__ASSEMBLER__*/
 

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -104,12 +104,13 @@ struct thread_vfp_state {
  *
  * OP-TEE owns xstatus.VS while it runs, so one owner per OP-TEE thread is
  * enough to describe the hardware: the registers hold either nothing worth
- * preserving, the normal world context, or the context of the TA the
- * thread is running.
+ * preserving, the normal world context, a secure kernel section, or the
+ * context of the TA the thread is running.
  */
 enum riscv_vector_owner {
 	RISCV_VECTOR_OWNER_NONE = 0,
 	RISCV_VECTOR_OWNER_NS,
+	RISCV_VECTOR_OWNER_KERNEL,
 	RISCV_VECTOR_OWNER_USER,
 };
 

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -104,16 +104,19 @@ struct thread_vfp_state {
  *
  * OP-TEE owns xstatus.VS while it runs, so one owner per OP-TEE thread is
  * enough to describe the hardware: the registers hold either nothing worth
- * preserving or the normal world context.
+ * preserving, the normal world context, or the context of the TA the
+ * thread is running.
  */
 enum riscv_vector_owner {
 	RISCV_VECTOR_OWNER_NONE = 0,
 	RISCV_VECTOR_OWNER_NS,
+	RISCV_VECTOR_OWNER_USER,
 };
 
 /*
  * struct thread_vector_state - per OP-TEE thread vector bookkeeping
  * @ns:		saved normal world vector context, allocated at boot
+ * @uvect:	vector context of the TA this thread is running, if it has one
  * @owner:	context the vector registers currently hold
  * @ns_vs:	xstatus.VS the normal world had on entry to OP-TEE
  * @ns_valid:	@ns holds a saved normal world context
@@ -121,6 +124,7 @@ enum riscv_vector_owner {
  */
 struct thread_vector_state {
 	struct riscv_vector_state *ns;
+	struct thread_user_vector_state *uvect;
 	enum riscv_vector_owner owner;
 	unsigned long ns_vs;
 	bool ns_valid;

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -9,6 +9,7 @@
 #ifndef __ASSEMBLER__
 
 #include <kernel/thread.h>
+#include <riscv_fp.h>
 
 #define STACK_TMP_OFFS		0
 
@@ -57,6 +58,41 @@ struct thread_user_mode_rec {
 	 */
 	unsigned long x[13];
 };
+
+#ifdef CFG_WITH_VFP
+/*
+ * Which context the f registers of this hart currently hold.
+ *
+ * OP-TEE owns xstatus.FS while it runs, so one owner per OP-TEE thread is
+ * enough to describe the hardware: the registers hold either nothing worth
+ * preserving, the normal world context, or a secure kernel context.
+ */
+enum riscv_fp_owner {
+	RISCV_FP_OWNER_NONE = 0,
+	RISCV_FP_OWNER_NS,
+	RISCV_FP_OWNER_KERNEL,
+};
+
+/*
+ * struct thread_vfp_state - per OP-TEE thread FP bookkeeping
+ * @ns:		saved normal world FP context
+ * @sec:	saved secure kernel FP context
+ * @owner:	context the f registers currently hold
+ * @ns_fs:	xstatus.FS the normal world had on entry to OP-TEE
+ * @ns_valid:	@ns holds a saved normal world context
+ * @sec_valid:	@sec holds a saved secure kernel context
+ * @sec_used:	secure code has written the f registers since entry
+ */
+struct thread_vfp_state {
+	struct riscv_fp_state ns;
+	struct riscv_fp_state sec;
+	enum riscv_fp_owner owner;
+	unsigned long ns_fs;
+	bool ns_valid;
+	bool sec_valid;
+	bool sec_used;
+};
+#endif /*CFG_WITH_VFP*/
 
 extern long thread_user_kcode_offset;
 

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -96,6 +96,19 @@
 #define CSR_XSTATUS_FS_CLEAN	2
 #define CSR_XSTATUS_FS_DIRTY	3
 
+/*
+ * xstatus.VS holds the state of the vector unit. The field is two bits wide
+ * and always resides in the low 32 bits of xstatus, on RV32 as well as on
+ * RV64.
+ */
+#define CSR_XSTATUS_VS_SHIFT	9
+#define CSR_XSTATUS_VS_MASK	SHIFT_U32(3, CSR_XSTATUS_VS_SHIFT)
+
+#define CSR_XSTATUS_VS_OFF	0
+#define CSR_XSTATUS_VS_INITIAL	1
+#define CSR_XSTATUS_VS_CLEAN	2
+#define CSR_XSTATUS_VS_DIRTY	3
+
 #define CSR_XCAUSE_INTR_FLAG	BIT64(__riscv_xlen - 1)
 
 #ifndef __ASSEMBLER__

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright 2022-2023 NXP
+ * Copyright (c) 2026, RISCStar Solutions Limited
  */
 
 #ifndef __RISCV_H
@@ -18,6 +19,13 @@
 
 #define RISCV_XLEN_BITS		(__riscv_xlen)
 #define RISCV_XLEN_BYTES	(__riscv_xlen / 8)
+
+/*
+ * Width of a floating-point register. Only defined when the core is built
+ * for a hart with the F or D extension, that is when CFG_RISCV_FPU=y.
+ */
+#define RISCV_FLEN_BITS		(__riscv_flen)
+#define RISCV_FLEN_BYTES	(__riscv_flen / 8)
 
 /* Bind registers to their ABI names */
 #define REG_RA	1
@@ -74,6 +82,19 @@
 #define CSR_XSTATUS_SPP		BIT(8)
 #define CSR_XSTATUS_SUM		BIT(18)
 #define CSR_XSTATUS_MXR		BIT(19)
+
+/*
+ * xstatus.FS holds the state of the floating-point unit. The field is two
+ * bits wide and always resides in the low 32 bits of xstatus, on RV32 as
+ * well as on RV64.
+ */
+#define CSR_XSTATUS_FS_SHIFT	13
+#define CSR_XSTATUS_FS_MASK	SHIFT_U32(3, CSR_XSTATUS_FS_SHIFT)
+
+#define CSR_XSTATUS_FS_OFF	0
+#define CSR_XSTATUS_FS_INITIAL	1
+#define CSR_XSTATUS_FS_CLEAN	2
+#define CSR_XSTATUS_FS_DIRTY	3
 
 #define CSR_XCAUSE_INTR_FLAG	BIT64(__riscv_xlen - 1)
 

--- a/core/arch/riscv/include/riscv_fp.h
+++ b/core/arch/riscv/include/riscv_fp.h
@@ -39,5 +39,66 @@ struct riscv_fp_state {
 void riscv_save_fp_state(struct riscv_fp_state *state);
 void riscv_restore_fp_state(struct riscv_fp_state *state);
 
+/*
+ * xstatus.FS holds the state of the FP unit:
+ *
+ * Off      the FP unit is disabled, an FP instruction traps as an illegal
+ *          instruction
+ * Initial  enabled, the f registers hold their initial value
+ * Clean    enabled, the f registers match the copy held in memory
+ * Dirty    enabled, the f registers have been written since they were last
+ *          saved
+ *
+ * The helpers below come in two flavours: those taking an xstatus value
+ * operate on a saved context, since xstatus is part of the register frame
+ * restored on the way back to a trapped context, while riscv_fp_write_fs()
+ * and friends act on the live CSR of this hart.
+ */
+
+static inline unsigned long riscv_fp_get_fs(unsigned long xstatus)
+{
+#ifdef RV32
+	return get_field_u32(xstatus, CSR_XSTATUS_FS_MASK);
+#else
+	return get_field_u64(xstatus, CSR_XSTATUS_FS_MASK);
+#endif
+}
+
+static inline unsigned long riscv_fp_set_fs(unsigned long xstatus,
+					    unsigned long fs)
+{
+#ifdef RV32
+	return set_field_u32(xstatus, CSR_XSTATUS_FS_MASK, fs);
+#else
+	return set_field_u64(xstatus, CSR_XSTATUS_FS_MASK, fs);
+#endif
+}
+
+/* Returns true if @xstatus describes a context with the FP unit enabled */
+static inline bool riscv_fp_state_is_enabled(unsigned long xstatus)
+{
+	return riscv_fp_get_fs(xstatus) != CSR_XSTATUS_FS_OFF;
+}
+
+static inline void riscv_fp_write_fs(unsigned long fs)
+{
+	write_csr(CSR_XSTATUS, riscv_fp_set_fs(read_csr(CSR_XSTATUS), fs));
+}
+
+static inline unsigned long riscv_fp_read_fs(void)
+{
+	return riscv_fp_get_fs(read_csr(CSR_XSTATUS));
+}
+
+static inline void riscv_fp_disable(void)
+{
+	clear_csr(CSR_XSTATUS, CSR_XSTATUS_FS_MASK);
+}
+
+static inline bool riscv_fp_is_enabled(void)
+{
+	return riscv_fp_read_fs() != CSR_XSTATUS_FS_OFF;
+}
+
 #endif /* !__ASSEMBLER__ */
 #endif /* __RISCV_FP_H */

--- a/core/arch/riscv/include/riscv_fp.h
+++ b/core/arch/riscv/include/riscv_fp.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+#ifndef __RISCV_FP_H
+#define __RISCV_FP_H
+
+#ifndef __ASSEMBLER__
+
+#include <compiler.h>
+#include <riscv.h>
+#include <types_ext.h>
+
+/*
+ * struct riscv_fp_state - floating-point register context
+ * @fpregs:	f0..f31, each RISCV_FLEN_BITS wide
+ * @fcsr:	floating-point control and status register
+ *
+ * The layout is shared with riscv_fp.S, see RISCV_FP_FCSR_OFF.
+ */
+struct riscv_fp_state {
+#if defined(__riscv_flen) && __riscv_flen == 64
+	uint64_t fpregs[32];
+#elif defined(__riscv_flen) && __riscv_flen == 32
+	uint32_t fpregs[32];
+#endif
+	uint32_t fcsr;
+};
+
+/*
+ * riscv_save_fp_state() - save f0..f31 and fcsr into @state
+ * riscv_restore_fp_state() - load f0..f31 and fcsr from @state
+ *
+ * Both enable the floating-point unit for the duration of the transfer and
+ * leave xstatus.FS as they found it, so they can be called with the FP unit
+ * disabled without disturbing the caller's view of xstatus.
+ */
+void riscv_save_fp_state(struct riscv_fp_state *state);
+void riscv_restore_fp_state(struct riscv_fp_state *state);
+
+#endif /* !__ASSEMBLER__ */
+#endif /* __RISCV_FP_H */

--- a/core/arch/riscv/include/riscv_macros.S
+++ b/core/arch/riscv/include/riscv_macros.S
@@ -93,6 +93,48 @@
 	.endm
 
 	/*
+	 * This helper macro transfers the whole vector register file, eight
+	 * registers at a time.
+	 *
+	 * The whole-register forms vs8r.v and vl8r.v are used because they
+	 * move a fixed amount of state regardless of the vtype and vl in
+	 * effect, so the context can be moved without first having to
+	 * reconstruct the configuration it was taken under.
+	 *
+	 * base_reg is advanced by 8 * vlenb between chunks and is left
+	 * pointing past the end. tmp_reg is clobbered. The vector ISA is
+	 * enabled for this block alone, so the file assembles for a core
+	 * that is otherwise built without it.
+	 */
+	.macro _do_vregs instr, base_reg, vlenb_reg, tmp_reg
+		.option push
+		.option arch, +v
+		slli	\tmp_reg, \vlenb_reg, 3
+		\instr	v0, (\base_reg)
+		add	\base_reg, \base_reg, \tmp_reg
+		\instr	v8, (\base_reg)
+		add	\base_reg, \base_reg, \tmp_reg
+		\instr	v16, (\base_reg)
+		add	\base_reg, \base_reg, \tmp_reg
+		\instr	v24, (\base_reg)
+		.option pop
+	.endm
+
+	/*
+	 * Stores registers v0..v31 at [base_reg], vlenb bytes each
+	 */
+	.macro store_vregs base_reg, vlenb_reg, tmp_reg
+		_do_vregs vs8r.v, \base_reg, \vlenb_reg, \tmp_reg
+	.endm
+
+	/*
+	 * Loads registers v0..v31 from [base_reg], vlenb bytes each
+	 */
+	.macro load_vregs base_reg, vlenb_reg, tmp_reg
+		_do_vregs vl8r.v, \base_reg, \vlenb_reg, \tmp_reg
+	.endm
+
+	/*
 	 * Multiplication macro for RISC-V harts without M extension.
 	 */
 	.macro mult, reg_op0, reg_op1, reg_res

--- a/core/arch/riscv/include/riscv_macros.S
+++ b/core/arch/riscv/include/riscv_macros.S
@@ -2,6 +2,7 @@
 /*
  * Copyright 2022-2023 NXP
  * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2026, RISCStar Solutions Limited
  */
 
 	.altmacro
@@ -47,6 +48,48 @@
 	.macro load_xregs base_reg, base_offs, from_regnum, to_regnum
 		_do_regs LDR, RISCV_XLEN_BYTES, \base_reg, \base_offs, \
 			 \from_regnum, \to_regnum
+	.endm
+
+	/*
+	 * This helper macro concatenates instr_prefix, instr_suffix, to
+	 * create a f(lw,ld)/f(sw,sd) instruction.
+	 */
+	.macro __do_fpreg instr_prefix, base_reg, base_offs, reg
+		\instr_prefix f\reg, \base_offs(\base_reg)
+	.endm
+
+	/*
+	 * This helper macro uses recursion to create a loop with a single
+	 * floating-point load/store.
+	 */
+	.macro _do_fpregs instr_prefix, reg_bytes, base_reg, base_offs, \
+			  from_regnum, to_regnum
+
+		.if (\to_regnum - \from_regnum + 1) > 1
+			_do_fpregs \instr_prefix, \reg_bytes, \base_reg, \
+				%(\base_offs + 1 * \reg_bytes), \
+				%(\from_regnum + 1), \to_regnum
+		.endif
+
+		__do_fpreg \instr_prefix, \base_reg, \base_offs, \from_regnum
+	.endm
+
+	/*
+	 * Stores registers f[from_regnum]..f[to_regnum] at
+	 * [base_reg, #base_offs]
+	 */
+	.macro store_fpregs base_reg, base_offs, from_regnum, to_regnum
+		_do_fpregs FST, RISCV_FLEN_BYTES, \base_reg, \base_offs, \
+			   \from_regnum, \to_regnum
+	.endm
+
+	/*
+	 * Loads registers f[from_regnum]..f[to_regnum] at
+	 * [base_reg, #base_offs]
+	 */
+	.macro load_fpregs base_reg, base_offs, from_regnum, to_regnum
+		_do_fpregs FLD, RISCV_FLEN_BYTES, \base_reg, \base_offs, \
+			   \from_regnum, \to_regnum
 	.endm
 
 	/*

--- a/core/arch/riscv/include/riscv_vector.h
+++ b/core/arch/riscv/include/riscv_vector.h
@@ -49,5 +49,84 @@ size_t riscv_vector_state_size(void);
 void riscv_vector_save_state(struct riscv_vector_state *state);
 void riscv_vector_restore_state(struct riscv_vector_state *state);
 
+/*
+ * xstatus.VS holds the state of the vector unit and takes the same four
+ * values as the FS field does for floating point:
+ *
+ * Off      the unit is disabled, a vector instruction or an access to a
+ *          vector CSR traps as an illegal instruction
+ * Initial  enabled, the registers hold their initial value
+ * Clean    enabled, the registers match the copy held in memory
+ * Dirty    enabled, the registers have been written since they were last
+ *          saved
+ *
+ * The helpers come in two flavours: those taking an xstatus value operate
+ * on a saved context, since xstatus is part of the register frame restored
+ * on the way back to a trapped context, while riscv_vector_write_vs() and
+ * friends act on the live CSR of this hart.
+ */
+
+static inline unsigned long riscv_vector_get_vs(unsigned long xstatus)
+{
+#ifdef RV32
+	return get_field_u32(xstatus, CSR_XSTATUS_VS_MASK);
+#else
+	return get_field_u64(xstatus, CSR_XSTATUS_VS_MASK);
+#endif
+}
+
+static inline unsigned long riscv_vector_set_vs(unsigned long xstatus,
+						unsigned long vs)
+{
+#ifdef RV32
+	return set_field_u32(xstatus, CSR_XSTATUS_VS_MASK, vs);
+#else
+	return set_field_u64(xstatus, CSR_XSTATUS_VS_MASK, vs);
+#endif
+}
+
+/* Returns true if @xstatus describes a context with the vector unit on */
+static inline bool riscv_vector_state_is_enabled(unsigned long xstatus)
+{
+	return riscv_vector_get_vs(xstatus) != CSR_XSTATUS_VS_OFF;
+}
+
+static inline void riscv_vector_write_vs(unsigned long vs)
+{
+	write_csr(CSR_XSTATUS,
+		  riscv_vector_set_vs(read_csr(CSR_XSTATUS), vs));
+}
+
+static inline unsigned long riscv_vector_read_vs(void)
+{
+	return riscv_vector_get_vs(read_csr(CSR_XSTATUS));
+}
+
+static inline void riscv_vector_disable(void)
+{
+	clear_csr(CSR_XSTATUS, CSR_XSTATUS_VS_MASK);
+}
+
+static inline bool riscv_vector_is_enabled(void)
+{
+	return riscv_vector_read_vs() != CSR_XSTATUS_VS_OFF;
+}
+
+/*
+ * vlenb is only readable with the unit enabled, so this leaves xstatus.VS
+ * as it found it the same way the save and restore routines do.
+ */
+static inline unsigned long riscv_vector_vlenb(void)
+{
+	unsigned long xstatus = read_csr(CSR_XSTATUS);
+	unsigned long vlenb = 0;
+
+	riscv_vector_write_vs(CSR_XSTATUS_VS_INITIAL);
+	vlenb = read_csr(CSR_VLENB);
+	write_csr(CSR_XSTATUS, xstatus);
+
+	return vlenb;
+}
+
 #endif /* !__ASSEMBLER__ */
 #endif /* __RISCV_VECTOR_H */

--- a/core/arch/riscv/include/riscv_vector.h
+++ b/core/arch/riscv/include/riscv_vector.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+#ifndef __RISCV_VECTOR_H
+#define __RISCV_VECTOR_H
+
+#ifndef __ASSEMBLER__
+
+#include <compiler.h>
+#include <riscv.h>
+#include <types_ext.h>
+
+/*
+ * The width of a vector register is discovered at run time from vlenb and
+ * can be anything from 8 bytes upwards, so a context cannot be sized from
+ * the ISA the core was built for. The register file is a flexible array and
+ * a context is allocated for the hart it will run on.
+ */
+#define RISCV_VECTOR_NUM_REGS	32
+
+/*
+ * struct riscv_vector_state - vector register context
+ * @vstart:	index the next vector instruction would resume from
+ * @vtype:	current vector type, read only, put back through vsetvl
+ * @vl:		current vector length, likewise
+ * @vcsr:	vector rounding mode and saturation flag
+ * @vregs:	v0..v31, each vlenb bytes wide and laid out back to back
+ *
+ * The layout is shared with riscv_vector.S, see the RISCV_VECTOR_*_OFF
+ * defines.
+ */
+struct riscv_vector_state {
+	unsigned long vstart;
+	unsigned long vtype;
+	unsigned long vl;
+	unsigned long vcsr;
+	uint8_t vregs[];
+};
+
+/*
+ * Bytes one context occupies on this hart, the header plus 32 * vlenb.
+ * Reads vlenb, so it enables the vector unit for the read the same way the
+ * save and restore routines do.
+ */
+size_t riscv_vector_state_size(void);
+
+void riscv_vector_save_state(struct riscv_vector_state *state);
+void riscv_vector_restore_state(struct riscv_vector_state *state);
+
+#endif /* !__ASSEMBLER__ */
+#endif /* __RISCV_VECTOR_H */

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -2,6 +2,7 @@
 /*
  * Copyright 2022-2023 NXP
  * Copyright (c) 2015-2022, Linaro Limited
+ * Copyright (c) 2026, RISCStar Solutions Limited
  */
 
 #include <kernel/abort.h>
@@ -14,6 +15,7 @@
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
 #include <riscv.h>
+#include <riscv_fp.h>
 #include <tee/tee_svc.h>
 #include <trace.h>
 #include <unw/unwind.h>
@@ -241,11 +243,20 @@ static void handle_user_mode_panic(struct abort_info *ai)
 }
 
 #ifdef CFG_WITH_VFP
-static void handle_user_mode_vfp(void)
+static void handle_user_mode_vfp(struct abort_info *ai)
 {
 	struct ts_session *s = ts_get_current_session();
 
 	thread_user_enable_vfp(&to_user_mode_ctx(s->ctx)->vfp);
+
+	/*
+	 * xstatus is restored from the saved context on the way back to the
+	 * TA, so handing it the FP unit means updating FS there and not only
+	 * in the live CSR. Without this the TA would resume with FS still
+	 * Off and trap on the very same instruction again.
+	 */
+	ai->regs->status = riscv_fp_set_fs(ai->regs->status,
+					   riscv_fp_read_fs());
 }
 #endif /*CFG_WITH_VFP*/
 
@@ -265,10 +276,123 @@ bool abort_is_user_exception(struct abort_info *ai __unused)
 #endif /*CFG_WITH_USER_TA*/
 
 #if defined(CFG_WITH_VFP) && defined(CFG_WITH_USER_TA)
+/* Major opcodes of the F/D/Q extensions, all instructions are 32-bit */
+#define OPCODE_MASK		0x7f
+#define OPCODE_LOAD_FP		0x07	/* flw, fld, flq */
+#define OPCODE_STORE_FP		0x27	/* fsw, fsd, fsq */
+#define OPCODE_MADD		0x43	/* fmadd */
+#define OPCODE_MSUB		0x47	/* fmsub */
+#define OPCODE_NMSUB		0x4b	/* fnmsub */
+#define OPCODE_NMADD		0x4f	/* fnmadd */
+#define OPCODE_OP_FP		0x53	/* fadd, fsub, fcvt, fmv, ... */
+#define OPCODE_SYSTEM		0x73	/* csrrw and friends */
+
+#define INSN_FUNCT3_SHIFT	12
+#define INSN_FUNCT3_MASK	0x7
+#define INSN_CSR_SHIFT		20
+#define INSN_CSR_MASK		0xfff
+
+/*
+ * With FS == Off a hart traps reads and writes of the floating-point CSRs
+ * exactly as it traps the floating-point instructions themselves, so a TA
+ * that looks at the rounding mode or the accrued exception flags before it
+ * does any arithmetic has to be given a context just the same.
+ */
+static bool is_fp_csr_insn(uint32_t insn)
+{
+	uint32_t csr = (insn >> INSN_CSR_SHIFT) & INSN_CSR_MASK;
+
+	/* funct3 zero is ecall, ebreak and friends, not a CSR access */
+	if (!((insn >> INSN_FUNCT3_SHIFT) & INSN_FUNCT3_MASK))
+		return false;
+
+	return csr == CSR_FFLAGS || csr == CSR_FRM || csr == CSR_FCSR;
+}
+
+static bool is_fp_insn(uint32_t insn)
+{
+	switch (insn & OPCODE_MASK) {
+	case OPCODE_LOAD_FP:
+	case OPCODE_STORE_FP:
+	case OPCODE_MADD:
+	case OPCODE_MSUB:
+	case OPCODE_NMSUB:
+	case OPCODE_NMADD:
+	case OPCODE_OP_FP:
+		return true;
+	case OPCODE_SYSTEM:
+		return is_fp_csr_insn(insn);
+	default:
+		return false;
+	}
+}
+
+/*
+ * The two low bits of an instruction are 0b11 for the 32-bit encodings and
+ * anything else for the 16-bit compressed ones, which are identified
+ * further by their quadrant and funct3 fields.
+ */
+#define INSN_LEN_MASK		0x3
+#define INSN_LEN_32BIT		0x3
+
+#define C_QUADRANT_MASK		0x3
+#define C_QUADRANT_0		0x0
+#define C_QUADRANT_2		0x2
+#define C_FUNCT3_SHIFT		13
+#define C_FUNCT3_MASK		0x7
+
+#define C_FUNCT3_FLD		1	/* c.fld, c.fldsp */
+#define C_FUNCT3_FLW		3	/* c.flw, c.flwsp, RV32 only. On RV64
+					 * this and C_FUNCT3_FSW are c.ld/c.sd
+					 * and c.ldsp/c.sdsp, which are integer
+					 * instructions.
+					 */
+#define C_FUNCT3_FSD		5	/* c.fsd, c.fsdsp */
+#define C_FUNCT3_FSW		7	/* c.fsw, c.fswsp, RV32 only */
+
+static bool is_compressed_fp_insn(uint16_t insn)
+{
+	uint16_t quadrant = insn & C_QUADRANT_MASK;
+	uint16_t funct3 = (insn >> C_FUNCT3_SHIFT) & C_FUNCT3_MASK;
+
+	if (quadrant != C_QUADRANT_0 && quadrant != C_QUADRANT_2)
+		return false;
+
+	if (funct3 == C_FUNCT3_FLD || funct3 == C_FUNCT3_FSD)
+		return true;
+
+#ifdef RV32
+	if (funct3 == C_FUNCT3_FLW || funct3 == C_FUNCT3_FSW)
+		return true;
+#endif
+
+	return false;
+}
+
+/*
+ * An FP instruction executed with xstatus.FS == Off traps as an illegal
+ * instruction. Recognising that case is what turns the first FP use by a
+ * TA into a request for an FP context instead of a panic.
+ *
+ * The decision is made on the faulting instruction, which the hart reports
+ * in xtval, so that a TA executing a genuinely illegal instruction still
+ * panics rather than being resumed on it forever.
+ */
 static bool is_vfp_fault(struct abort_info *ai)
 {
-	/* Implement */
-	return false;
+	unsigned long insn = ai->regs->tval;
+
+	if (ai->regs->cause != CAUSE_ILLEGAL_INSTRUCTION)
+		return false;
+
+	/* Only a context that had FP disabled can be asking for it */
+	if (riscv_fp_state_is_enabled(ai->regs->status))
+		return false;
+
+	if ((insn & INSN_LEN_MASK) != INSN_LEN_32BIT)
+		return is_compressed_fp_insn((uint16_t)insn);
+
+	return is_fp_insn((uint32_t)insn);
 }
 #else /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
 static bool is_vfp_fault(struct abort_info *ai __unused)
@@ -364,7 +488,7 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 		break;
 #ifdef CFG_WITH_VFP
 	case FAULT_TYPE_USER_MODE_VFP:
-		handle_user_mode_vfp();
+		handle_user_mode_vfp(&ai);
 		break;
 #endif
 	case FAULT_TYPE_PAGE_FAULT:

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -16,6 +16,7 @@
 #include <mm/mobj.h>
 #include <riscv.h>
 #include <riscv_fp.h>
+#include <riscv_vector.h>
 #include <tee/tee_svc.h>
 #include <trace.h>
 #include <unw/unwind.h>
@@ -23,6 +24,7 @@
 enum fault_type {
 	FAULT_TYPE_USER_MODE_PANIC,
 	FAULT_TYPE_USER_MODE_VFP,
+	FAULT_TYPE_USER_MODE_VECTOR,
 	FAULT_TYPE_PAGE_FAULT,
 	FAULT_TYPE_IGNORE,
 };
@@ -275,22 +277,32 @@ bool abort_is_user_exception(struct abort_info *ai __unused)
 }
 #endif /*CFG_WITH_USER_TA*/
 
-#if defined(CFG_WITH_VFP) && defined(CFG_WITH_USER_TA)
-/* Major opcodes of the F/D/Q extensions, all instructions are 32-bit */
+#if defined(CFG_WITH_USER_TA) && \
+	(defined(CFG_WITH_VFP) || defined(CFG_RISCV_WITH_VECTOR))
+/*
+ * Instruction fields shared by the floating-point and the vector decoders.
+ * The two extensions share the load and store major opcodes, told apart by
+ * the width field, and both trap accesses to their own CSRs when their unit
+ * is disabled.
+ */
 #define OPCODE_MASK		0x7f
-#define OPCODE_LOAD_FP		0x07	/* flw, fld, flq */
-#define OPCODE_STORE_FP		0x27	/* fsw, fsd, fsq */
-#define OPCODE_MADD		0x43	/* fmadd */
-#define OPCODE_MSUB		0x47	/* fmsub */
-#define OPCODE_NMSUB		0x4b	/* fnmsub */
-#define OPCODE_NMADD		0x4f	/* fnmadd */
-#define OPCODE_OP_FP		0x53	/* fadd, fsub, fcvt, fmv, ... */
+#define OPCODE_LOAD_FP		0x07	/* FP and vector loads */
+#define OPCODE_STORE_FP		0x27	/* FP and vector stores */
 #define OPCODE_SYSTEM		0x73	/* csrrw and friends */
 
 #define INSN_FUNCT3_SHIFT	12
 #define INSN_FUNCT3_MASK	0x7
 #define INSN_CSR_SHIFT		20
 #define INSN_CSR_MASK		0xfff
+#endif
+
+#if defined(CFG_WITH_VFP) && defined(CFG_WITH_USER_TA)
+/* Major opcodes of the F/D/Q extensions, all instructions are 32-bit */
+#define OPCODE_MADD		0x43	/* fmadd */
+#define OPCODE_MSUB		0x47	/* fmsub */
+#define OPCODE_NMSUB		0x4b	/* fnmsub */
+#define OPCODE_NMADD		0x4f	/* fnmadd */
+#define OPCODE_OP_FP		0x53	/* fadd, fsub, fcvt, fmv, ... */
 
 /*
  * With FS == Off a hart traps reads and writes of the floating-point CSRs
@@ -309,11 +321,38 @@ static bool is_fp_csr_insn(uint32_t insn)
 	return csr == CSR_FFLAGS || csr == CSR_FRM || csr == CSR_FCSR;
 }
 
+/*
+ * The load and store major opcodes are shared with the vector extension,
+ * which uses the width encodings the floating-point widths leave free. Both
+ * decoders have to look at the width, otherwise whichever runs first claims
+ * the other's instructions and hands the TA the wrong unit.
+ */
+#define WIDTH_FP_16		1	/* flh, fsh */
+#define WIDTH_FP_32		2	/* flw, fsw */
+#define WIDTH_FP_64		3	/* fld, fsd */
+#define WIDTH_FP_128		4	/* flq, fsq */
+
+static bool is_fp_ldst_insn(uint32_t insn)
+{
+	uint32_t width = (insn >> INSN_FUNCT3_SHIFT) & INSN_FUNCT3_MASK;
+
+	switch (width) {
+	case WIDTH_FP_16:
+	case WIDTH_FP_32:
+	case WIDTH_FP_64:
+	case WIDTH_FP_128:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static bool is_fp_insn(uint32_t insn)
 {
 	switch (insn & OPCODE_MASK) {
 	case OPCODE_LOAD_FP:
 	case OPCODE_STORE_FP:
+		return is_fp_ldst_insn(insn);
 	case OPCODE_MADD:
 	case OPCODE_MSUB:
 	case OPCODE_NMSUB:
@@ -401,11 +440,132 @@ static bool is_vfp_fault(struct abort_info *ai __unused)
 }
 #endif  /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
 
+#if defined(CFG_RISCV_WITH_VECTOR) && defined(CFG_WITH_USER_TA)
+#define OPCODE_OP_V		0x57	/* vadd, vsetvli, vsetvl, ... */
+
+/*
+ * The vector loads and stores share their major opcodes with the
+ * floating-point ones and are told apart by the width field, which holds
+ * the three reserved-for-vector encodings rather than one of the
+ * floating-point widths.
+ */
+#define WIDTH_VECTOR_8		0
+#define WIDTH_VECTOR_16		5
+#define WIDTH_VECTOR_32		6
+#define WIDTH_VECTOR_64		7
+
+static bool is_vector_ldst_insn(uint32_t insn)
+{
+	uint32_t width = (insn >> INSN_FUNCT3_SHIFT) & INSN_FUNCT3_MASK;
+
+	switch (width) {
+	case WIDTH_VECTOR_8:
+	case WIDTH_VECTOR_16:
+	case WIDTH_VECTOR_32:
+	case WIDTH_VECTOR_64:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/*
+ * With VS == Off a hart traps reads and writes of the vector CSRs exactly
+ * as it traps the vector instructions themselves, so a TA that asks for
+ * vlenb or sets a rounding mode before it issues any vector instruction
+ * has to be given a context just the same.
+ */
+static bool is_vector_csr_insn(uint32_t insn)
+{
+	uint32_t csr = (insn >> INSN_CSR_SHIFT) & INSN_CSR_MASK;
+
+	/* funct3 zero is ecall, ebreak and friends, not a CSR access */
+	if (!((insn >> INSN_FUNCT3_SHIFT) & INSN_FUNCT3_MASK))
+		return false;
+
+	switch (csr) {
+	case CSR_VSTART:
+	case CSR_VXSAT:
+	case CSR_VXRM:
+	case CSR_VCSR:
+	case CSR_VL:
+	case CSR_VTYPE:
+	case CSR_VLENB:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool is_vector_insn(uint32_t insn)
+{
+	switch (insn & OPCODE_MASK) {
+	case OPCODE_OP_V:
+		return true;
+	case OPCODE_LOAD_FP:
+	case OPCODE_STORE_FP:
+		return is_vector_ldst_insn(insn);
+	case OPCODE_SYSTEM:
+		return is_vector_csr_insn(insn);
+	default:
+		return false;
+	}
+}
+
+/*
+ * A vector instruction executed with xstatus.VS == Off traps as an illegal
+ * instruction. Recognising that case is what turns the first vector use by
+ * a TA into a request for a context instead of a panic.
+ *
+ * The decision is made on the faulting instruction, which the hart reports
+ * in xtval, so that a TA executing a genuinely illegal instruction still
+ * panics rather than being resumed on it forever. Vector instructions are
+ * always 32 bits wide, there are no compressed forms.
+ */
+static bool is_vector_fault(struct abort_info *ai)
+{
+	if (ai->regs->cause != CAUSE_ILLEGAL_INSTRUCTION)
+		return false;
+
+	/* Only a context that had vector disabled can be asking for it */
+	if (riscv_vector_state_is_enabled(ai->regs->status))
+		return false;
+
+	return is_vector_insn(ai->regs->tval);
+}
+
+static bool handle_user_mode_vector(struct abort_info *ai)
+{
+	struct ts_session *s = ts_get_current_session();
+
+	if (!thread_user_enable_vector(&to_user_mode_ctx(s->ctx)->vector))
+		return false;
+
+	/*
+	 * xstatus is restored from the saved context on the way back to the
+	 * TA, so handing it the vector unit means updating VS there and not
+	 * only in the live CSR. Without this the TA would resume with VS
+	 * still Off and trap on the very same instruction again.
+	 */
+	ai->regs->status = riscv_vector_set_vs(ai->regs->status,
+					       riscv_vector_read_vs());
+
+	return true;
+}
+#else /*CFG_RISCV_WITH_VECTOR && CFG_WITH_USER_TA*/
+static bool is_vector_fault(struct abort_info *ai __unused)
+{
+	return false;
+}
+#endif /*CFG_RISCV_WITH_VECTOR && CFG_WITH_USER_TA*/
+
 static enum fault_type get_fault_type(struct abort_info *ai)
 {
 	if (abort_is_user_exception(ai)) {
 		if (is_vfp_fault(ai))
 			return FAULT_TYPE_USER_MODE_VFP;
+		if (is_vector_fault(ai))
+			return FAULT_TYPE_USER_MODE_VECTOR;
 		return FAULT_TYPE_USER_MODE_PANIC;
 	}
 
@@ -489,6 +649,15 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 #ifdef CFG_WITH_VFP
 	case FAULT_TYPE_USER_MODE_VFP:
 		handle_user_mode_vfp(&ai);
+		break;
+#endif
+#if defined(CFG_RISCV_WITH_VECTOR) && defined(CFG_WITH_USER_TA)
+	case FAULT_TYPE_USER_MODE_VECTOR:
+		if (!handle_user_mode_vector(&ai)) {
+			EMSG("Out of memory for a TA vector context");
+			save_abort_info_in_tsd(&ai);
+			handle_user_mode_panic(&ai);
+		}
 		break;
 #endif
 	case FAULT_TYPE_PAGE_FAULT:

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -10,6 +10,7 @@
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <mm/core_mmu_arch.h>
+#include <riscv_fp.h>
 #include <types_ext.h>
 
 DEFINES
@@ -109,4 +110,9 @@ DEFINES
 	/* struct thread_abi_args */
 	DEFINE(THREAD_ABI_ARGS_A0, offsetof(struct thread_abi_args, a0));
 	DEFINE(THREAD_ABI_ARGS_SIZE, sizeof(struct thread_abi_args));
+
+#ifdef CFG_WITH_VFP
+	/* struct riscv_fp_state */
+	DEFINE(RISCV_FP_FCSR_OFF, offsetof(struct riscv_fp_state, fcsr));
+#endif
 }

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -11,6 +11,7 @@
 #include <mm/core_mmu.h>
 #include <mm/core_mmu_arch.h>
 #include <riscv_fp.h>
+#include <riscv_vector.h>
 #include <types_ext.h>
 
 DEFINES
@@ -114,5 +115,18 @@ DEFINES
 #ifdef CFG_WITH_VFP
 	/* struct riscv_fp_state */
 	DEFINE(RISCV_FP_FCSR_OFF, offsetof(struct riscv_fp_state, fcsr));
+#endif
+#ifdef CFG_RISCV_WITH_VECTOR
+	/* struct riscv_vector_state */
+	DEFINE(RISCV_VECTOR_VSTART_OFF,
+	       offsetof(struct riscv_vector_state, vstart));
+	DEFINE(RISCV_VECTOR_VTYPE_OFF,
+	       offsetof(struct riscv_vector_state, vtype));
+	DEFINE(RISCV_VECTOR_VL_OFF, offsetof(struct riscv_vector_state, vl));
+	DEFINE(RISCV_VECTOR_VCSR_OFF,
+	       offsetof(struct riscv_vector_state, vcsr));
+	DEFINE(RISCV_VECTOR_VREGS_OFF,
+	       offsetof(struct riscv_vector_state, vregs));
+	DEFINE(RISCV_VECTOR_NREGS, RISCV_VECTOR_NUM_REGS);
 #endif
 }

--- a/core/arch/riscv/kernel/riscv_fp.S
+++ b/core/arch/riscv/kernel/riscv_fp.S
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+#include <asm.S>
+#include <generated/asm-defines.h>
+#include <riscv.h>
+#include <riscv_fp.h>
+#include <riscv_macros.S>
+
+/*
+ * void riscv_save_fp_state(struct riscv_fp_state *state)
+ *
+ * Saves f0..f31 and fcsr. The floating-point unit is enabled for the
+ * duration of the transfer and xstatus is written back unmodified before
+ * returning, so the caller's FS state is preserved.
+ */
+FUNC riscv_save_fp_state , :
+	csrr	t1, CSR_XSTATUS
+	li	t0, CSR_XSTATUS_FS_MASK
+	csrs	CSR_XSTATUS, t0
+
+	store_fpregs a0, 0, 0, 31
+
+	frcsr	t0
+	sw	t0, RISCV_FP_FCSR_OFF(a0)
+
+	csrw	CSR_XSTATUS, t1
+	ret
+END_FUNC riscv_save_fp_state
+
+/*
+ * void riscv_restore_fp_state(struct riscv_fp_state *state)
+ *
+ * Loads f0..f31 and fcsr. Enables and restores xstatus as above.
+ */
+FUNC riscv_restore_fp_state , :
+	csrr	t1, CSR_XSTATUS
+	li	t0, CSR_XSTATUS_FS_MASK
+	csrs	CSR_XSTATUS, t0
+
+	load_fpregs a0, 0, 0, 31
+
+	lw	t0, RISCV_FP_FCSR_OFF(a0)
+	fscsr	t0
+
+	csrw	CSR_XSTATUS, t1
+	ret
+END_FUNC riscv_restore_fp_state

--- a/core/arch/riscv/kernel/riscv_vector.S
+++ b/core/arch/riscv/kernel/riscv_vector.S
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, RISCStar Solutions Limited
+ */
+
+#include <asm.S>
+#include <generated/asm-defines.h>
+#include <riscv.h>
+#include <riscv_macros.S>
+
+/*
+ * size_t riscv_vector_state_size(void)
+ *
+ * Returns the header plus 32 * vlenb. vlenb is only readable with the
+ * vector unit enabled, so it is enabled for the read and xstatus is put
+ * back untouched, as in the two routines below.
+ */
+FUNC riscv_vector_state_size , :
+	csrr	t1, CSR_XSTATUS
+	li	t0, CSR_XSTATUS_VS_MASK
+	csrs	CSR_XSTATUS, t0
+
+	csrr	a0, CSR_VLENB
+
+	csrw	CSR_XSTATUS, t1
+
+	li	t0, RISCV_VECTOR_NREGS
+	mul	a0, a0, t0
+	addi	a0, a0, RISCV_VECTOR_VREGS_OFF
+	ret
+END_FUNC riscv_vector_state_size
+
+/*
+ * void riscv_vector_save_state(struct riscv_vector_state *state)
+ *
+ * Saves v0..v31 and the vector CSRs. The vector unit is enabled for the
+ * duration of the transfer and xstatus is written back unmodified before
+ * returning, so the caller's VS state is preserved.
+ */
+FUNC riscv_vector_save_state , :
+	csrr	t1, CSR_XSTATUS
+	li	t0, CSR_XSTATUS_VS_MASK
+	csrs	CSR_XSTATUS, t0
+
+	/* Take the CSRs before vstart is cleared below */
+	csrr	t2, CSR_VSTART
+	STR	t2, RISCV_VECTOR_VSTART_OFF(a0)
+	csrr	t2, CSR_VTYPE
+	STR	t2, RISCV_VECTOR_VTYPE_OFF(a0)
+	csrr	t2, CSR_VL
+	STR	t2, RISCV_VECTOR_VL_OFF(a0)
+	csrr	t2, CSR_VCSR
+	STR	t2, RISCV_VECTOR_VCSR_OFF(a0)
+
+	/*
+	 * The whole-register stores below honour vstart and would skip the
+	 * elements below it, so start them from zero.
+	 */
+	csrw	CSR_VSTART, zero
+
+	csrr	t2, CSR_VLENB
+	addi	a1, a0, RISCV_VECTOR_VREGS_OFF
+	store_vregs a1, t2, t3
+
+	csrw	CSR_XSTATUS, t1
+	ret
+END_FUNC riscv_vector_save_state
+
+/*
+ * void riscv_vector_restore_state(struct riscv_vector_state *state)
+ *
+ * Loads v0..v31 and the vector CSRs. Enables and restores xstatus as above.
+ */
+FUNC riscv_vector_restore_state , :
+	csrr	t1, CSR_XSTATUS
+	li	t0, CSR_XSTATUS_VS_MASK
+	csrs	CSR_XSTATUS, t0
+
+	/* As above, the whole-register loads must start from vstart zero */
+	csrw	CSR_VSTART, zero
+
+	csrr	t2, CSR_VLENB
+	addi	a1, a0, RISCV_VECTOR_VREGS_OFF
+	load_vregs a1, t2, t3
+
+	/*
+	 * vl and vtype are read only, the pair is put back by re-running the
+	 * vsetvl that produced them.
+	 */
+	LDR	t2, RISCV_VECTOR_VL_OFF(a0)
+	LDR	t3, RISCV_VECTOR_VTYPE_OFF(a0)
+	.option push
+	.option arch, +v
+	vsetvl	zero, t2, t3
+	.option pop
+
+	LDR	t2, RISCV_VECTOR_VSTART_OFF(a0)
+	csrw	CSR_VSTART, t2
+	LDR	t2, RISCV_VECTOR_VCSR_OFF(a0)
+	csrw	CSR_VCSR, t2
+
+	csrw	CSR_XSTATUS, t1
+	ret
+END_FUNC riscv_vector_restore_state

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -18,6 +18,7 @@ srcs-$(CFG_UNWIND) += unwind_rv.c
 srcs-$(CFG_SEMIHOSTING) += semihosting_rv.S
 srcs-y += thread_optee_abi.c
 srcs-y += thread_optee_abi_rv.S
+srcs-$(CFG_WITH_VFP) += riscv_fp.S
 asm-defines-y += asm-defines.c
 
 ifeq ($(CFG_SYSCALL_FTRACE),y)

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -19,6 +19,7 @@ srcs-$(CFG_SEMIHOSTING) += semihosting_rv.S
 srcs-y += thread_optee_abi.c
 srcs-y += thread_optee_abi_rv.S
 srcs-$(CFG_WITH_VFP) += riscv_fp.S
+srcs-$(CFG_RISCV_WITH_VECTOR) += riscv_vector.S
 asm-defines-y += asm-defines.c
 
 ifeq ($(CFG_SYSCALL_FTRACE),y)

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -111,6 +111,11 @@ static void thread_fp_release(struct thread_ctx *thr)
 		riscv_save_fp_state(&thr->vfp_state.sec);
 		thr->vfp_state.sec_valid = true;
 		break;
+	case RISCV_FP_OWNER_USER:
+		assert(thr->vfp_state.uvfp);
+		riscv_save_fp_state(&thr->vfp_state.uvfp->fp);
+		thr->vfp_state.uvfp->valid = true;
+		break;
 	default:
 		panic();
 	}
@@ -119,6 +124,21 @@ static void thread_fp_release(struct thread_ctx *thr)
 	riscv_fp_disable();
 }
 #endif /*CFG_WITH_VFP*/
+
+/*
+ * A TA runs with the FP unit disabled until it executes an FP instruction
+ * and traps, so whenever its FP context is saved and released the saved
+ * xstatus has to go back to FS == Off. Unlike the ARM FPEXC.EN, FS is part
+ * of the register frame restored on the way back to user mode, so it is
+ * the saved copy that decides whether the TA traps again.
+ */
+static unsigned long user_status_disable_fp(unsigned long status)
+{
+	if (IS_ENABLED(CFG_WITH_VFP))
+		return riscv_fp_set_fs(status, CSR_XSTATUS_FS_OFF);
+
+	return status;
+}
 
 static void thread_save_ns_vfp(void)
 {
@@ -213,6 +233,7 @@ void thread_scall_handler(struct thread_scall_regs *regs)
 	thread_unmask_exceptions(state & ~THREAD_EXCP_NATIVE_INTR);
 
 	thread_user_save_vfp();
+	regs->status = user_status_disable_fp(regs->status);
 
 	sess = ts_get_current_session();
 
@@ -526,6 +547,7 @@ int thread_state_suspend(uint32_t flags, unsigned long status, vaddr_t pc)
 
 	if (is_from_user(status)) {
 		thread_user_save_vfp();
+		status = user_status_disable_fp(status);
 		tee_ta_update_session_utime_suspend();
 		tee_ta_gprof_sample_pc(pc);
 	}
@@ -641,7 +663,8 @@ uint32_t thread_enter_user_mode(unsigned long a0, unsigned long a1,
 	 */
 	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 	regs = thread_get_ctx_regs();
-	status = xstatus_for_xret(true, PRV_U);
+	/* A TA starts with FP disabled and is given the FP unit on first use */
+	status = user_status_disable_fp(xstatus_for_xret(true, PRV_U));
 	set_ctx_regs(regs, a0, a1, a2, a3, user_sp, entry_func, status, ie,
 		     NULL);
 	rc = __thread_enter_user_mode(regs, exit_status0, exit_status1);
@@ -720,6 +743,101 @@ void thread_kernel_save_vfp(void)
 	riscv_save_fp_state(&thr->vfp_state.sec);
 	thr->vfp_state.sec_valid = true;
 	thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+	riscv_fp_disable();
+}
+
+static void thread_fp_clear_regs(void)
+{
+	struct riscv_fp_state zero_state = { };
+
+	riscv_restore_fp_state(&zero_state);
+}
+
+/*
+ * A TA is given the FP unit the first time it executes an FP instruction,
+ * rather than on every entry to user mode. Within the TEE, OP-TEE owns FS
+ * and no other context can look at the f registers behind our back, so
+ * there is nothing to defend against here, and most TAs never touch FP.
+ * Enabling on first use keeps those TAs from paying for a context switch
+ * they have no use for.
+ */
+void thread_user_enable_vfp(struct thread_user_vfp_state *uvfp)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+
+	assert(uvfp);
+
+	/* Take the f registers away from whoever holds them */
+	thread_fp_release(thr);
+
+	if (uvfp->valid) {
+		riscv_restore_fp_state(&uvfp->fp);
+		riscv_fp_write_fs(CSR_XSTATUS_FS_CLEAN);
+	} else {
+		/*
+		 * This TA has no FP context yet. Clear the registers before
+		 * handing them over: FS == Initial says the context is new,
+		 * but enabling the FP unit does not architecturally clear
+		 * the register file, so the TA would otherwise start out
+		 * seeing what the previous owner left there.
+		 */
+		thread_fp_clear_regs();
+		riscv_fp_write_fs(CSR_XSTATUS_FS_INITIAL);
+	}
+
+	thr->vfp_state.uvfp = uvfp;
+	thr->vfp_state.owner = RISCV_FP_OWNER_USER;
+	thr->vfp_state.sec_used = true;
+
+	thread_set_exceptions(exceptions);
+}
+
+void thread_user_save_vfp(void)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+
+	/* The TA either never used FP or has already been saved */
+	if (thr->vfp_state.owner != RISCV_FP_OWNER_USER)
+		return;
+
+	thread_fp_release(thr);
+}
+
+void thread_user_clear_vfp(struct user_mode_ctx *uctx)
+{
+	struct thread_user_vfp_state *uvfp = &uctx->vfp;
+	struct thread_ctx *thr = threads + thread_get_id();
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+
+	if (uvfp == thr->vfp_state.uvfp) {
+		if (thr->vfp_state.owner == RISCV_FP_OWNER_USER) {
+			thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+			riscv_fp_disable();
+		}
+		thr->vfp_state.uvfp = NULL;
+	}
+
+	memset(uvfp, 0, sizeof(*uvfp));
+
+	thread_set_exceptions(exceptions);
+}
+
+void vfp_disable(void)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	/*
+	 * The TA is about to be killed and its FP context dies with it, so
+	 * the registers are released rather than saved. What they hold is
+	 * overwritten by the normal world context before that world resumes,
+	 * see thread_restore_ns_vfp().
+	 */
+	if (thr->vfp_state.owner == RISCV_FP_OWNER_USER)
+		thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+
 	riscv_fp_disable();
 }
 

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -221,6 +221,13 @@ static void thread_vector_release(struct thread_ctx *thr)
 		riscv_vector_save_state(thr->vector_state.ns);
 		thr->vector_state.ns_valid = true;
 		break;
+	case RISCV_VECTOR_OWNER_KERNEL:
+		/*
+		 * A secure kernel section runs with foreign interrupts
+		 * masked from end to end, so it cannot be preempted and
+		 * its registers have no life beyond it. Nothing to save.
+		 */
+		break;
 	case RISCV_VECTOR_OWNER_USER:
 		assert(thr->vector_state.uvect &&
 		       thr->vector_state.uvect->state);
@@ -332,6 +339,7 @@ static void thread_restore_ns_vector(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 
 	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+	assert(thr->vector_state.owner != RISCV_VECTOR_OWNER_KERNEL);
 
 	/* Release the registers from whatever secure context holds them */
 	thread_vector_release(thr);
@@ -1044,6 +1052,52 @@ static void thread_vector_clear_regs(struct riscv_vector_state *state)
  * from paying for a context switch they have no use for, which for vector
  * is a good deal larger than it is for floating point.
  */
+uint32_t thread_kernel_enable_vector(void)
+{
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	/*
+	 * The section runs to thread_kernel_disable_vector(), which is also
+	 * where the foreign interrupt mask is restored. Nesting is not
+	 * supported.
+	 */
+	assert(thr->vector_state.owner != RISCV_VECTOR_OWNER_KERNEL);
+
+	/* Take the vector registers away from whoever holds them */
+	thread_vector_release(thr);
+
+	/*
+	 * VS == Initial enables the unit and says the registers hold no
+	 * context worth preserving, which is what core code wants: it sets
+	 * up its own vtype and vl before touching them.
+	 */
+	riscv_vector_write_vs(CSR_XSTATUS_VS_INITIAL);
+
+	thr->vector_state.owner = RISCV_VECTOR_OWNER_KERNEL;
+	thr->vector_state.sec_used = true;
+
+	return exceptions;
+}
+
+void thread_kernel_disable_vector(uint32_t state)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+	uint32_t exceptions = 0;
+
+	assert(thr->vector_state.owner == RISCV_VECTOR_OWNER_KERNEL);
+	assert(riscv_vector_is_enabled());
+
+	thr->vector_state.owner = RISCV_VECTOR_OWNER_NONE;
+	riscv_vector_disable();
+
+	exceptions = thread_get_exceptions();
+	assert(exceptions & THREAD_EXCP_FOREIGN_INTR);
+	exceptions &= ~THREAD_EXCP_FOREIGN_INTR;
+	exceptions |= state & THREAD_EXCP_FOREIGN_INTR;
+	thread_set_exceptions(exceptions);
+}
+
 bool thread_user_enable_vector(struct thread_user_vector_state *uvect)
 {
 	struct thread_ctx *thr = threads + thread_get_id();

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -221,6 +221,12 @@ static void thread_vector_release(struct thread_ctx *thr)
 		riscv_vector_save_state(thr->vector_state.ns);
 		thr->vector_state.ns_valid = true;
 		break;
+	case RISCV_VECTOR_OWNER_USER:
+		assert(thr->vector_state.uvect &&
+		       thr->vector_state.uvect->state);
+		riscv_vector_save_state(thr->vector_state.uvect->state);
+		thr->vector_state.uvect->valid = true;
+		break;
 	default:
 		panic();
 	}
@@ -272,6 +278,21 @@ static void init_vector_state(struct thread_ctx *thread __maybe_unused)
 	thread->vector_state.ns = ns;
 	thread->vector_state.owner = RISCV_VECTOR_OWNER_NS;
 #endif /*CFG_RISCV_WITH_VECTOR*/
+}
+
+/*
+ * A TA runs with the vector unit disabled until it executes a vector
+ * instruction and traps, so whenever its context is saved and released the
+ * saved xstatus has to go back to VS == Off. VS is part of the register
+ * frame restored on the way back to user mode, so it is the saved copy
+ * that decides whether the TA traps again.
+ */
+static unsigned long user_status_disable_vector(unsigned long status)
+{
+	if (IS_ENABLED(CFG_RISCV_WITH_VECTOR))
+		return riscv_vector_set_vs(status, CSR_XSTATUS_VS_OFF);
+
+	return status;
 }
 
 static void thread_save_ns_vector(void)
@@ -367,7 +388,9 @@ void thread_scall_handler(struct thread_scall_regs *regs)
 	thread_unmask_exceptions(state & ~THREAD_EXCP_NATIVE_INTR);
 
 	thread_user_save_vfp();
+	thread_user_save_vector();
 	regs->status = user_status_disable_fp(regs->status);
+	regs->status = user_status_disable_vector(regs->status);
 
 	sess = ts_get_current_session();
 
@@ -685,7 +708,9 @@ int thread_state_suspend(uint32_t flags, unsigned long status, vaddr_t pc)
 
 	if (is_from_user(status)) {
 		thread_user_save_vfp();
+		thread_user_save_vector();
 		status = user_status_disable_fp(status);
+		status = user_status_disable_vector(status);
 		tee_ta_update_session_utime_suspend();
 		tee_ta_gprof_sample_pc(pc);
 	}
@@ -802,8 +827,13 @@ uint32_t thread_enter_user_mode(unsigned long a0, unsigned long a1,
 	 */
 	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 	regs = thread_get_ctx_regs();
-	/* A TA starts with FP disabled and is given the FP unit on first use */
-	status = user_status_disable_fp(xstatus_for_xret(true, PRV_U));
+	/*
+	 * A TA starts with both the FP and the vector unit disabled and is
+	 * given each on its first use.
+	 */
+	status = xstatus_for_xret(true, PRV_U);
+	status = user_status_disable_fp(status);
+	status = user_status_disable_vector(status);
 	set_ctx_regs(regs, a0, a1, a2, a3, user_sp, entry_func, status, ie,
 		     NULL);
 	rc = __thread_enter_user_mode(regs, exit_status0, exit_status1);
@@ -997,3 +1027,104 @@ void thread_kernel_restore_vfp(void)
 	thr->vfp_state.sec_used = true;
 }
 #endif /*CFG_WITH_VFP*/
+
+#ifdef CFG_RISCV_WITH_VECTOR
+static void thread_vector_clear_regs(struct riscv_vector_state *state)
+{
+	memset(state, 0, riscv_vector_state_size());
+	riscv_vector_restore_state(state);
+}
+
+/*
+ * A TA is given the vector unit the first time it executes a vector
+ * instruction, rather than on every entry to user mode. Within the TEE,
+ * OP-TEE alone owns VS and no other context can look at the vector
+ * registers behind our back, so there is nothing to defend against here,
+ * and most TAs never touch vector. Enabling on first use keeps those TAs
+ * from paying for a context switch they have no use for, which for vector
+ * is a good deal larger than it is for floating point.
+ */
+bool thread_user_enable_vector(struct thread_user_vector_state *uvect)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+	uint32_t exceptions = 0;
+
+	assert(uvect);
+
+	/*
+	 * The TA's context is allocated the first time it asks for the
+	 * vector unit, so a TA that never uses vector costs nothing beyond
+	 * the flag. Do it before masking, allocation may sleep on a mutex.
+	 */
+	if (!uvect->state) {
+		uvect->state = memalign(__alignof__(long),
+					riscv_vector_state_size());
+		if (!uvect->state)
+			return false;
+		uvect->valid = false;
+	}
+
+	exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+
+	/* Take the vector registers away from whoever holds them */
+	thread_vector_release(thr);
+
+	if (uvect->valid) {
+		riscv_vector_restore_state(uvect->state);
+		riscv_vector_write_vs(CSR_XSTATUS_VS_CLEAN);
+	} else {
+		/*
+		 * This TA has no vector context yet. Clear the registers
+		 * before handing them over: VS == Initial says the context
+		 * is new, but enabling the unit does not architecturally
+		 * clear the register file, so the TA would otherwise start
+		 * out seeing what the previous owner left there.
+		 */
+		thread_vector_clear_regs(uvect->state);
+		riscv_vector_write_vs(CSR_XSTATUS_VS_INITIAL);
+	}
+
+	thr->vector_state.uvect = uvect;
+	thr->vector_state.owner = RISCV_VECTOR_OWNER_USER;
+	thr->vector_state.sec_used = true;
+
+	thread_set_exceptions(exceptions);
+
+	return true;
+}
+
+void thread_user_save_vector(void)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+
+	/* The TA either never used vector or has already been saved */
+	if (thr->vector_state.owner != RISCV_VECTOR_OWNER_USER)
+		return;
+
+	thread_vector_release(thr);
+}
+
+void thread_user_clear_vector(struct user_mode_ctx *uctx)
+{
+	struct thread_user_vector_state *uvect = &uctx->vector;
+	struct thread_ctx *thr = threads + thread_get_id();
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+
+	if (uvect == thr->vector_state.uvect) {
+		if (thr->vector_state.owner == RISCV_VECTOR_OWNER_USER) {
+			thr->vector_state.owner = RISCV_VECTOR_OWNER_NONE;
+			riscv_vector_disable();
+		}
+		thr->vector_state.uvect = NULL;
+	}
+
+	uvect->valid = false;
+
+	thread_set_exceptions(exceptions);
+
+	free(uvect->state);
+	uvect->state = NULL;
+}
+#endif /*CFG_RISCV_WITH_VECTOR*/

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -29,8 +29,11 @@
 #include <mm/mobj.h>
 #include <mm/tee_mm.h>
 #include <mm/vm.h>
+#include <initcall.h>
+#include <malloc.h>
 #include <riscv.h>
 #include <riscv_fp.h>
+#include <riscv_vector.h>
 #include <string.h>
 #include <trace.h>
 #include <util.h>
@@ -199,6 +202,137 @@ static void thread_restore_ns_vfp(void)
 	riscv_fp_write_fs(thr->vfp_state.ns_fs);
 	thr->vfp_state.owner = RISCV_FP_OWNER_NS;
 #endif /*CFG_WITH_VFP*/
+}
+
+#ifdef CFG_RISCV_WITH_VECTOR
+/*
+ * The normal world vector context is switched eagerly at the domain
+ * boundary: the registers are saved on the way in and the unit is
+ * disabled, so nothing of the normal world is reachable from secure code,
+ * and whatever secure code puts in the registers is overwritten before the
+ * normal world resumes.
+ */
+static void thread_vector_release(struct thread_ctx *thr)
+{
+	switch (thr->vector_state.owner) {
+	case RISCV_VECTOR_OWNER_NONE:
+		return;
+	case RISCV_VECTOR_OWNER_NS:
+		riscv_vector_save_state(thr->vector_state.ns);
+		thr->vector_state.ns_valid = true;
+		break;
+	default:
+		panic();
+	}
+
+	thr->vector_state.owner = RISCV_VECTOR_OWNER_NONE;
+	riscv_vector_disable();
+}
+
+/*
+ * A context is sized from the vlenb of the hart it will run on, so the
+ * normal world contexts are allocated once here rather than in the domain
+ * switch, which then has no allocation and so no failure path in it.
+ */
+static TEE_Result riscv_vector_init(void)
+{
+	size_t size = riscv_vector_state_size();
+	size_t n = 0;
+
+	for (n = 0; n < CFG_NUM_THREADS; n++) {
+		threads[n].vector_state.ns = memalign(__alignof__(long), size);
+		if (!threads[n].vector_state.ns) {
+			EMSG("Failed to allocate %zu bytes of vector context",
+			     size);
+			panic();
+		}
+		memset(threads[n].vector_state.ns, 0, size);
+	}
+
+	DMSG("Vector context switching enabled, vlenb %lu, %zu bytes a context",
+	     riscv_vector_vlenb(), size);
+
+	return TEE_SUCCESS;
+}
+service_init(riscv_vector_init);
+#endif /*CFG_RISCV_WITH_VECTOR*/
+
+static void init_vector_state(struct thread_ctx *thread __maybe_unused)
+{
+#ifdef CFG_RISCV_WITH_VECTOR
+	/*
+	 * The thread slot may have been used before, so start from a clean
+	 * state, keeping the buffer allocated for it at boot. The vector
+	 * registers hold the normal world context at this point, which
+	 * thread_save_ns_vector() takes care of below.
+	 */
+	struct riscv_vector_state *ns = thread->vector_state.ns;
+
+	memset(&thread->vector_state, 0, sizeof(thread->vector_state));
+	thread->vector_state.ns = ns;
+	thread->vector_state.owner = RISCV_VECTOR_OWNER_NS;
+#endif /*CFG_RISCV_WITH_VECTOR*/
+}
+
+static void thread_save_ns_vector(void)
+{
+#ifdef CFG_RISCV_WITH_VECTOR
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+	assert(thr->vector_state.owner == RISCV_VECTOR_OWNER_NS);
+
+	/*
+	 * The save cannot be made conditional on the normal world VS. A
+	 * monitor that gives each domain its own S-mode CSRs, as OpenSBI
+	 * does for the domain it runs OP-TEE in, swaps xstatus across the
+	 * domain switch while leaving the vector registers shared. The VS
+	 * read here is therefore OP-TEE's own and says nothing about
+	 * whether the normal world has a live vector context.
+	 *
+	 * VS is saved and put back all the same, so that a monitor which
+	 * does share xstatus between the domains gets the normal world VS
+	 * it had on entry rather than the Off that OP-TEE runs with.
+	 */
+	assert(thr->vector_state.ns);
+	thr->vector_state.ns_vs = riscv_vector_read_vs();
+	riscv_vector_save_state(thr->vector_state.ns);
+	thr->vector_state.ns_valid = true;
+	thr->vector_state.sec_used = false;
+
+	thr->vector_state.owner = RISCV_VECTOR_OWNER_NONE;
+	riscv_vector_disable();
+#endif /*CFG_RISCV_WITH_VECTOR*/
+}
+
+static void thread_restore_ns_vector(void)
+{
+#ifdef CFG_RISCV_WITH_VECTOR
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+
+	/* Release the registers from whatever secure context holds them */
+	thread_vector_release(thr);
+
+	/*
+	 * This is where the VS tracking pays off. Secure code only reaches
+	 * the vector registers by taking VS out of Off, so if that never
+	 * happened they still hold exactly what the normal world left in
+	 * them and the restore can be skipped. A thread running a TA that
+	 * never touches vector, which is most of them, costs one save per
+	 * call and no restore.
+	 */
+	if (thr->vector_state.sec_used) {
+		assert(thr->vector_state.ns_valid);
+		riscv_vector_restore_state(thr->vector_state.ns);
+	}
+
+	thr->vector_state.ns_valid = false;
+	thr->vector_state.sec_used = false;
+	riscv_vector_write_vs(thr->vector_state.ns_vs);
+	thr->vector_state.owner = RISCV_VECTOR_OWNER_NS;
+#endif /*CFG_RISCV_WITH_VECTOR*/
 }
 
 static void setup_unwind_user_mode(struct thread_scall_regs *regs)
@@ -375,8 +509,10 @@ static void __thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2,
 	threads[n].flags = 0;
 	init_regs(threads + n, a0, a1, a2, a3, a4, a5, a6, a7, pc);
 	init_vfp_state(threads + n);
+	init_vector_state(threads + n);
 
 	thread_save_ns_vfp();
+	thread_save_ns_vector();
 
 	l->flags &= ~THREAD_CLF_TMP;
 
@@ -502,6 +638,7 @@ void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,
 	}
 
 	thread_save_ns_vfp();
+	thread_save_ns_vector();
 
 	if (threads[n].have_user_map)
 		ftrace_resume();
@@ -520,6 +657,7 @@ void thread_state_free(void)
 	assert(ct != THREAD_ID_INVALID);
 
 	thread_restore_ns_vfp();
+	thread_restore_ns_vector();
 
 	thread_lock_global();
 
@@ -552,6 +690,7 @@ int thread_state_suspend(uint32_t flags, unsigned long status, vaddr_t pc)
 		tee_ta_gprof_sample_pc(pc);
 	}
 	thread_restore_ns_vfp();
+	thread_restore_ns_vector();
 
 	thread_lock_global();
 

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -30,6 +30,8 @@
 #include <mm/tee_mm.h>
 #include <mm/vm.h>
 #include <riscv.h>
+#include <riscv_fp.h>
+#include <string.h>
 #include <trace.h>
 #include <util.h>
 
@@ -86,14 +88,97 @@ void __nostackcheck thread_unmask_exceptions(uint32_t state)
 	thread_set_exceptions(state & THREAD_EXCP_ALL);
 }
 
-static void thread_lazy_save_ns_vfp(void)
+#ifdef CFG_WITH_VFP
+/*
+ * The normal world FP context is switched eagerly at the domain boundary:
+ * the f registers are saved on the way in and the FP unit is disabled, so
+ * nothing of the normal world is reachable from secure code, and whatever
+ * secure code puts in the registers is overwritten before the normal world
+ * resumes. Lazy switching cannot give that, since it leaves the peer's
+ * registers live and relies on a trap that only fires if the other side
+ * happens to touch FP.
+ */
+static void thread_fp_release(struct thread_ctx *thr)
 {
-	static_assert(!IS_ENABLED(CFG_WITH_VFP));
+	switch (thr->vfp_state.owner) {
+	case RISCV_FP_OWNER_NONE:
+		return;
+	case RISCV_FP_OWNER_NS:
+		riscv_save_fp_state(&thr->vfp_state.ns);
+		thr->vfp_state.ns_valid = true;
+		break;
+	case RISCV_FP_OWNER_KERNEL:
+		riscv_save_fp_state(&thr->vfp_state.sec);
+		thr->vfp_state.sec_valid = true;
+		break;
+	default:
+		panic();
+	}
+
+	thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+	riscv_fp_disable();
+}
+#endif /*CFG_WITH_VFP*/
+
+static void thread_save_ns_vfp(void)
+{
+#ifdef CFG_WITH_VFP
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+	assert(thr->vfp_state.owner == RISCV_FP_OWNER_NS);
+
+	/*
+	 * The save cannot be made conditional on the normal world FS. A
+	 * monitor that gives each domain its own S-mode CSRs, as OpenSBI
+	 * does for the domain it runs OP-TEE in, swaps xstatus across the
+	 * domain switch while leaving the f registers shared. The FS read
+	 * here is therefore OP-TEE's own and says nothing about whether the
+	 * normal world has a live FP context.
+	 *
+	 * FS is saved and put back all the same, so that a monitor which
+	 * does share xstatus between the domains gets the normal world FS
+	 * it had on entry rather than the Off that OP-TEE runs with.
+	 */
+	thr->vfp_state.ns_fs = riscv_fp_read_fs();
+	riscv_save_fp_state(&thr->vfp_state.ns);
+	thr->vfp_state.ns_valid = true;
+	thr->vfp_state.sec_used = false;
+
+	thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+	riscv_fp_disable();
+#endif /*CFG_WITH_VFP*/
 }
 
-static void thread_lazy_restore_ns_vfp(void)
+static void thread_restore_ns_vfp(void)
 {
-	static_assert(!IS_ENABLED(CFG_WITH_VFP));
+#ifdef CFG_WITH_VFP
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+	assert(thr->vfp_state.owner != RISCV_FP_OWNER_KERNEL);
+
+	/* Release the f registers from whatever secure context holds them */
+	thread_fp_release(thr);
+
+	/*
+	 * This is where the FS tracking pays off. Secure code only reaches
+	 * the f registers by taking FS out of Off, so if that never happened
+	 * the registers still hold exactly what the normal world left in
+	 * them and the restore can be skipped. A thread running a TA that
+	 * never touches FP, which is most of them, costs one save per call
+	 * and no restore.
+	 */
+	if (thr->vfp_state.sec_used) {
+		assert(thr->vfp_state.ns_valid);
+		riscv_restore_fp_state(&thr->vfp_state.ns);
+	}
+
+	thr->vfp_state.ns_valid = false;
+	thr->vfp_state.sec_used = false;
+	riscv_fp_write_fs(thr->vfp_state.ns_fs);
+	thr->vfp_state.owner = RISCV_FP_OWNER_NS;
+#endif /*CFG_WITH_VFP*/
 }
 
 static void setup_unwind_user_mode(struct thread_scall_regs *regs)
@@ -225,6 +310,19 @@ static void init_regs(struct thread_ctx *thread, uint32_t a0, uint32_t a1,
 	thread->regs.a7 = a7;
 }
 
+static void init_vfp_state(struct thread_ctx *thread __maybe_unused)
+{
+#ifdef CFG_WITH_VFP
+	/*
+	 * The thread slot may have been used before, so start from a clean
+	 * state. The f registers hold the normal world context at this
+	 * point, which thread_save_ns_vfp() takes care of below.
+	 */
+	memset(&thread->vfp_state, 0, sizeof(thread->vfp_state));
+	thread->vfp_state.owner = RISCV_FP_OWNER_NS;
+#endif /*CFG_WITH_VFP*/
+}
+
 static void __thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2,
 				   uint32_t a3, uint32_t a4, uint32_t a5,
 				   uint32_t a6, uint32_t a7,
@@ -255,8 +353,9 @@ static void __thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2,
 
 	threads[n].flags = 0;
 	init_regs(threads + n, a0, a1, a2, a3, a4, a5, a6, a7, pc);
+	init_vfp_state(threads + n);
 
-	thread_lazy_save_ns_vfp();
+	thread_save_ns_vfp();
 
 	l->flags &= ~THREAD_CLF_TMP;
 
@@ -381,7 +480,7 @@ void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,
 		threads[n].flags &= ~THREAD_FLAGS_COPY_ARGS_ON_RETURN;
 	}
 
-	thread_lazy_save_ns_vfp();
+	thread_save_ns_vfp();
 
 	if (threads[n].have_user_map)
 		ftrace_resume();
@@ -399,7 +498,7 @@ void thread_state_free(void)
 
 	assert(ct != THREAD_ID_INVALID);
 
-	thread_lazy_restore_ns_vfp();
+	thread_restore_ns_vfp();
 
 	thread_lock_global();
 
@@ -430,7 +529,7 @@ int thread_state_suspend(uint32_t flags, unsigned long status, vaddr_t pc)
 		tee_ta_update_session_utime_suspend();
 		tee_ta_gprof_sample_pc(pc);
 	}
-	thread_lazy_restore_ns_vfp();
+	thread_restore_ns_vfp();
 
 	thread_lock_global();
 
@@ -555,3 +654,89 @@ void __thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS])
 {
 	thread_rpc_xstatus(rv, xstatus_for_xret(false, PRV_S));
 }
+
+#ifdef CFG_WITH_VFP
+uint32_t thread_kernel_enable_vfp(void)
+{
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	/*
+	 * The FP section runs to thread_kernel_disable_vfp(), which is also
+	 * where the foreign interrupt mask is restored. Nesting is not
+	 * supported.
+	 */
+	assert(thr->vfp_state.owner != RISCV_FP_OWNER_KERNEL);
+
+	/* Take the f registers away from whoever holds them */
+	thread_fp_release(thr);
+
+	if (thr->vfp_state.sec_valid) {
+		riscv_restore_fp_state(&thr->vfp_state.sec);
+		thr->vfp_state.sec_valid = false;
+		riscv_fp_write_fs(CSR_XSTATUS_FS_CLEAN);
+	} else {
+		riscv_fp_write_fs(CSR_XSTATUS_FS_INITIAL);
+	}
+
+	thr->vfp_state.owner = RISCV_FP_OWNER_KERNEL;
+	thr->vfp_state.sec_used = true;
+
+	return exceptions;
+}
+
+void thread_kernel_disable_vfp(uint32_t state)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+	uint32_t exceptions = 0;
+
+	assert(thr->vfp_state.owner == RISCV_FP_OWNER_KERNEL);
+	assert(riscv_fp_is_enabled());
+
+	/*
+	 * The secure kernel FP context has no life beyond the section that
+	 * is ending here, so it is dropped rather than saved.
+	 */
+	thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+	thr->vfp_state.sec_valid = false;
+	riscv_fp_disable();
+
+	exceptions = thread_get_exceptions();
+	assert(exceptions & THREAD_EXCP_FOREIGN_INTR);
+	exceptions &= ~THREAD_EXCP_FOREIGN_INTR;
+	exceptions |= state & THREAD_EXCP_FOREIGN_INTR;
+	thread_set_exceptions(exceptions);
+}
+
+void thread_kernel_save_vfp(void)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+
+	if (thr->vfp_state.owner != RISCV_FP_OWNER_KERNEL)
+		return;
+
+	riscv_save_fp_state(&thr->vfp_state.sec);
+	thr->vfp_state.sec_valid = true;
+	thr->vfp_state.owner = RISCV_FP_OWNER_NONE;
+	riscv_fp_disable();
+}
+
+void thread_kernel_restore_vfp(void)
+{
+	struct thread_ctx *thr = threads + thread_get_id();
+
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+	assert(thr->vfp_state.owner == RISCV_FP_OWNER_NONE);
+
+	if (!thr->vfp_state.sec_valid)
+		return;
+
+	riscv_restore_fp_state(&thr->vfp_state.sec);
+	thr->vfp_state.sec_valid = false;
+	riscv_fp_write_fs(CSR_XSTATUS_FS_CLEAN);
+	thr->vfp_state.owner = RISCV_FP_OWNER_KERNEL;
+	thr->vfp_state.sec_used = true;
+}
+#endif /*CFG_WITH_VFP*/

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -3,6 +3,7 @@ $(call force,CFG_RV64_core,y)
 # ISA extension flags
 $(call force,CFG_RISCV_ISA_C,y)
 $(call force,CFG_RISCV_FPU,y)
+CFG_RISCV_VEC ?= y
 
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_RESERVED_SHM,n)

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -3,6 +3,9 @@ $(call force,CFG_RV64_core,y)
 # ISA extension flags
 $(call force,CFG_RISCV_ISA_C,y)
 $(call force,CFG_RISCV_FPU,y)
+
+# QEMU virt provides the vector crypto extensions
+CFG_CRYPTO_AES_RISCV_ZVKNED ?= n
 CFG_RISCV_VEC ?= y
 
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -102,6 +102,35 @@ $(call force,CFG_ARM_GICV3,n)
 $(call force,CFG_WITH_STMM_SP,n)
 $(call force,CFG_TA_BTI,n)
 
+# AES acceleration with the Zvkned vector crypto extension, and its CTR mode
+# with Zvkb on top. The assembly turns each extension on for itself with
+# .option arch, so the core is not built for them, but the vector registers
+# they use are real state that OP-TEE has to preserve, so this selects both
+# the vector ISA and the context switching. It has to come before those two
+# are given their defaults below, because force refuses to move a flag that
+# already has a value.
+#
+# Zvkb is a separate flag because it is a separate extension, needed only by
+# the CTR code, but the two are not separable in practice: CTR is one of the
+# entry points the LibTomCrypt glue names unconditionally, so the
+# accelerator cannot be built without it. The standard vector crypto suites
+# bundle them anyway (Zvkn is Zvkned + Zvknhb + Zvkb), so a platform with the
+# AES instructions has vrev8.v as well.
+#
+# XTS is the remaining accelerated entry point and is not implemented here,
+# so a core built with this on does not link yet.
+CFG_CRYPTO_AES_RISCV_ZVKNED ?= n
+ifeq ($(CFG_CRYPTO_AES_RISCV_ZVKNED),y)
+ifneq ($(CFG_RV64_core),y)
+$(error CFG_CRYPTO_AES_RISCV_ZVKNED requires CFG_RV64_core=y)
+endif
+$(call force,CFG_CRYPTO_AES_RISCV_ZVKNED_ZVKB,y,required by \
+	CFG_CRYPTO_AES_RISCV_ZVKNED)
+$(call force,CFG_WITH_VFP,y,required by CFG_CRYPTO_AES_RISCV_ZVKNED)
+$(call force,CFG_RISCV_VEC,y,required by CFG_CRYPTO_AES_RISCV_ZVKNED)
+endif
+
+
 # CFG_WITH_VFP asks OP-TEE to context switch the extended register state.
 # Which register files that covers follows the extensions the platform says
 # the hart has: the floating-point registers when CFG_RISCV_FPU=y and the
@@ -131,7 +160,7 @@ $(call force,CFG_CORE_HAS_GENERIC_TIMER,y)
 
 core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
-	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
+	$(addprefix $(arch-dir)/, kernel mm tee crypto) $(platform-dir)
 
 # Default values for "-mcmodel" compiler flag
 riscv-platform-mcmodel ?= medany

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -104,8 +104,8 @@ $(call force,CFG_TA_BTI,n)
 
 # CFG_WITH_VFP asks OP-TEE to context switch the extended register state.
 # Which register files that covers follows the extensions the platform says
-# the hart has, so this series switches the floating-point registers when
-# CFG_RISCV_FPU=y. It does not need a knob of its own.
+# the hart has: the floating-point registers when CFG_RISCV_FPU=y and the
+# vector registers when CFG_RISCV_VEC=y. Neither needs a knob of its own.
 #
 # The floating-point half is not optional once the flag is on, because the
 # generic entry points core calls under CFG_WITH_VFP are the floating-point
@@ -115,6 +115,15 @@ $(call force,CFG_TA_BTI,n)
 CFG_WITH_VFP ?= n
 ifeq ($(CFG_WITH_VFP),y)
 $(call force,CFG_RISCV_FPU,y,required by CFG_WITH_VFP)
+endif
+
+# 'y' if the hart has the vector extension. The context is switched only
+# when CFG_WITH_VFP asks for it as well.
+CFG_RISCV_VEC ?= n
+
+CFG_RISCV_WITH_VECTOR := n
+ifeq ($(CFG_WITH_VFP)-$(CFG_RISCV_VEC),y-y)
+CFG_RISCV_WITH_VECTOR := y
 endif
 
 # Enable generic timer
@@ -138,6 +147,9 @@ ifeq ($(CFG_RISCV_FPU),y)
 ISA_D = fd
 ABI_D = d
 endif
+ifeq ($(CFG_RISCV_WITH_VECTOR),y)
+TA_ISA_V = v
+endif
 ifeq ($(CFG_RISCV_ISA_C),y)
 ISA_C = c
 endif
@@ -147,6 +159,13 @@ endif
 
 riscv-isa = $(ISA_BASE)$(ISA_D)$(ISA_C)$(ISA_ZBB)_zicsr_zifencei
 riscv-abi = $(ABI_BASE)$(ABI_D)
+
+# The core is deliberately not built for the vector ISA even when vector
+# context switching is on. riscv_vector.S turns it on for the two save and
+# restore routines with .option arch, and leaving it off everywhere else
+# means the compiler cannot put vector instructions into core code, which
+# would otherwise trap against the VS == Off that core runs with.
+riscv-ta-isa = $(ISA_BASE)$(ISA_D)$(ISA_C)$(TA_ISA_V)$(ISA_ZBB)_zicsr_zifencei
 
 rv64-platform-cflags += -mcmodel=$(riscv-platform-mcmodel)
 rv64-platform-cflags += -march=$(riscv-isa) -mabi=$(riscv-abi)
@@ -282,9 +301,14 @@ ta_rv64-platform-cflags += $(rv64-platform-cflags-hard-float)
 else
 ta_rv64-platform-cflags += $(rv64-platform-cflags-no-hard-float)
 endif
+# TAs are built for the vector ISA when the context is being switched, even
+# though the core is not, so this has to come after the core flags were
+# inherited above.
+ta_rv64-platform-cflags += -march=$(riscv-ta-isa)
 ta_rv64-platform-aflags += $(platform-aflags-generic)
 ta_rv64-platform-aflags += $(platform-aflags-debug-info)
 ta_rv64-platform-aflags += $(rv64-platform-aflags)
+ta_rv64-platform-aflags += -march=$(riscv-ta-isa)
 
 ta_rv64-platform-cxxflags += -fpic
 ta_rv64-platform-cxxflags += $(platform-cflags-optimization)

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -165,6 +165,14 @@ core-platform-cflags += $(platform-cflags-debug-info)
 core-platform-aflags += $(platform-aflags-generic)
 core-platform-aflags += $(platform-aflags-debug-info)
 
+ifeq ($(CFG_WITH_VFP),y)
+ifeq ($(COMPILER_core),clang)
+# store_fpregs/load_fpregs recurse once per floating-point register, which is
+# deeper than the 20 levels Clang's integrated assembler allows by default.
+core-platform-aflags += -mllvm -asm-macro-max-nesting-depth=100
+endif
+endif
+
 ifeq ($(CFG_CORE_ASLR),y)
 core-platform-cflags += -fpie
 endif

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -99,9 +99,23 @@ $(call force,CFG_PAGED_USER_TA,n)
 $(call force,CFG_WITH_PAGER,n)
 $(call force,CFG_GIC,n)
 $(call force,CFG_ARM_GICV3,n)
-$(call force,CFG_WITH_VFP,n)
 $(call force,CFG_WITH_STMM_SP,n)
 $(call force,CFG_TA_BTI,n)
+
+# CFG_WITH_VFP asks OP-TEE to context switch the extended register state.
+# Which register files that covers follows the extensions the platform says
+# the hart has, so this series switches the floating-point registers when
+# CFG_RISCV_FPU=y. It does not need a knob of its own.
+#
+# The floating-point half is not optional once the flag is on, because the
+# generic entry points core calls under CFG_WITH_VFP are the floating-point
+# ones, so a hart without F or D is a configuration error rather than a
+# silent no-op. The save and restore routines use FP load and store
+# instructions, so the core has to be built for such a hart anyway.
+CFG_WITH_VFP ?= n
+ifeq ($(CFG_WITH_VFP),y)
+$(call force,CFG_RISCV_FPU,y,required by CFG_WITH_VFP)
+endif
 
 # Enable generic timer
 $(call force,CFG_CORE_HAS_GENERIC_TIMER,y)

--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -138,6 +138,23 @@ CFG_AES_GCM_TABLE_BASED ?= y
 
 endif #!CFG_CRYPTO_WITH_CE
 
+# RISC-V AES acceleration with the Zvkned vector crypto extension, and its
+# CTR mode with Zvkb on top. This sits outside the CFG_CRYPTO_WITH_CE region
+# above, which is the Arm Cryptographic Extensions and is never on for
+# RISC-V, but it feeds the same generic CFG_CORE_CRYPTO_AES_ACCEL that the
+# LibTomCrypt glue keys off.
+#
+# The ISA side of the selection lives in core/arch/riscv/riscv.mk.
+CFG_CRYPTO_AES_RISCV_ZVKNED ?= n
+ifeq ($(CFG_CRYPTO_AES_RISCV_ZVKNED),y)
+$(call force,CFG_CORE_CRYPTO_AES_ACCEL,y,required by \
+	CFG_CRYPTO_AES_RISCV_ZVKNED)
+$(call force,CFG_CRYPTO_AES,y,required by CFG_CRYPTO_AES_RISCV_ZVKNED)
+$(call force,CFG_CRYPTO_ECB,y,required by CFG_CRYPTO_AES_RISCV_ZVKNED)
+$(call force,CFG_CRYPTO_CBC,y,required by CFG_CRYPTO_AES_RISCV_ZVKNED)
+$(call force,CFG_CRYPTO_CTR,y,required by CFG_CRYPTO_AES_RISCV_ZVKNED)
+endif
+
 
 # Cryptographic extensions can only be used safely when OP-TEE knows how to
 # preserve the VFP context

--- a/core/include/kernel/thread_private.h
+++ b/core/include/kernel/thread_private.h
@@ -48,6 +48,9 @@ struct thread_ctx {
 #ifdef CFG_WITH_VFP
 	struct thread_vfp_state vfp_state;
 #endif
+#ifdef CFG_RISCV_WITH_VECTOR
+	struct thread_vector_state vector_state;
+#endif
 	void *rpc_arg;
 	struct mobj *rpc_mobj;
 	struct thread_shm_cache shm_cache;

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -38,6 +38,9 @@ struct user_mode_ctx {
 #if defined(CFG_WITH_VFP)
 	struct thread_user_vfp_state vfp;
 #endif
+#if defined(CFG_RISCV_WITH_VECTOR)
+	struct thread_user_vector_state vector;
+#endif
 #if defined(CFG_TA_PAUTH)
 	struct thread_pauth_keys keys;
 #endif

--- a/lib/libutils/ext/include/riscv.S
+++ b/lib/libutils/ext/include/riscv.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2023 Andes Technology Corporation
+ * Copyright (c) 2026, RISCStar Solutions Limited
  */
 
 #if __riscv_xlen == 32
@@ -11,4 +12,12 @@
 #define STR       sd
 #define LDR       ld
 #define REGOFF(x) ((x) * 8)
+#endif
+
+#if __riscv_flen == 32
+#define FST       fsw
+#define FLD       flw
+#elif __riscv_flen == 64
+#define FST       fsd
+#define FLD       fld
 #endif


### PR DESCRIPTION
**Draft — see Status below.**

Adds an AES accelerator for RISC-V built on the Zvkned vector crypto
extension, covering ECB, CBC and CTR.

The round instructions are the vector-scalar forms, so one round key applies
across every element group and ECB is strip-mined at LMUL=4: the number of
blocks in flight follows VLEN rather than being fixed at one. Decryption
reuses the encryption schedule read backwards, since Zvkned folds
InvMixColumns into its decrypt rounds. The assembly enables each extension
for itself with `.option arch`, so the core is not built for Zvkned.

CTR is in its own pair of files because it additionally needs `vrev8.v` from
Zvkb: the counter is a 128-bit big-endian integer but vector arithmetic is
little-endian per element, so counting several blocks ahead means
byte-swapping, adding, and swapping back. Carry out of the low 32 bits is
handled by clamping each batch to the blocks remaining before the low word
wraps, then propagating into the upper 96 bits in scalar code between
batches — that path runs at most once per 2^32 blocks.

### Status

Two things to know before reviewing:

1. The last 5 commits are the AES work. The first 12 are the RISC-V FP and
   vector context-switching series, already under review as #7951 and #7961.
   They are included because the AES glue calls `thread_kernel_enable_vector()`
   and cannot build without them; they should land through those PRs, and
   this branch will be rebased once they do.
2. The accelerator has to supply every entry point `aes_desc` names, and
   three are not in this series: `crypto_accel_aes_xts_enc()`, `_dec()` and
   the shared `crypto_accel_aes_expand_keys()`. Those are being written
   separately, so a build with `CFG_CRYPTO_AES_RISCV_ZVKNED=y` does not link
   yet. `CFG_CRYPTO_XTS=n` does not avoid the XTS pair, because `aes_desc`
   names them whether or not the mode is reachable.

Every commit builds with the accelerator off, and with `CFG_WITH_VFP=y`.

### Testing

The block functions were exercised directly under `qemu-system-riscv64`
(`-cpu rv64,v=on,zvkned=on,zvkb=on`) against the NIST SP 800-38A appendix F
vectors for all three key lengths, encrypt and decrypt, at VLEN 128, 256 and
512. Additional CTR cases cover a non-block-multiple length, a counter that
wraps from all-ones, and a carry out of the low 32 bits — none of which the
SP 800-38A vectors reach, since their counters stay inside the low byte.

Matching xtest coverage is in OP-TEE/optee_test (regression 4018/4019/4020).
