### PR TITLE
core: storage: fix cleanup of mapped open corruption

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -217,7 +217,9 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 	res = tee_svc_storage_read_head(o);
 	tee_pobj_unlock_usage(o->pobj);
 	if (res != TEE_SUCCESS) {
-		if (res == TEE_ERROR_CORRUPT_OBJECT) {
+		if (res == TEE_ERROR_CORRUPT_OBJECT ||
+		    res == TEE_ERROR_NO_DATA ||
+		    res == TEE_ERROR_BAD_FORMAT) {
 			EMSG("Object corrupt");
 			goto err;
 		}


### PR DESCRIPTION
syscall_storage_obj_open() closes and clears its local object before mapping TEE_ERROR_NO_DATA and TEE_ERROR_BAD_FORMAT to TEE_ERROR_CORRUPT_OBJECT. The subsequent corruption cleanup therefore sees a NULL object and leaves the backing object in storage.

Route errors that will be mapped to TEE_ERROR_CORRUPT_OBJECT through the corruption cleanup path while the object is still available.

Fixes: a2e9a83066c0 ("GP11 : trusted storage verify (block enc fs)")