### PR TITLE
core: riscv: SMP correctness fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,7 @@ jobs:
               _make PLATFORM=virt
               _make PLATFORM=virt CFG_RISCV_PLIC=n CFG_RISCV_APLIC=y
               _make PLATFORM=virt CFG_RISCV_PLIC=n CFG_RISCV_APLIC_MSI=y CFG_RISCV_IMSIC=y
+              _make PLATFORM=virt CFG_RISCV_ISA_ZICBOM=y
               _make PLATFORM=sifive
               _make PLATFORM=cva6
     steps:

--- a/core/arch/riscv/include/kernel/tlb_helpers.h
+++ b/core/arch/riscv/include/kernel/tlb_helpers.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2026 NXP
  */
 
 #ifndef __KERNEL_TLB_HELPERS_H
@@ -8,6 +8,13 @@
 
 #ifndef __ASSEMBLER__
 
+/* Invalidate TLB entries of the calling hart only */
+void tlbi_all_local(void);
+void tlbi_va_allasid_local(vaddr_t va);
+void tlbi_asid_local(unsigned long asid);
+void tlbi_va_asid_local(vaddr_t va, uint32_t asid);
+
+/* Invalidate TLB entries of every hart running OP-TEE */
 void tlbi_all(void);
 void tlbi_va_allasid(vaddr_t va);
 void tlbi_asid(unsigned long asid);

--- a/core/arch/riscv/include/sbi.h
+++ b/core/arch/riscv/include/sbi.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022, 2025 NXP
+ * Copyright 2022, 2025-2026 NXP
  */
 
 #ifndef __SBI_H
@@ -30,6 +30,7 @@
 /* SBI Extension IDs */
 #define SBI_EXT_0_1_CONSOLE_PUTCHAR	0x01
 #define SBI_EXT_BASE			0x10
+#define SBI_EXT_RFENCE			0x52464E43
 #define SBI_EXT_HSM			0x48534D
 #define SBI_EXT_DBCN			0x4442434E
 #define SBI_EXT_TEE			0x544545
@@ -71,6 +72,24 @@ enum sbi_ext_base_fid {
 	SBI_EXT_BASE_GET_MIMPID,
 };
 
+/* SBI function IDs for RFENCE extension */
+enum sbi_ext_rfence_fid {
+	SBI_EXT_RFENCE_REMOTE_FENCE_I = 0,
+	SBI_EXT_RFENCE_REMOTE_SFENCE_VMA,
+	SBI_EXT_RFENCE_REMOTE_SFENCE_VMA_ASID,
+	SBI_EXT_RFENCE_REMOTE_HFENCE_GVMA_VMID,
+	SBI_EXT_RFENCE_REMOTE_HFENCE_GVMA,
+	SBI_EXT_RFENCE_REMOTE_HFENCE_VVMA_ASID,
+	SBI_EXT_RFENCE_REMOTE_HFENCE_VVMA,
+};
+
+/*
+ * hart_mask_base value for which hart_mask is ignored and every hart
+ * available to the supervisor is targeted (SBI spec, "Binary Encoding",
+ * hart mask parameters).
+ */
+#define SBI_HART_MASK_BASE_ALL		(-1UL)
+
 /* SBI function IDs for HSM extension */
 enum sbi_ext_hsm_fid {
 	SBI_EXT_HSM_HART_START = 0,
@@ -108,6 +127,13 @@ void sbi_console_putchar(int ch);
 int sbi_dbcn_write_byte(unsigned char ch);
 int sbi_hsm_hart_start(uint32_t hartid, paddr_t start_addr, unsigned long arg);
 int sbi_hsm_hart_get_status(uint32_t hartid, enum sbi_hsm_hart_state *status);
+int sbi_remote_fence_i(unsigned long hart_mask, unsigned long hart_mask_base);
+int sbi_remote_sfence_vma(unsigned long hart_mask, unsigned long hart_mask_base,
+			  unsigned long start_addr, unsigned long size);
+int sbi_remote_sfence_vma_asid(unsigned long hart_mask,
+			       unsigned long hart_mask_base,
+			       unsigned long start_addr, unsigned long size,
+			       unsigned long asid);
 
 #endif /*__ASSEMBLER__*/
 #endif /*defined(CFG_RISCV_SBI)*/

--- a/core/arch/riscv/kernel/cache_helpers_rv.S
+++ b/core/arch/riscv/kernel/cache_helpers_rv.S
@@ -1,17 +1,57 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2023,2026 NXP
  */
 
 #include <asm.S>
 #include <riscv.h>
 
+#ifdef CFG_RISCV_ISA_ZICBOM
 /*
- * On the below data cache management, we rely on FENCE instruction.
- * The FENCE instruction is used to order device I/O and memory accesses
- * as viewed by other RISC-V harts and external devices or coprocessors.
- * "fence" below is a pseudo-instruction of "fence iorw, iorw" which
- * performs Fence on all memory and I/O.
+ * Apply a Zicbom cache-block operation to every cache block overlapping
+ * [a0, a0 + a1). The leading FENCE orders prior memory accesses before
+ * the operations, the trailing one orders the operations before
+ * subsequent accesses (and device accesses, "fence" being
+ * "fence iorw, iorw").
+ */
+.macro cbo_range op
+	fence
+	add	a1, a0, a1
+	li	t0, -CFG_RISCV_CBOM_BLOCK_SIZE
+	and	a0, a0, t0
+1:	cbo.\op	(a0)
+	addi	a0, a0, CFG_RISCV_CBOM_BLOCK_SIZE
+	bltu	a0, a1, 1b
+	fence
+	ret
+.endm
+
+/* void dcache_cleaninv_range(void *addr, size_t size); */
+FUNC dcache_cleaninv_range , :
+	cbo_range flush
+END_FUNC dcache_cleaninv_range
+
+/* void dcache_clean_range(void *addr, size_t size); */
+FUNC dcache_clean_range , :
+	cbo_range clean
+END_FUNC dcache_clean_range
+
+/*
+ * void dcache_inv_range(void *addr, size_t size);
+ *
+ * Executed from S-mode, CBO.INVAL is either an invalidate or a flush
+ * depending on menvcfg.CBIE, both of which are acceptable here.
+ */
+FUNC dcache_inv_range , :
+	cbo_range inval
+END_FUNC dcache_inv_range
+#else
+/*
+ * Without Zicbom there is no architectural cache-block management. The
+ * range operations rely on the FENCE instruction, which orders device I/O
+ * and memory accesses as viewed by other RISC-V harts and external devices
+ * or coprocessors ("fence" is "fence iorw, iorw"). This is sufficient on
+ * cache-coherent platforms only.
  */
 
 /* void dcache_cleaninv_range(void *addr, size_t size); */
@@ -31,8 +71,15 @@ FUNC dcache_inv_range , :
 	fence
 	ret
 END_FUNC dcache_inv_range
+#endif /* CFG_RISCV_ISA_ZICBOM */
 
-/* void dcache_op_all(unsigned long op_type); */
+/*
+ * void dcache_op_all(unsigned long op_type);
+ *
+ * RISC-V has no architectural whole-cache maintenance operation, Zicbom
+ * being block-based. A platform with non-coherent caches has to provide
+ * its own implementation.
+ */
 FUNC dcache_op_all , :
 	fence
 	ret

--- a/core/arch/riscv/kernel/sbi.c
+++ b/core/arch/riscv/kernel/sbi.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2026 NXP
  */
 
 #include <riscv.h>
@@ -83,4 +83,76 @@ int sbi_hsm_hart_get_status(uint32_t hartid, enum sbi_hsm_hart_state *status)
 
 	*status = ret.value;
 	return SBI_SUCCESS;
+}
+
+/**
+ * sbi_remote_fence_i() - Execute FENCE.I on remote harts
+ * @hart_mask:      Bit-vector of target hart IDs, relative to @hart_mask_base
+ * @hart_mask_base: First hart ID covered by @hart_mask, or
+ *                  SBI_HART_MASK_BASE_ALL to target every hart available
+ *                  to the supervisor
+ *
+ * Return:          SBI error code (SBI_SUCCESS = 0 on success)
+ */
+int sbi_remote_fence_i(unsigned long hart_mask, unsigned long hart_mask_base)
+{
+	struct sbiret ret = { };
+
+	ret = sbi_ecall(SBI_EXT_RFENCE, SBI_EXT_RFENCE_REMOTE_FENCE_I,
+			hart_mask, hart_mask_base);
+
+	return ret.error;
+}
+
+/**
+ * sbi_remote_sfence_vma() - Execute SFENCE.VMA on remote harts
+ * @hart_mask:      Bit-vector of target hart IDs, relative to @hart_mask_base
+ * @hart_mask_base: First hart ID covered by @hart_mask, or
+ *                  SBI_HART_MASK_BASE_ALL to target every hart available
+ *                  to the supervisor
+ * @start_addr:     First virtual address of the range to fence
+ * @size:           Size of the range to fence
+ *
+ * The whole address space is fenced when @start_addr and @size are both 0,
+ * or when @size is -1 (SBI spec, "RFENCE Extension").
+ *
+ * Return:          SBI error code (SBI_SUCCESS = 0 on success)
+ */
+int sbi_remote_sfence_vma(unsigned long hart_mask, unsigned long hart_mask_base,
+			  unsigned long start_addr, unsigned long size)
+{
+	struct sbiret ret = { };
+
+	ret = sbi_ecall(SBI_EXT_RFENCE, SBI_EXT_RFENCE_REMOTE_SFENCE_VMA,
+			hart_mask, hart_mask_base, start_addr, size);
+
+	return ret.error;
+}
+
+/**
+ * sbi_remote_sfence_vma_asid() - Execute SFENCE.VMA with ASID on remote harts
+ * @hart_mask:      Bit-vector of target hart IDs, relative to @hart_mask_base
+ * @hart_mask_base: First hart ID covered by @hart_mask, or
+ *                  SBI_HART_MASK_BASE_ALL to target every hart available
+ *                  to the supervisor
+ * @start_addr:     First virtual address of the range to fence
+ * @size:           Size of the range to fence
+ * @asid:           Address space identifier to fence
+ *
+ * The whole address space of @asid is fenced when @start_addr and @size
+ * are both 0, or when @size is -1 (SBI spec, "RFENCE Extension").
+ *
+ * Return:          SBI error code (SBI_SUCCESS = 0 on success)
+ */
+int sbi_remote_sfence_vma_asid(unsigned long hart_mask,
+			       unsigned long hart_mask_base,
+			       unsigned long start_addr, unsigned long size,
+			       unsigned long asid)
+{
+	struct sbiret ret = { };
+
+	ret = sbi_ecall(SBI_EXT_RFENCE, SBI_EXT_RFENCE_REMOTE_SFENCE_VMA_ASID,
+			hart_mask, hart_mask_base, start_addr, size, asid);
+
+	return ret.error;
 }

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2023,2026 NXP
  */
 
 #include <assert.h>
@@ -19,6 +19,7 @@
 #include <mm/phys_mem.h>
 #include <platform_config.h>
 #include <riscv.h>
+#include <sbi.h>
 #include <stdalign.h>
 #include <stdlib.h>
 #include <string.h>
@@ -571,9 +572,79 @@ static void core_init_mmu_prtn_tee(struct mmu_partition *prtn,
 	}
 }
 
+/*
+ * tlbi_remote() - Invalidate TLB entries on the other harts
+ * @va:		Start of the virtual address range, 0 with @len == 0 for all
+ * @len:	Length of the range, 0 with @va == 0 for the whole address space
+ * @asid:	ASID to target when @with_asid is true
+ * @with_asid:	Restrict the invalidation to @asid
+ *
+ * SFENCE.VMA only orders the calling hart. The remaining harts of the
+ * OP-TEE domain are reached through the SBI RFENCE extension, which has
+ * the M-mode firmware execute the fence on each of them and wait for
+ * completion. SBI_HART_MASK_BASE_ALL targets every hart available to the
+ * supervisor, which for a domain-isolated OP-TEE is exactly the hart set
+ * of its domain.
+ *
+ * The remote fence is executed in M-mode, so it is safe to call this
+ * with S-mode interrupts masked, for instance while holding a spinlock.
+ *
+ * Without SBI (CFG_RISCV_M_MODE=y) there is no remote fence: a
+ * multi-hart M-mode configuration keeps hart-local invalidation.
+ */
+static void tlbi_remote(vaddr_t va __maybe_unused, size_t len __maybe_unused,
+			unsigned long asid __maybe_unused,
+			bool with_asid __maybe_unused)
+{
+#ifdef CFG_RISCV_SBI
+	int rc = SBI_SUCCESS;
+
+	if (CFG_TEE_CORE_NB_CORE == 1)
+		return;
+
+	if (with_asid)
+		rc = sbi_remote_sfence_vma_asid(0, SBI_HART_MASK_BASE_ALL, va,
+						len, asid);
+	else
+		rc = sbi_remote_sfence_vma(0, SBI_HART_MASK_BASE_ALL, va, len);
+
+	if (rc) {
+		EMSG("SBI remote SFENCE.VMA failed: %d", rc);
+		panic();
+	}
+#endif
+}
+
+void tlbi_all(void)
+{
+	tlbi_all_local();
+	tlbi_remote(0, 0, 0, false);
+}
+
+void tlbi_va_allasid(vaddr_t va)
+{
+	tlbi_va_allasid_local(va);
+	tlbi_remote(va, SMALL_PAGE_SIZE, 0, false);
+}
+
+void tlbi_asid(unsigned long asid)
+{
+	tlbi_asid_local(asid);
+	tlbi_remote(0, 0, asid, true);
+}
+
+void tlbi_va_asid(vaddr_t va, uint32_t asid)
+{
+	tlbi_va_asid_local(va, asid);
+	tlbi_remote(va, SMALL_PAGE_SIZE, asid, true);
+}
+
 void tlbi_va_range(vaddr_t va, size_t len,
 		   size_t granule)
 {
+	vaddr_t v = va;
+	size_t l = len;
+
 	assert(granule == CORE_MMU_PGDIR_SIZE || granule == SMALL_PAGE_SIZE);
 	assert(!(va & (granule - 1)) && !(len & (granule - 1)));
 
@@ -582,11 +653,13 @@ void tlbi_va_range(vaddr_t va, size_t len,
 	 * with TLB invalidation.
 	 */
 	mb();
-	while (len) {
-		tlbi_va_allasid(va);
-		len -= granule;
-		va += granule;
+	while (l) {
+		tlbi_va_allasid_local(v);
+		l -= granule;
+		v += granule;
 	}
+	/* One remote fence covers the whole range */
+	tlbi_remote(va, len, 0, false);
 	/*
 	 * After invalidating TLB entries, a memory barrier is required
 	 * to ensure that the page table entries become visible to other harts
@@ -598,6 +671,9 @@ void tlbi_va_range(vaddr_t va, size_t len,
 void tlbi_va_range_asid(vaddr_t va, size_t len,
 			size_t granule, uint32_t asid)
 {
+	vaddr_t v = va;
+	size_t l = len;
+
 	assert(granule == CORE_MMU_PGDIR_SIZE || granule == SMALL_PAGE_SIZE);
 	assert(!(va & (granule - 1)) && !(len & (granule - 1)));
 
@@ -606,11 +682,13 @@ void tlbi_va_range_asid(vaddr_t va, size_t len,
 	 * and correctness of memory accesses.
 	 */
 	mb();
-	while (len) {
-		tlbi_va_asid(va, asid);
-		len -= granule;
-		va += granule;
+	while (l) {
+		tlbi_va_asid_local(v, asid);
+		l -= granule;
+		v += granule;
 	}
+	/* One remote fence covers the whole range */
+	tlbi_remote(va, len, asid, true);
 	/* Enforce ordering of memory operations and ensure that all
 	 * preceding memory operations are completed after TLB
 	 * invalidation.
@@ -967,7 +1045,8 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 		core_mmu_table_write_barrier();
 	}
 
-	tlbi_all();
+	/* The user mapping is per hart, no need to reach the other harts */
+	tlbi_all_local();
 	thread_unmask_exceptions(exceptions);
 }
 

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -696,6 +696,33 @@ void tlbi_va_range_asid(vaddr_t va, size_t len,
 	mb();
 }
 
+/*
+ * icache_inv_remote() - Execute FENCE.I on the other harts
+ *
+ * FENCE.I only synchronizes instruction fetches of the calling hart with
+ * its own prior stores. Code written by this hart (TA loading, W^X
+ * transitions) may run on any hart of the domain, so reach the others
+ * through the SBI RFENCE extension. See tlbi_remote() for the hart mask
+ * and M-mode considerations.
+ */
+static void icache_inv_remote(void)
+{
+#ifdef CFG_RISCV_SBI
+	int rc = SBI_SUCCESS;
+
+	if (CFG_TEE_CORE_NB_CORE == 1)
+		return;
+
+	/* Make the instruction memory stores visible to the other harts */
+	mb();
+	rc = sbi_remote_fence_i(0, SBI_HART_MASK_BASE_ALL);
+	if (rc) {
+		EMSG("SBI remote FENCE.I failed: %d", rc);
+		panic();
+	}
+#endif
+}
+
 TEE_Result cache_op_inner(enum cache_op op, void *va, size_t len)
 {
 	switch (op) {
@@ -713,9 +740,11 @@ TEE_Result cache_op_inner(enum cache_op op, void *va, size_t len)
 		break;
 	case ICACHE_INVALIDATE:
 		icache_inv_all();
+		icache_inv_remote();
 		break;
 	case ICACHE_AREA_INVALIDATE:
 		icache_inv_range(va, len);
+		icache_inv_remote();
 		break;
 	case DCACHE_CLEAN_INV:
 		dcache_op_all(DCACHE_OP_CLEAN_INV);

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -42,7 +42,21 @@
 
 #define IS_PAGE_ALIGNED(addr)	IS_ALIGNED(addr, SMALL_PAGE_SIZE)
 
-static bitstr_t bit_decl(g_asid, RISCV_SATP_ASID_WIDTH) __nex_bss;
+/*
+ * Number of ASIDs handed out to user mode contexts. ASID 0 is reserved for
+ * the core mappings, so the pool covers 1..RISCV_MMU_NUM_ASIDS, which must
+ * fit in the satp ASID field of every SvXX mode. An implementation with
+ * ASIDLEN < ASIDMAX ignores the upper bits of both satp.ASID and the
+ * SFENCE.VMA rs2 operand (privileged spec, "Supervisor Address Translation
+ * and Protection Register" and "Supervisor Memory-Management Fence
+ * Instruction"), so a pool wider than the hardware only over-fences,
+ * which is always legal.
+ */
+#define RISCV_MMU_NUM_ASIDS	U(256)
+
+static_assert(RISCV_MMU_NUM_ASIDS <= RISCV_SATP_ASID_MASK);
+
+static bitstr_t bit_decl(g_asid, RISCV_MMU_NUM_ASIDS) __nex_bss;
 static unsigned int g_asid_spinlock __nex_bss = SPINLOCK_UNLOCK;
 
 struct mmu_pte {
@@ -764,7 +778,7 @@ unsigned int asid_alloc(void)
 	unsigned int r = 0;
 	int i = 0;
 
-	bit_ffc(g_asid, (int)RISCV_SATP_ASID_WIDTH, &i);
+	bit_ffc(g_asid, (int)RISCV_MMU_NUM_ASIDS, &i);
 	if (i == -1) {
 		r = 0;
 	} else {
@@ -784,7 +798,7 @@ void asid_free(unsigned int asid)
 	if (asid) {
 		unsigned int i = asid - 1;
 
-		assert(i < RISCV_SATP_ASID_WIDTH && bit_test(g_asid, i));
+		assert(i < RISCV_MMU_NUM_ASIDS && bit_test(g_asid, i));
 		bit_clear(g_asid, i);
 	}
 

--- a/core/arch/riscv/mm/tlb_helpers_rv.S
+++ b/core/arch/riscv/mm/tlb_helpers_rv.S
@@ -1,31 +1,37 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2023 Andes Technology Corporation
- * Copyright 2022 NXP
+ * Copyright 2022,2026 NXP
  */
 
 #include <asm.S>
 
-/* void tlbi_all(void); */
-FUNC tlbi_all , :
+/*
+ * SFENCE.VMA only orders the calling hart. The helpers below are local
+ * primitives; the hart-wide variants without the _local suffix are
+ * implemented in core_mmu_arch.c on top of the SBI RFENCE extension.
+ */
+
+/* void tlbi_all_local(void); */
+FUNC tlbi_all_local , :
 	sfence.vma	zero, zero
 	ret
-END_FUNC tlbi_all
+END_FUNC tlbi_all_local
 
-/* void tlbi_va_allasid(vaddr_t va); */
-FUNC tlbi_va_allasid , :
+/* void tlbi_va_allasid_local(vaddr_t va); */
+FUNC tlbi_va_allasid_local , :
 	sfence.vma	a0, zero
 	ret
-END_FUNC tlbi_va_allasid
+END_FUNC tlbi_va_allasid_local
 
-/* void tlbi_asid(unsigned int asid); */
-FUNC tlbi_asid , :
+/* void tlbi_asid_local(unsigned long asid); */
+FUNC tlbi_asid_local , :
 	sfence.vma	zero, a0
 	ret
-END_FUNC tlbi_asid
+END_FUNC tlbi_asid_local
 
-/* void tlbi_va_asid(vaddr_t va, uint32_t asid); */
-FUNC tlbi_va_asid , :
+/* void tlbi_va_asid_local(vaddr_t va, uint32_t asid); */
+FUNC tlbi_va_asid_local , :
 	sfence.vma	a0, a1
 	ret
-END_FUNC tlbi_va_asid
+END_FUNC tlbi_va_asid_local

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -130,8 +130,18 @@ endif
 ifeq ($(CFG_RISCV_ISA_ZBB),y)
 ISA_ZBB = _zbb
 endif
+# Zicbom cache-block management operations, used for the data cache range
+# maintenance in cache_helpers_rv.S. The M-mode firmware must allow them
+# from S-mode (menvcfg.CBCFE and menvcfg.CBIE), which OpenSBI does when
+# the hart advertises the extension.
+CFG_RISCV_ISA_ZICBOM ?= n
+ifeq ($(CFG_RISCV_ISA_ZICBOM),y)
+ISA_ZICBOM = _zicbom
+# Cache block size in bytes ("riscv,cbom-block-size" in the device tree)
+CFG_RISCV_CBOM_BLOCK_SIZE ?= 64
+endif
 
-riscv-isa = $(ISA_BASE)$(ISA_D)$(ISA_C)$(ISA_ZBB)_zicsr_zifencei
+riscv-isa = $(ISA_BASE)$(ISA_D)$(ISA_C)$(ISA_ZBB)_zicsr_zifencei$(ISA_ZICBOM)
 riscv-abi = $(ABI_BASE)$(ABI_D)
 
 rv64-platform-cflags += -mcmodel=$(riscv-platform-mcmodel)


### PR DESCRIPTION
Currently our RISC-V port issues bare `SFENCE.VMA` / `FENCE.I`, which only order the executing hart, while the generic code calls `tlbi_*()` and `cache_op_inner(ICACHE_*)` expecting the ARM inner-shareable broadcast semantics. 

With `CFG_TEE_CORE_NB_CORE` > 1 this leaves stale translations and instruction cache lines on the other harts of the domain. The same file also sizes the ASID pool with the `satp` field width instead of a count, capping concurrently loaded user contexts at 16, and the data cache range helpers are plain `FENCE` instructions.

Patches 1-3 route the hart-wide operations through the SBI RFENCE extension (M-mode firmware executes the fence on the targeted harts and waits for completion, so calling it with S-mode interrupts masked is safe). Patch 4 fixes the ASID pool. Patch 5 adds an opt-in Zicbom implementation of the data cache range operations.

Scope:
- `CFG_RISCV_M_MODE=y` has no SBI; multi-hart M-mode configurations (plat-spike) keep hart-local invalidation. A CLINT IPI based shootdown would need a synchronous ack from harts that may be spinning with interrupts masked on the lock the sender holds (`core_mmu_unmap_pages()` flushes under `mmu_lock()`), so it is not attempted here.
- OP-TEE OS and the Linux share the per-hart TLB and the ASID namespace; cross-domain isolation relies on the M-mode secure monitor flushing on domain switch. That contract is not touched here.
- `core_mmu_set_user_map()` flushing the whole local TLB on every user context switch is a performance item, left as is.

Build-tested and runtime-tested.
