### PR TITLE
Align ASU Drivers with ASUFW changes

### DIFF
--- a/core/drivers/crypto/asu_driver/asu_authenc.c
+++ b/core/drivers/crypto/asu_driver/asu_authenc.c
@@ -88,17 +88,15 @@ struct asu_aes_params {
 	uint64_t output_data_addr;
 	uint64_t aad_addr;
 	uint64_t key_object_addr;
-	uint64_t iv_addr;
 	uint64_t tag_addr;
+	struct asu_aes_iv_object iv_obj;
 	uint32_t data_len;
 	uint32_t aad_len;
-	uint32_t iv_len;
 	uint32_t tag_len;
 	uint8_t mode;
 	uint8_t operation_flags;
 	uint8_t is_last;
 	uint8_t operation_type;
-	uint32_t iv_id;
 };
 
 struct asu_aes_key_object {
@@ -252,8 +250,8 @@ static TEE_Result asu_aes_send(struct asu_authenc_ctx *ctx,
 static void asu_authenc_set_init_params(struct asu_authenc_ctx *ae_ctx,
 					struct asu_aes_params *params)
 {
-	params->iv_addr = virt_to_phys(ae_ctx->nonce_buf);
-	params->iv_len = ae_ctx->nonce_len;
+	params->iv_obj.iv_addr = virt_to_phys(ae_ctx->nonce_buf);
+	params->iv_obj.iv_len = ae_ctx->nonce_len;
 	params->key_object_addr = virt_to_phys(&ae_ctx->key_obj);
 	params->mode = ae_ctx->mode;
 	params->operation_flags |= ASU_AES_INIT;

--- a/core/drivers/crypto/asu_driver/asu_cipher.c
+++ b/core/drivers/crypto/asu_driver/asu_cipher.c
@@ -74,17 +74,15 @@ struct asu_cipher_op_cmd {
 	uint64_t outputdataaddr;
 	uint64_t aadaddr;
 	uint64_t keyobjectaddr;
-	uint64_t ivaddr;
 	uint64_t tagaddr;
+	struct asu_aes_iv_object iv_obj;
 	uint32_t datalen;
 	uint32_t aadlen;
-	uint32_t ivlen;
 	uint32_t taglen;
 	uint8_t enginemode;
 	uint8_t operationflags;
 	uint8_t islast;
 	uint8_t operationtype;
-	uint32_t ivid;
 };
 
 struct asu_cipher_ctx {
@@ -463,8 +461,8 @@ static TEE_Result asu_cipher_cbc_update(struct asu_cipher_ctx *asu_cipherctx,
 	op.keyobjectaddr = virt_to_phys(kobj);
 	op.enginemode = ASU_CIPHER_CBC_MODE;
 	op.operationtype = asu_cipherctx->optype;
-	op.ivaddr = virt_to_phys(asu_cipherctx->iv);
-	op.ivlen = ASU_CIPHER_BLOCK_SIZE;
+	op.iv_obj.iv_addr = virt_to_phys(asu_cipherctx->iv);
+	op.iv_obj.iv_len = ASU_CIPHER_BLOCK_SIZE;
 	op.operationflags = ASU_CIPHER_INIT | ASU_CIPHER_UPDATE |
 			    ASU_CIPHER_FINAL;
 	op.islast = 1;
@@ -662,8 +660,8 @@ static TEE_Result asu_cipher_ctr_update(struct asu_cipher_ctx *ctx,
 	op.keyobjectaddr = virt_to_phys(kobj);
 	op.enginemode = ASU_CIPHER_CTR_MODE;
 	op.operationtype = ctx->optype;
-	op.ivaddr = virt_to_phys(ctx->iv);
-	op.ivlen = ASU_CIPHER_BLOCK_SIZE;
+	op.iv_obj.iv_addr = virt_to_phys(ctx->iv);
+	op.iv_obj.iv_len = ASU_CIPHER_BLOCK_SIZE;
 	op.operationflags = ASU_CIPHER_INIT | ASU_CIPHER_UPDATE |
 			    ASU_CIPHER_FINAL;
 	op.islast = 1;

--- a/core/drivers/crypto/asu_driver/asu_ecc.c
+++ b/core/drivers/crypto/asu_driver/asu_ecc.c
@@ -72,6 +72,8 @@ struct asu_ecc_key_object {
 	uint64_t key_addr;
 	uint32_t key_id;
 	uint32_t key_len;
+	uint32_t curve_type;
+	uint8_t reserved[4];
 };
 
 /* ECC sign/verify params passed to ASU firmware */
@@ -79,8 +81,8 @@ struct asu_ecc_params {
 	struct asu_ecc_key_object key;
 	uint64_t digest_addr;
 	uint64_t sign_addr;
-	uint32_t curve_type;
 	uint32_t digest_len;
+	uint8_t reserved[4];
 };
 
 /* Key manager metadata for ECC key-pair generation */
@@ -126,8 +128,6 @@ struct asu_ecc_ecdh_params {
 	struct asu_ecc_key_object pub_key;
 	uint64_t shared_secret_addr;
 	uint64_t shared_secret_obj_id_addr;
-	uint32_t curve_type;
-	uint8_t reserved[4];
 };
 
 /* Callback context for key pair generation */
@@ -781,9 +781,9 @@ static TEE_Result asu_ecc_sign(struct drvcrypt_sign_data *sdata)
 	ecc_params.key.key_addr = virt_to_phys(priv_key);
 	ecc_params.key.key_id = 0U;
 	ecc_params.key.key_len = key_len;
+	ecc_params.key.curve_type = asu_curve_id;
 	ecc_params.digest_addr = virt_to_phys(sdata->message.data);
 	ecc_params.sign_addr = virt_to_phys(sdata->signature.data);
-	ecc_params.curve_type = asu_curve_id;
 	ecc_params.digest_len = digest_len;
 
 	ret = asu_update_queue_buffer_n_send_ipi(&cparams, &ecc_params,
@@ -907,9 +907,9 @@ static TEE_Result asu_ecc_verify(struct drvcrypt_sign_data *sdata)
 	ecc_params.key.key_addr = virt_to_phys(pub_key);
 	ecc_params.key.key_id = 0U;
 	ecc_params.key.key_len = key_len;
+	ecc_params.key.curve_type = asu_curve_id;
 	ecc_params.digest_addr = virt_to_phys(sdata->message.data);
 	ecc_params.sign_addr = virt_to_phys(sdata->signature.data);
-	ecc_params.curve_type = asu_curve_id;
 	ecc_params.digest_len = digest_len;
 
 	ret = asu_update_queue_buffer_n_send_ipi(&cparams, &ecc_params,
@@ -1061,12 +1061,13 @@ static TEE_Result asu_ecc_shared_secret(struct drvcrypt_secret_data *sdata)
 	ecdh_params.pvt_key.key_addr = virt_to_phys(priv_key_buf);
 	ecdh_params.pvt_key.key_id = 0U;
 	ecdh_params.pvt_key.key_len = key_len;
+	ecdh_params.pvt_key.curve_type = asu_curve_id;
 	ecdh_params.pub_key.key_addr = virt_to_phys(pub_key_buf);
 	ecdh_params.pub_key.key_id = 0U;
 	ecdh_params.pub_key.key_len = key_len;
+	ecdh_params.pub_key.curve_type = asu_curve_id;
 	ecdh_params.shared_secret_addr = virt_to_phys(shared_secret_buf);
 	ecdh_params.shared_secret_obj_id_addr = 0;
-	ecdh_params.curve_type = asu_curve_id;
 
 	ret = asu_update_queue_buffer_n_send_ipi(&cparams, &ecdh_params,
 						 sizeof(ecdh_params), header,

--- a/core/drivers/crypto/asu_driver/asu_rsa.c
+++ b/core/drivers/crypto/asu_driver/asu_rsa.c
@@ -172,6 +172,9 @@ struct asu_rsa_km_params {
 	uint8_t reserved[4];
 };
 
+/* Public exponent prefix size in the KeyManager key-pair object */
+#define ASU_RSA_KM_PUBEXP_SIZE_IN_BYTES		4U
+
 /*
  * Cached ASUFW RSA module compatibility, populated once by
  * asu_rsa_check_fw_compat() at driver_init() from the fw_compat_check()
@@ -242,7 +245,8 @@ static size_t asu_rsa_keypair_blob_len(size_t size_bytes)
 {
 	size_t prime_bytes = size_bytes / 2U;
 
-	return (size_bytes * 2U) + (prime_bytes * 5U);
+	return ASU_RSA_KM_PUBEXP_SIZE_IN_BYTES + (size_bytes * 2U) +
+	       (prime_bytes * 5U);
 }
 
 /*
@@ -717,7 +721,6 @@ asu_rsa_import_generated_keypair(struct rsa_keypair *key,
 				 size_t size_bytes,
 				 uint8_t *obj)
 {
-	const uint8_t e_f4[] = { 0x01U, 0x00U, 0x01U };
 	size_t prime_bytes = size_bytes / 2U;
 	size_t keyobj_len = asu_rsa_keypair_blob_len(size_bytes);
 	uint8_t *p = obj;
@@ -728,6 +731,11 @@ asu_rsa_import_generated_keypair(struct rsa_keypair *key,
 
 	if (keyobj_len > asu_rsa_keypair_blob_len(ASU_RSA_MAX_MOD_LEN))
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	ret = crypto_bignum_bin2bn(p, ASU_RSA_KM_PUBEXP_SIZE_IN_BYTES, key->e);
+	if (ret)
+		return ret;
+	p += ASU_RSA_KM_PUBEXP_SIZE_IN_BYTES;
 
 	ret = crypto_bignum_bin2bn(p, size_bytes, key->n);
 	if (ret)
@@ -760,10 +768,6 @@ asu_rsa_import_generated_keypair(struct rsa_keypair *key,
 	p += prime_bytes;
 
 	ret = crypto_bignum_bin2bn(p, prime_bytes, key->qp);
-	if (ret)
-		return ret;
-
-	ret = crypto_bignum_bin2bn(e_f4, sizeof(e_f4), key->e);
 
 	return ret;
 }

--- a/core/drivers/crypto/asu_driver/asu_rsa.c
+++ b/core/drivers/crypto/asu_driver/asu_rsa.c
@@ -87,6 +87,10 @@
 #define ASU_RSA_KM_USAGE_COUNT_NON_DEPLETING	0xFFFFFFFFU
 #define ASU_RSA_KM_KEY_ATTR_PRIME_PRESENT	2U
 
+/* KeyManager first-error status code */
+#define ASU_RSA_FW_STATUS_CODE_MASK		0x3FFU
+#define ASU_RSA_KM_KEY_NOT_FOUND		0x1BCU
+
 /* Public key payload expected by ASU FW */
 struct asu_rsa_pub_key_comp {
 	uint32_t key_size;
@@ -1932,9 +1936,17 @@ static TEE_Result asu_rsa_gen_keypair(struct rsa_keypair *key,
 			       ASU_KM_GEN_RSA_KEY_PAIR_CMD_ID,
 			       NULL, &fw_status);
 	if (ret) {
-		DMSG("HW key-pair unavailable status=0x%08"PRIx32
-		     ", using SW fallback", fw_status);
-		ret = sw_crypto_acipher_gen_rsa_key(key, size_bits);
+		/* Fall back to SW only when the key vault is empty */
+		if ((fw_status & ASU_RSA_FW_STATUS_CODE_MASK) ==
+		    ASU_RSA_KM_KEY_NOT_FOUND) {
+			EMSG("HW key vault empty status=0x%08"PRIx32
+			     ", using SW fallback", fw_status);
+			ret = sw_crypto_acipher_gen_rsa_key(key, size_bits);
+			goto out;
+		}
+
+		EMSG("ASU KeyManager key-pair gen failed ret=%#"PRIx32
+		     " status=0x%08"PRIx32, ret, fw_status);
 		goto out;
 	}
 

--- a/core/include/drivers/amd/asu_client.h
+++ b/core/include/drivers/amd/asu_client.h
@@ -22,6 +22,12 @@
 #define ASU_MODULE_HMAC_ID              6U
 #define ASU_MODULE_KEYMANAGER_ID	12U
 
+struct asu_aes_iv_object {
+	uint64_t iv_addr;
+	uint32_t iv_len;
+	uint32_t iv_id;
+};
+
 struct asu_client_params {
 	TEE_Result (*cbhandler)(void *cbrefptr, struct asu_resp_buf *resp);
 	void *cbptr;


### PR DESCRIPTION
Align the ASU crypto driver command structures with the latest ASUFW
interface and fix an RSA key-pair import field offset for the public
exponent.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
