### PR TITLE
core: rpmb: accept shared input buffers in file writes

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2751,7 +2751,8 @@ static TEE_Result rpmb_fs_write(struct tee_file_handle *tfh, size_t pos,
 		res = rpmb_fs_write_primitive((struct rpmb_file_handle *)tfh,
 					      pos, buf_core, size);
 	} else if (buf_user) {
-		uint32_t f = TEE_MEMORY_ACCESS_READ;
+		uint32_t f = TEE_MEMORY_ACCESS_READ |
+			     TEE_MEMORY_ACCESS_ANY_OWNER;
 
 		res = check_user_access(f, buf_user, size);
 		if (res)


### PR DESCRIPTION
GP TEE Internal Core API v1.3 changed the buffer annotation of TEE_WriteObjectData() from [in] to [inbuf] specifically to resolve its inconsistency with the [inbuf] initialData parameter of TEE_CreatePersistentObject(). An [inbuf] may reside in TA-private or client-owned shared memory, provided that the complete range is readable.

The RPMB write path still checks the user buffer with the former [in] semantics, without TEE_MEMORY_ACCESS_ANY_OWNER. It therefore rejects a readable client-owned buffer with TEE_ERROR_ACCESS_DENIED, which causes libutee to panic the TA.

Fixes: 41af5286e515 ("GP131: Update TEE_ReadObjectData() and TEE_WriteObjectData()")
