### PR TITLE
tee: rpmb_fs: use temporary files for all overwrites

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -3153,7 +3153,8 @@ static TEE_Result rpmb_fs_create(struct tee_pobj *po, bool overwrite,
 {
 	TEE_Result res;
 	size_t pos = 0;
-	struct rpmb_file_handle *fh = alloc_file_handle(po, po->temporary);
+	bool temporary = po->temporary || overwrite;
+	struct rpmb_file_handle *fh = alloc_file_handle(po, temporary);
 
 	/* One of data_core and data_user must be NULL */
 	assert(!data_core || !data_user);
@@ -3202,18 +3203,16 @@ static TEE_Result rpmb_fs_create(struct tee_pobj *po, bool overwrite,
 		}
 	}
 
-	if (po->temporary) {
+	if (temporary) {
 		/*
-		 * If it's a temporary filename (which it normally is)
-		 * rename into the final filename now that the file is
-		 * fully initialized.
+		 * Rename the fully initialized temporary file into place.
+		 * Always use a temporary file for overwrite, including when
+		 * another handle keeps the persistent object alive.
 		 */
-		po->temporary = false;
 		res = rpmb_fs_rename_internal(po, NULL, overwrite);
-		if (res) {
-			po->temporary = true;
+		if (res)
 			goto out;
-		}
+		po->temporary = false;
 		/* Update file handle after rename. */
 		create_filename(fh->filename, sizeof(fh->filename), po, false);
 	}


### PR DESCRIPTION
When an object has a live shared handle, tee_pobj_get() reuses its tee_pobj. Its temporary flag is already clear, causing rpmb_fs_create() to overwrite the final RPMB file in place. If the new initial data is shorter, the old FAT size and stale tail are retained.

Use a temporary filename for every overwrite and rename it only after the replacement has been fully initialized. This makes a successful overwrite persist exactly the requested initial data even when another compatible handle remains open.

Fixes: 63146177355e ("core: add tee_pobj_create_final()")
