### PR TITLE
libutee: validate TEE_ReadObjectData output buffer

### DIFF
--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -901,6 +901,7 @@ TEE_Result TEE_ReadObjectData(TEE_ObjectHandle object, void *buffer,
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
+	__utee_check_out_annotation(buffer, size);
 	__utee_check_out_annotation(count, sizeof(*count));
 
 	cnt64 = *count;


### PR DESCRIPTION
Check the data buffer against the [out] annotation before reading persistent-object data. This prevents client-shared memory from being used where the API requires a private TA output buffer.

The count output was already validated; validate the data output as well.