### PR TITLE
core: intersect object usage when copying attributes

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2072,10 +2072,10 @@ TEE_Result syscall_cryp_obj_copy(unsigned long dst, unsigned long src)
 	dst_o->info.objectSize = src_o->info.objectSize;
 	if (src_o->info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT) {
 		tee_pobj_lock_usage(src_o->pobj);
-		dst_o->info.objectUsage = src_o->pobj->obj_info_usage;
+		dst_o->info.objectUsage &= src_o->pobj->obj_info_usage;
 		tee_pobj_unlock_usage(src_o->pobj);
 	} else {
-		dst_o->info.objectUsage = src_o->info.objectUsage;
+		dst_o->info.objectUsage &= src_o->info.objectUsage;
 	}
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
TEE_CopyObjectAttributes1() is required to set the destination object usage to the intersection of its current usage and the source object usage.

syscall_cryp_obj_copy() instead replaces the destination usage with the source usage. This can re-enable usage bits previously cleared with TEE_RestrictObjectUsage1().

Intersect the usage marks for both transient and persistent source objects.

Fixes: b01047730e77 ("Open-source the TEE Core")
