### PR TITLE
core: normalize NVIDIA copyright notices

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2015-2023, Linaro Limited
  * Copyright (c) 2023, Arm Limited
- * Copyright (c) 2025-2026, NVIDIA Corporation & AFFILIATES.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  */
 
 #include <arm.h>

--- a/core/arch/arm/plat-tegra/conf.mk
+++ b/core/arch/arm/plat-tegra/conf.mk
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Copyright (c) 2020-2026, NVIDIA CORPORATION
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES
 #
 
 include core/arch/arm/cpu/cortex-armv8-0.mk

--- a/core/arch/arm/plat-tegra/main.c
+++ b/core/arch/arm/plat-tegra/main.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2020-2026, NVIDIA CORPORATION
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES
  */
 
 #include <console.h>

--- a/core/arch/arm/plat-tegra/platform_config.h
+++ b/core/arch/arm/plat-tegra/platform_config.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2020-2026, NVIDIA CORPORATION
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-tegra/sub.mk
+++ b/core/arch/arm/plat-tegra/sub.mk
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Copyright (c) 2020-2026, NVIDIA CORPORATION
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES
 #
 
 global-incdirs-y += .

--- a/core/drivers/ffa_console.c
+++ b/core/drivers/ffa_console.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES
  */
 
 #include <compiler.h>

--- a/core/drivers/tegra_combined_uart.c
+++ b/core/drivers/tegra_combined_uart.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2021-2026, NVIDIA CORPORATION
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES
  */
 
 #include <drivers/tegra_combined_uart.h>

--- a/core/drivers/tegra_utc.c
+++ b/core/drivers/tegra_utc.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES
  */
 
 #include <drivers/tegra_utc.h>

--- a/core/include/drivers/ffa_console.h
+++ b/core/include/drivers/ffa_console.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES
  */
 
 #ifndef FFA_CONSOLE_H

--- a/core/include/drivers/tegra_combined_uart.h
+++ b/core/include/drivers/tegra_combined_uart.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2021-2026, NVIDIA CORPORATION
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES
  */
 
 #ifndef TEGRA_COMBINED_UART_H

--- a/core/include/drivers/tegra_utc.h
+++ b/core/include/drivers/tegra_utc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES
  */
 
 #ifndef TEGRA_UTC_H

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2020, Arm Limited
- * Copyright (c) 2025, NVIDIA Corporation & AFFILIATES.
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
  */
 
 #include <assert.h>

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
  * Copyright (c) 2020-2023, ARM Limited. All rights reserved.
- * Copyright (c) 2025, NVIDIA Corporation & AFFILIATES.
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
  */
 
 #include <compiler.h>


### PR DESCRIPTION
Normalize existing NVIDIA copyright notices to consistently use "NVIDIA CORPORATION & AFFILIATES".

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
