### PR TITLE
MAINTAINERS: update Selvam's e-mail, add PAS Authentication, WDT and XPU entries

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -164,6 +164,20 @@ S:	Maintained
 F:	core/drivers/qcom/rpmh/
 F:	core/include/drivers/qcom/rpmh/
 
+Core Drivers QCOM WDT
+R:	Harikrishna <hart@qti.qualcomm.com> [@thariaruchamy-bit]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
+S:	Maintained
+F:	core/drivers/qcom/wdt/
+
+Core Drivers QCOM XPU
+R:	Harikrishna <hart@qti.qualcomm.com> [@thariaruchamy-bit]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
+S:	Maintained
+F:	core/arch/arm/plat-qcom/xpu_policy.c
+F:	core/drivers/qcom/xpu/
+F:	core/include/drivers/qcom/xpu*
+
 Core Drivers ZYNQMP
 R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
 S:	Maintained

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -301,6 +301,15 @@ R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelv
 S:	Maintained
 F:	core/arch/arm/plat-qcom/provision/
 
+Qualcomm PAS Authentication
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
+S:	Maintained
+F:	core/pta/qcom/fuse/
+F:	core/pta/qcom/pas/pas_auth.c
+F:	lib/libutee/include/pta_qcom_fuse.h
+F:	ta/qcom_pas/include/auth/
+F:	ta/qcom_pas/src/auth/
+
 Raspberry Pi3
 R:	Joakim Bech <joakim.bech@gmail.com> [@jockebech]
 S:	Maintained

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -141,7 +141,7 @@ F:	core/drivers/versal_sha3_384.c
 F:	core/drivers/versal_trng.c
 
 Core Drivers QCOM CMD_DB
-R:	Selvam Sathappan Periakaruppan <speriaka@qti.qualcomm.com> [@zelvam95]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
 S:	Maintained
 F:	core/drivers/qcom/cmd_db/
 F:	core/include/drivers/qcom/cmd_db/
@@ -152,14 +152,14 @@ S:	Maintained
 F:	core/drivers/crypto/qcom/
 
 Core Drivers QCOM QFPROM
-R:	Selvam Sathappan Periakaruppan <speriaka@qti.qualcomm.com> [@zelvam95]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
 R:	Kishore Batta <kishore.batta@oss.qualcomm.com> [@kishorebatta-ossqcom]
 S:	Maintained
 F:	core/drivers/qcom/qfprom/
 F:	core/include/drivers/qcom/qfprom/
 
 Core Drivers QCOM RPMH
-R:	Selvam Sathappan Periakaruppan <speriaka@qti.qualcomm.com> [@zelvam95]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
 S:	Maintained
 F:	core/drivers/qcom/rpmh/
 F:	core/include/drivers/qcom/rpmh/
@@ -292,12 +292,12 @@ F:	core/pta/qcom/
 F:	ta/qcom_pas/
 
 Qualcomm Bobcat Arch
-R:	Selvam Sathappan Periakaruppan <speriaka@qti.qualcomm.com> [@zelvam95]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
 S:	Maintained
 F:	core/arch/arm/plat-qcom/bobcat/
 
 Qualcomm Fuse Provisioning
-R:	Selvam Sathappan Periakaruppan <speriaka@qti.qualcomm.com> [@zelvam95]
+R:	Selvam Sathappan Periakaruppan <selvam.periakaruppan@oss.qualcomm.com> [@zelvam95]
 S:	Maintained
 F:	core/arch/arm/plat-qcom/provision/
 


### PR DESCRIPTION
Three small, independent MAINTAINERS updates:

- Update my e-mail address to the oss.qualcomm.com account used for
  upstream contributions (core/drivers/qcom/{cmd_db,qfprom,rpmh}/,
  plat-qcom/bobcat/, plat-qcom/provision/).

- Add a dedicated entry for the Qualcomm PAS authentication code
  (fuse-exposure PTA, the auth slice of the PAS PTA, and the
  qcom_pas TA's auth/ subdirectories), reviewed separately from the
  overall Qualcomm architecture entry.

- Add entries for the Qualcomm WDT and XPU drivers, used on the
  Bobcat family (IPQ52xx/IPQ96xx). Both were authored by Harikrishna,
  who is listed alongside me as co-maintainer.