### PR TITLE
RISC-V: Ensure secondary boot prints are completed before semaphore release 

### DIFF
--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -47,7 +47,12 @@
 
 .macro cpu_is_ready
 #ifdef CFG_BOOT_SYNC_CPU
-	csrr	t0, CSR_XSCRATCH
+	lw	t0, THREAD_CORE_LOCAL_HART_INDEX(tp)
+#ifdef CFG_TEE_CORE_DEBUG
+	/* Sanity check for hart index */
+	li	t2, CFG_TEE_CORE_NB_CORE
+	bgeu	t0, t2, unhandled_cpu
+#endif
 	lla	t1, sem_cpu_sync
 	slli	t0, t0, 2
 	add	t1, t1, t0

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -404,9 +404,8 @@ UNWIND(	.cantunwind)
 	set_sp
 	set_tp
 #endif
-	cpu_is_ready
-
 	jal	boot_init_secondary
+	cpu_is_ready
 #ifdef CFG_RISCV_WITH_M_MODE_SM
 	/* Return to untrusted domain */
 	li	a0, TEEABI_OPTEED_RETURN_ON_DONE


### PR DESCRIPTION
https://github.com/OP-TEE/optee_os/pull/7977 did not fully prevent secondary harts’ output from interleaving with the primary hart’s U-Boot output. This change ensures that all secondary boot messages are printed before the semaphore is released.