### PR TITLE
plat-versal2: increase reserved VA space and xlat table budget for tr…

### DIFF
--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -59,6 +59,11 @@ CFG_TZDRAM_SIZE    ?= 0x8000000
 # device tree with additional nodes.
 CFG_DTB_MAX_SIZE ?= 0x200000
 
+# Reserved VA space for late/dynamic mappings (transfer list, ASU, etc.)
+# Default ARM value (10MB) is not enough once the transfer list (6MB) is
+# held mapped for most of boot alongside other dynamic IO_SEC mappings.
+CFG_RESERVED_VASPACE_SIZE ?= (24 * 1024 * 1024)
+
 # Console selection
 # 0 : UART0[pl011, pl011_0] (default)
 # 1 : UART1[pl011_1]

--- a/core/arch/arm/plat-versal2/platform_config.h
+++ b/core/arch/arm/plat-versal2/platform_config.h
@@ -60,4 +60,12 @@
 #define CONSOLE_BAUDRATE	UART_BAUDRATE
 #endif
 
+/*
+ * Scale MAX_XLAT_TABLES with CFG_RESERVED_VASPACE_SIZE, else its fixed
+ * default can exhaust the xlat table pool even with VA-space bytes
+ * free. 12 = 9 (this platform's default MAX_XLAT_TABLES) + 3 (margin).
+ */
+#define MAX_XLAT_TABLES		(12 + (CFG_RESERVED_VASPACE_SIZE) / \
+				 (CORE_MMU_PGDIR_SIZE))
+
 #endif /* PLATFORM_CONFIG_H */


### PR DESCRIPTION
With CFG_TRANSFER_LIST enabled, the transfer list stays mapped in MEM_AREA_RES_VASPACE for most of boot, leaving too little of the default 10MB CFG_RESERVED_VASPACE_SIZE for other dynamic IO_SEC mappings (e.g. ASU's doorbell/shared-memory registers), causing core_mmu_add_mapping() to fail once those drivers initialize. Bump CFG_RESERVED_VASPACE_SIZE to 24MB to fix this.

MAX_XLAT_TABLES defaults to a small fixed constant independent of CFG_RESERVED_VASPACE_SIZE, so also scale it in platform_config.h to ensure the translation-table pool can back the larger reserved VA space, rather than moving the same class of
core_mmu_add_mapping() failure to the xlat-table-pool ceiling instead.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines, and pay extra attention to the
       "Developer Certificate of Origin" section:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. You should run checkpatch preferably before submitting the pull request.

    3. As a courtesy to the reviewers, please mention in this pull request
       description if AI was used to help write or generate any part of the
       code (this is separate from any commit-level AI attribution tags you
       may also choose to use). If nothing is mentioned here, it will be
       assumed that no AI was used.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
