### PR TITLE
 core: riscv: probe SBI extensions at boot

### DIFF
--- a/core/arch/riscv/include/sbi.h
+++ b/core/arch/riscv/include/sbi.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022, 2025 NXP
+ * Copyright 2022, 2025-2026 NXP
  */
 
 #ifndef __SBI_H
@@ -30,10 +30,27 @@
 /* SBI Extension IDs */
 #define SBI_EXT_0_1_CONSOLE_PUTCHAR	0x01
 #define SBI_EXT_BASE			0x10
+#define SBI_EXT_TIME			0x54494D45
+#define SBI_EXT_IPI			0x735049
+#define SBI_EXT_RFENCE			0x52464E43
 #define SBI_EXT_HSM			0x48534D
+#define SBI_EXT_SRST			0x53525354
+#define SBI_EXT_PMU			0x504D55
 #define SBI_EXT_DBCN			0x4442434E
-#define SBI_EXT_TEE			0x544545
+#define SBI_EXT_SUSP			0x53555350
+#define SBI_EXT_CPPC			0x43505043
+#define SBI_EXT_NACL			0x4E41434C
+#define SBI_EXT_STA			0x535441
+#define SBI_EXT_SSE			0x535345
+#define SBI_EXT_FWFT			0x46574654
+#define SBI_EXT_DBTR			0x44425452
 #define SBI_EXT_MPXY                    0x4D505859
+#define SBI_EXT_TEE			0x544545
+
+/* sbi_get_spec_version() encoding: major in bits [30:24], minor in [23:0] */
+#define SBI_SPEC_VERSION_MAJOR_SHIFT	U(24)
+#define SBI_SPEC_VERSION_MAJOR_MASK	U(0x7f)
+#define SBI_SPEC_VERSION_MINOR_MASK	U(0xffffff)
 
 #ifndef __ASSEMBLER__
 
@@ -98,11 +115,15 @@ enum sbi_hsm_hart_state {
 
 #include <compiler.h>
 #include <encoding.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/cdefs.h>
 #include <types_ext.h>
 #include <util.h>
 
+void sbi_init(void);
+void sbi_print_info(void);
+bool sbi_ext_available(unsigned long extid);
 int sbi_probe_extension(int extid);
 void sbi_console_putchar(int ch);
 int sbi_dbcn_write_byte(unsigned char ch);

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -85,6 +85,11 @@ void boot_start_secondary_cores(void)
 	/* The primary CPU is always indexed by 0 */
 	assert(get_core_pos() == 0);
 
+	if (CFG_TEE_CORE_NB_CORE > 1 && !sbi_ext_available(SBI_EXT_HSM)) {
+		EMSG("SBI HSM extension required to start secondary harts");
+		panic();
+	}
+
 	for (i = 0; i < CFG_TEE_CORE_NB_CORE; i++) {
 		hartid = hartids[i];
 

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2023 Andes Technology Corporation
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2023,2026 NXP
  */
 
 #include <assert.h>
@@ -142,6 +142,9 @@ static void init_primary(void)
 
 	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
 	IMSG_RAW("\n");
+#ifdef CFG_RISCV_SBI
+	sbi_print_info();
+#endif
 	if (IS_ENABLED(CFG_DYN_CONFIG)) {
 		size_t sz = sizeof(struct thread_core_local) *
 			    CFG_TEE_CORE_NB_CORE;

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2023 Andes Technology Corporation
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2023,2026 NXP
  */
 
 #include <asm.S>
@@ -215,6 +215,9 @@ UNWIND(	.cantunwind)
 	sw	a0, THREAD_CORE_LOCAL_FLAGS(tp)
 #endif
 
+#ifdef CFG_RISCV_SBI
+	jal	sbi_init
+#endif
 	jal	plat_primary_init_early
 	jal	console_init
 

--- a/core/arch/riscv/kernel/sbi.c
+++ b/core/arch/riscv/kernel/sbi.c
@@ -1,10 +1,42 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2026 NXP
  */
 
+#include <assert.h>
 #include <riscv.h>
 #include <sbi.h>
+#include <stdio.h>
+#include <trace.h>
+
+/* Extensions probed once at boot by sbi_init() */
+static const struct {
+	unsigned long id;
+	const char *name;
+} sbi_exts[] = {
+	{ SBI_EXT_TIME, "TIME" },
+	{ SBI_EXT_IPI, "IPI" },
+	{ SBI_EXT_RFENCE, "RFENCE" },
+	{ SBI_EXT_HSM, "HSM" },
+	{ SBI_EXT_SRST, "SRST" },
+	{ SBI_EXT_PMU, "PMU" },
+	{ SBI_EXT_DBCN, "DBCN" },
+	{ SBI_EXT_SUSP, "SUSP" },
+	{ SBI_EXT_CPPC, "CPPC" },
+	{ SBI_EXT_NACL, "NACL" },
+	{ SBI_EXT_STA, "STA" },
+	{ SBI_EXT_SSE, "SSE" },
+	{ SBI_EXT_FWFT, "FWFT" },
+	{ SBI_EXT_DBTR, "DBTR" },
+	{ SBI_EXT_MPXY, "MPXY" },
+	{ SBI_EXT_TEE, "TEE" },
+};
+
+static unsigned long sbi_spec_version __nex_bss;
+static unsigned long sbi_impl_id __nex_bss;
+static unsigned long sbi_impl_version __nex_bss;
+/* sbi_ext_present[n] is true when sbi_exts[n] is available */
+static bool sbi_ext_present[ARRAY_SIZE(sbi_exts)] __nex_bss;
 
 /**
  * sbi_probe_extension() - Check if an SBI extension ID is supported or not.
@@ -21,6 +53,93 @@ int sbi_probe_extension(int extid)
 		return ret.value;
 
 	return 0;
+}
+
+static unsigned long sbi_base_get(enum sbi_ext_base_fid fid)
+{
+	struct sbiret ret = { };
+
+	ret = sbi_ecall(SBI_EXT_BASE, fid);
+	if (ret.error)
+		return 0;
+
+	return ret.value;
+}
+
+/**
+ * sbi_init() - Identify the SBI implementation and probe its extensions
+ *
+ * Called once on the primary hart before the console is initialized so
+ * that every SBI user can rely on sbi_ext_available(). Only the Base
+ * extension is used here, which is mandatory since SBI v0.2; a v0.1
+ * firmware fails the Base calls and is recorded as v0.1 with no
+ * extension available.
+ */
+void sbi_init(void)
+{
+	size_t n = 0;
+
+	sbi_spec_version = sbi_base_get(SBI_EXT_BASE_GET_SPEC_VERSION);
+	if (!sbi_spec_version) {
+		sbi_spec_version = 1;	/* v0.1: no Base extension */
+		return;
+	}
+	sbi_impl_id = sbi_base_get(SBI_EXT_BASE_GET_IMP_ID);
+	sbi_impl_version = sbi_base_get(SBI_EXT_BASE_GET_IMP_VERSION);
+
+	for (n = 0; n < ARRAY_SIZE(sbi_exts); n++)
+		sbi_ext_present[n] = sbi_probe_extension(sbi_exts[n].id);
+}
+
+/**
+ * sbi_print_info() - Log the SBI implementation and its extensions
+ *
+ * To be called once the console is up.
+ */
+void sbi_print_info(void)
+{
+	unsigned long major = sbi_spec_version >> SBI_SPEC_VERSION_MAJOR_SHIFT;
+	unsigned long minor = sbi_spec_version;
+	char buf[128] = { };
+	size_t pos = 0;
+	size_t n = 0;
+	int rc = 0;
+
+	major &= SBI_SPEC_VERSION_MAJOR_MASK;
+	minor &= SBI_SPEC_VERSION_MINOR_MASK;
+	IMSG("SBI v%lu.%lu, implementation ID %#lx version %#lx",
+	     major, minor, sbi_impl_id, sbi_impl_version);
+
+	for (n = 0; n < ARRAY_SIZE(sbi_exts); n++) {
+		if (!sbi_ext_present[n])
+			continue;
+		rc = snprintf(buf + pos, sizeof(buf) - pos, "%s%s",
+			      pos ? " " : "", sbi_exts[n].name);
+		if (rc < 0 || (size_t)rc >= sizeof(buf) - pos)
+			break;
+		pos += rc;
+	}
+	IMSG("SBI extensions: %s", pos ? buf : "none");
+}
+
+/**
+ * sbi_ext_available() - Availability of an SBI extension
+ * @extid: The extension ID
+ *
+ * Returns the result cached by sbi_init() for the extensions it probes and
+ * falls back to a live probe for any other extension ID.
+ *
+ * Return: true if the extension is available, false otherwise.
+ */
+bool sbi_ext_available(unsigned long extid)
+{
+	size_t n = 0;
+
+	for (n = 0; n < ARRAY_SIZE(sbi_exts); n++)
+		if (sbi_exts[n].id == extid)
+			return sbi_ext_present[n];
+
+	return sbi_probe_extension(extid);
 }
 
 /**

--- a/core/arch/riscv/kernel/sbi_console.c
+++ b/core/arch/riscv/kernel/sbi_console.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2026 NXP
  */
 
 #include <assert.h>
@@ -33,7 +33,7 @@ static void sbi_console_putc(struct serial_chip *chip __unused, int ch)
 
 static void sbi_console_init(struct sbi_console_data *pd)
 {
-	if (sbi_probe_extension(SBI_EXT_DBCN))
+	if (sbi_ext_available(SBI_EXT_DBCN))
 		sbi_console_ops.putc = sbi_console_putc;
 	else
 		sbi_console_ops.putc = sbi_console_putc_legacy;


### PR DESCRIPTION
SBI extension discovery in the RISC-V port is ad hoc: `sbi_console_init()` probes DBCN before choosing between it and the legacy putchar, the HSM calls in boot_start_secondary_cores() are issued without probing, and nothing records or logs which SBI implementation OP-TEE runs on. 
A firmware without HSM makes `sbi_hsm_hart_get_status()` fail for every hart, which takes the same branch as a hart outside the trusted domain: all secondary harts are silently skipped.

Commit 1 adds `sbi_init()`, called on the primary hart from the boot entry  before `plat_primary_init_early()` and the first `console_init()`. It reads the specification version, implementation ID and implementation version through the Base extension and probes in one pass the extensions defined by the specification (TIME, IPI, RFENCE, HSM, SRST, PMU, DBCN,
SUSP, CPPC, NACL, STA, SSE, FWFT, DBTR, MPXY). Results are cached and served by `sbi_ext_available()`; IDs outside the table fall back to a live probe. `sbi_print_info()` logs the result once the console is up:

```
  I/TC: SBI v<major>.<minor>, implementation ID <id> version <version>
  I/TC: SBI extensions: TIME IPI RFENCE HSM ...
```

Commit 2 converts the two existing users: the console takes the cached DBCN result, and `boot_start_secondary_cores()` panics with an explicit message when `CFG_TEE_CORE_NB_CORE` > 1 and HSM is missing.

The MPXY code has no initialization path in the tree to convert; A follow-up series for multi-hart TLB and
instruction cache maintenance builds on `sbi_ext_available()` for RFENCE.

Extension IDs and the version encoding were checked against the SBI specification sources ("Base Extension" chapter and the individual extension chapters).

Build-tested and runtime-tested.